### PR TITLE
GASP CMC: add gameplay rotation modes

### DIFF
--- a/Config/DefaultGame.ini
+++ b/Config/DefaultGame.ini
@@ -162,8 +162,6 @@ GlobalAttributeMetaDataTableName=None
 GlobalGameplayCueManagerClass=/Script/GameplayAbilities.GameplayCueManager
 GlobalGameplayCueManagerName=None
 GlobalCurveTableName=None
-PredictTargetGameplayEffects=True
-ReplicateActivationOwnedTags=True
 ActivateFailCanActivateAbilityTag=(TagName="")
 ActivateFailCooldownTag=(TagName="Ability.ActivateFail.Cooldown")
 ActivateFailCostTag=(TagName="Ability.ActivateFail.Cost")
@@ -184,6 +182,10 @@ GameplayModEvaluationChannelAliases[7]=None
 GameplayModEvaluationChannelAliases[8]=None
 GameplayModEvaluationChannelAliases[9]=None
 MinimalReplicationTagCountBits=5
+
+[/Script/GameplayAbilities.GameplayAbilitiesDeveloperSettings]
+PredictTargetGameplayEffects=True
+ReplicateActivationOwnedTags=True
 
 [/Script/SurvivalRpg.RpgCombatDeveloperSettings]
 bDrawWeaponAttackTraces=True

--- a/Content/SurvivalRpg/Core/Character/GASP/DA_PawnData_GASP.uasset
+++ b/Content/SurvivalRpg/Core/Character/GASP/DA_PawnData_GASP.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1fe61a28be4fa262084f8942c78d555d02947215dbf13698a3b5912fca6b96ca
-size 2584
+oid sha256:d2bb8d404a150fe7d37f439b5a6028066c2273305ecce5e4506c7b951093cf69
+size 2797

--- a/Plugins/GameFeatures/GF_Combat_Core/Content/Input/DA_InputConfig_Combat.uasset
+++ b/Plugins/GameFeatures/GF_Combat_Core/Content/Input/DA_InputConfig_Combat.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f3310e5a0593df52686a48a33ac3ca31c5fc31808b375e300c8453fdba5912a7
-size 3337
+oid sha256:b1e7b16dcf47a7abc94d5f571a19c729a23714e2e98bfc7279e9a11f0357eb17
+size 3616

--- a/Plugins/GameFeatures/GF_Combat_Core/Content/Input/IA_ToggleCombatStance.uasset
+++ b/Plugins/GameFeatures/GF_Combat_Core/Content/Input/IA_ToggleCombatStance.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5262311c83e50ad595a37a406c2e64f5cf3d60f360ca635f40ceabb18adebd91
+size 1166

--- a/Plugins/GameFeatures/GF_Combat_Core/Content/Input/IMC_Combat.uasset
+++ b/Plugins/GameFeatures/GF_Combat_Core/Content/Input/IMC_Combat.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:35e3b97cb0de97f8dee5f2125a159c85b4e3c096de1e2c471c914129f5fcd4cc
-size 4229
+oid sha256:ad67c9599cdbb51e204f390e022587dee562347bfc542e93a79f0fef85cc424b
+size 4669

--- a/Source/SurvivalRpg/AbilitySystem/Abilities/RpgGameplayAbility_BasicWeaponAttack.cpp
+++ b/Source/SurvivalRpg/AbilitySystem/Abilities/RpgGameplayAbility_BasicWeaponAttack.cpp
@@ -132,6 +132,7 @@ URpgGameplayAbility_BasicWeaponAttack::URpgGameplayAbility_BasicWeaponAttack(con
 	NetExecutionPolicy = EGameplayAbilityNetExecutionPolicy::LocalPredicted;
 	ActivationPolicy = ERpgAbilityActivationPolicy::OnInputTriggered;
 	ActivationGroup = ERpgAbilityActivationGroup::Exclusive_Blocking;
+	ActivationOwnedTags.AddTag(RpgGameplayTags::State_Rotation_CombatStrafe);
 	AttackDefinitionTag = RpgGameplayTags::Weapon_Attack_Primary;
 }
 

--- a/Source/SurvivalRpg/AbilitySystem/Abilities/RpgGameplayAbility_Block.cpp
+++ b/Source/SurvivalRpg/AbilitySystem/Abilities/RpgGameplayAbility_Block.cpp
@@ -26,6 +26,7 @@ URpgGameplayAbility_Block::URpgGameplayAbility_Block(const FObjectInitializer& O
 	NetExecutionPolicy = EGameplayAbilityNetExecutionPolicy::LocalPredicted;
 	ActivationPolicy = ERpgAbilityActivationPolicy::WhileInputActive;
 	ActivationGroup = ERpgAbilityActivationGroup::Exclusive_Blocking;
+	ActivationOwnedTags.AddTag(RpgGameplayTags::State_Rotation_CombatStrafe);
 
 	DefaultBlockDefinition.bCanBlock = false;
 	DefaultBlockDefinition.bAllowPerfectBlock = false;

--- a/Source/SurvivalRpg/Animation/RpgAnimInstance.cpp
+++ b/Source/SurvivalRpg/Animation/RpgAnimInstance.cpp
@@ -38,6 +38,12 @@ constexpr float TurnInPlaceInactiveAccumulatorTimeout = 0.2f;
 constexpr float TurnInPlaceFinishedTimeTolerance = 0.05f;
 constexpr float TurnInPlaceLargePositionDelta = 200.0f;
 
+constexpr bool SupportsTurnInPlace(ERpgCharacterRotationMode RotationMode)
+{
+	return RotationMode == ERpgCharacterRotationMode::CombatStrafe ||
+		RotationMode == ERpgCharacterRotationMode::Aim;
+}
+
 float CalculateTurnInPlacePlaybackWatchdogDuration(
 	float RemainingAnimationTime,
 	float PlayRate,
@@ -176,6 +182,7 @@ void FRpgAnimInstanceProxy::PreUpdate(UAnimInstance* InAnimInstance, float Delta
 	Gait = ERpgLocomotionGait::Idle;
 	Stance = ERpgLocomotionStance::Standing;
 	MovementState = ERpgLocomotionMovementState::None;
+	RotationMode = ERpgCharacterRotationMode::Free;
 	bHasVelocity = false;
 	bHasAcceleration = false;
 	bHasGroundedMoveIntent = false;
@@ -208,6 +215,7 @@ void FRpgAnimInstanceProxy::PreUpdate(UAnimInstance* InAnimInstance, float Delta
 		bHasPreviousOwnerSnapshot = false;
 		return;
 	}
+	RotationMode = Character->GetRotationMode();
 
 	URpgCharacterMovementComponent* MovementComponent = Cast<URpgCharacterMovementComponent>(Character->GetCharacterMovement());
 	if (!MovementComponent)
@@ -447,6 +455,7 @@ bool URpgAnimInstance::IsTurnInPlaceEligible(const FRpgAnimInstanceProxy& Proxy)
 {
 	return
 		TurnInPlaceMotionMatchingDatabase != nullptr &&
+		SupportsTurnInPlace(Proxy.RotationMode) &&
 		Proxy.MovementState == ERpgLocomotionMovementState::Grounded &&
 		Proxy.bIsMovingOnGround &&
 		!Proxy.bIsCrouching &&
@@ -526,6 +535,7 @@ void URpgAnimInstance::UpdateTurnInPlaceRuntime(float DeltaSeconds, const FRpgAn
 
 	const bool bHardResetCondition =
 		Proxy.bTurnInPlaceHardReset ||
+		!SupportsTurnInPlace(Proxy.RotationMode) ||
 		Proxy.bHasTurnInPlaceBlockingGameplayTag ||
 		Proxy.bIsAnyMontagePlaying ||
 		Proxy.bIsCrouching ||
@@ -876,6 +886,7 @@ void URpgAnimInstance::NativeThreadSafeUpdateAnimation(float DeltaSeconds)
 	LocomotionGait = Proxy.Gait;
 	LocomotionStance = Proxy.Stance;
 	LocomotionMovementState = Proxy.MovementState;
+	CharacterRotationMode = Proxy.RotationMode;
 	LocomotionTrajectory = Proxy.TransformTrajectory;
 	ProceduralLocomotionAlpha = Proxy.ProceduralLocomotionAlpha;
 	bIsAnyMontagePlaying = Proxy.bIsAnyMontagePlaying;

--- a/Source/SurvivalRpg/Animation/RpgAnimInstance.cpp
+++ b/Source/SurvivalRpg/Animation/RpgAnimInstance.cpp
@@ -115,6 +115,25 @@ float URpgAnimInstance::CalculateTurnInPlaceYawDelta(float PreviousActorYaw, flo
 	return FMath::FindDeltaAngleDegrees(PreviousActorYaw, CurrentActorYaw);
 }
 
+bool URpgAnimInstance::DidTurnInPlaceSupportChange(
+	bool bHasPreviousSnapshot,
+	ERpgCharacterRotationMode PreviousMode,
+	ERpgCharacterRotationMode CurrentMode)
+{
+	return bHasPreviousSnapshot && SupportsTurnInPlace(PreviousMode) != SupportsTurnInPlace(CurrentMode);
+}
+
+float URpgAnimInstance::CalculateTurnInPlaceSnapshotYawDelta(
+	float PreviousActorYaw,
+	float CurrentActorYaw,
+	bool bHardReset,
+	bool bSupportChanged)
+{
+	return bHardReset || bSupportChanged
+		? 0.0f
+		: CalculateTurnInPlaceYawDelta(PreviousActorYaw, CurrentActorYaw);
+}
+
 FTransformTrajectory URpgAnimInstance::MakeTurnInPlaceSyntheticTrajectory(
 	const FTransformTrajectory& SourceTrajectory,
 	float CurrentActorYaw,
@@ -192,6 +211,7 @@ void FRpgAnimInstanceProxy::PreUpdate(UAnimInstance* InAnimInstance, float Delta
 	bIsAnyMontagePlaying = false;
 	bHasTurnInPlaceBlockingGameplayTag = false;
 	bTurnInPlaceHardReset = false;
+	bTurnInPlaceSupportChanged = false;
 	ActorYaw = 0.0f;
 	ActorYawDelta = 0.0f;
 	ActorLocation = FVector::ZeroVector;
@@ -240,19 +260,26 @@ void FRpgAnimInstanceProxy::PreUpdate(UAnimInstance* InAnimInstance, float Delta
 		PreviousOwnerUniqueId != OwnerUniqueId ||
 		PreviousLocalRole != LocalRole ||
 		PreviousRemoteRole != RemoteRole;
+	bTurnInPlaceSupportChanged = URpgAnimInstance::DidTurnInPlaceSupportChange(
+		bHasPreviousOwnerSnapshot,
+		PreviousRotationMode,
+		RotationMode);
 	const bool bLargePositionJump =
 		bHasPreviousOwnerSnapshot &&
 		FVector::DistSquared(PreviousActorLocation, ActorLocation) > FMath::Square(TurnInPlaceLargePositionDelta);
 	bTurnInPlaceHardReset = bOwnerOrRoleChanged || bLargePositionJump || MovementComponent->bJustTeleported;
-	ActorYawDelta = bTurnInPlaceHardReset
-		? 0.0f
-		: URpgAnimInstance::CalculateTurnInPlaceYawDelta(PreviousActorYaw, ActorYaw);
+	ActorYawDelta = URpgAnimInstance::CalculateTurnInPlaceSnapshotYawDelta(
+		PreviousActorYaw,
+		ActorYaw,
+		bTurnInPlaceHardReset,
+		bTurnInPlaceSupportChanged);
 
 	PreviousOwnerUniqueId = OwnerUniqueId;
 	PreviousLocalRole = LocalRole;
 	PreviousRemoteRole = RemoteRole;
 	PreviousActorYaw = ActorYaw;
 	PreviousActorLocation = ActorLocation;
+	PreviousRotationMode = RotationMode;
 	bHasPreviousOwnerSnapshot = true;
 
 	WorldVelocity = MovementComponent->Velocity;
@@ -552,6 +579,16 @@ void URpgAnimInstance::UpdateTurnInPlaceRuntime(float DeltaSeconds, const FRpgAn
 		return;
 	}
 	bTurnInPlaceHardResetConditionLastFrame = false;
+
+	if (Proxy.bTurnInPlaceSupportChanged)
+	{
+		// Entering a controller-facing mode can rotate the capsule from an arbitrary free-camera
+		// heading in one frame. Treat that policy transition as a reset, not authored turn intent.
+		// Recovery also absorbs the short network-smoothing tail on simulated proxies.
+		BeginTurnInPlaceRecovery(true);
+		LocomotionTrajectory = Proxy.TransformTrajectory;
+		return;
+	}
 
 	const bool bEligible = IsTurnInPlaceEligible(Proxy);
 	if (!bEligible)

--- a/Source/SurvivalRpg/Animation/RpgAnimInstance.h
+++ b/Source/SurvivalRpg/Animation/RpgAnimInstance.h
@@ -10,6 +10,7 @@
 #include "AnimationWarpingTypes.h"
 #include "GameplayEffectTypes.h"
 #include "PoseSearch/PoseSearchTrajectoryLibrary.h"
+#include "SurvivalRpg/Core/Character/RpgCharacterRotationMode.h"
 #include "RpgAnimInstance.generated.h"
 
 class UAbilitySystemComponent;
@@ -97,6 +98,7 @@ struct SURVIVALRPG_API FRpgAnimInstanceProxy : public FAnimInstanceProxy
 	ERpgLocomotionGait Gait = ERpgLocomotionGait::Idle;
 	ERpgLocomotionStance Stance = ERpgLocomotionStance::Standing;
 	ERpgLocomotionMovementState MovementState = ERpgLocomotionMovementState::None;
+	ERpgCharacterRotationMode RotationMode = ERpgCharacterRotationMode::Free;
 	FPoseSearchTrajectoryData TrajectoryGenerationData;
 	FTransformTrajectory TransformTrajectory;
 	bool bHasVelocity = false;
@@ -348,6 +350,13 @@ protected:
 	/** CharacterMovement mode translated into a worker-thread-safe animation state. */
 	UPROPERTY(BlueprintReadOnly, Transient, Category = "Rpg|Animation|Locomotion")
 	ERpgLocomotionMovementState LocomotionMovementState = ERpgLocomotionMovementState::None;
+
+	/**
+	 * Replicated character rotation policy copied from the game-thread proxy for AnimBP debugging.
+	 * This transient cosmetic snapshot is read-only and never owns authoritative rotation state.
+	 */
+	UPROPERTY(BlueprintReadOnly, Transient, Category = "Rpg|Animation|Locomotion")
+	ERpgCharacterRotationMode CharacterRotationMode = ERpgCharacterRotationMode::Free;
 
 	/**
 	 * Game-thread-generated world-space trajectory consumed read-only by the Motion Matching history collector.

--- a/Source/SurvivalRpg/Animation/RpgAnimInstance.h
+++ b/Source/SurvivalRpg/Animation/RpgAnimInstance.h
@@ -110,6 +110,8 @@ struct SURVIVALRPG_API FRpgAnimInstanceProxy : public FAnimInstanceProxy
 	bool bIsAnyMontagePlaying = false;
 	bool bHasTurnInPlaceBlockingGameplayTag = false;
 	bool bTurnInPlaceHardReset = true;
+	/** True when the game-thread snapshot crosses between free-facing and turn-in-place-capable rotation. */
+	bool bTurnInPlaceSupportChanged = false;
 
 	// Previous-owner data is maintained and consumed only by game-thread PreUpdate.
 	uint32 PreviousOwnerUniqueId = 0;
@@ -117,6 +119,7 @@ struct SURVIVALRPG_API FRpgAnimInstanceProxy : public FAnimInstanceProxy
 	uint8 PreviousRemoteRole = 0;
 	float PreviousActorYaw = 0.0f;
 	FVector PreviousActorLocation = FVector::ZeroVector;
+	ERpgCharacterRotationMode PreviousRotationMode = ERpgCharacterRotationMode::Free;
 	bool bHasPreviousOwnerSnapshot = false;
 };
 
@@ -413,6 +416,17 @@ private:
 		ContinueSelectedTurn,
 	};
 
+	/** Detects a transition across the Free versus controller-facing turn-in-place policy boundary. */
+	static bool DidTurnInPlaceSupportChange(
+		bool bHasPreviousSnapshot,
+		ERpgCharacterRotationMode PreviousMode,
+		ERpgCharacterRotationMode CurrentMode);
+	/** Rebases actor yaw when the owner snapshot is invalidated or the facing policy changes. */
+	static float CalculateTurnInPlaceSnapshotYawDelta(
+		float PreviousActorYaw,
+		float CurrentActorYaw,
+		bool bHardReset,
+		bool bSupportChanged);
 	void UpdateTurnInPlaceRuntime(float DeltaSeconds, const FRpgAnimInstanceProxy& Proxy);
 	void BeginTurnInPlaceRequest(float QuantizedAngle);
 	void BeginTurnInPlaceRecovery(bool bHardResetOffset);

--- a/Source/SurvivalRpg/Core/Character/RpgCharacter.cpp
+++ b/Source/SurvivalRpg/Core/Character/RpgCharacter.cpp
@@ -9,14 +9,20 @@
 #include "RpgHealthComponent.h"
 #include "RpgPawnExtensionComponent.h"
 #include "RpgPawnGameplayComponent.h"
+#include "RpgPawnData.h"
+#include "AbilitySystemComponent.h"
+#include "Animation/AnimInstance.h"
 #include "Components/CapsuleComponent.h"
 #include "Components/SkeletalMeshComponent.h"
+#include "GameFramework/Controller.h"
+#include "GameplayTagContainer.h"
 #include "SurvivalRpg/AbilitySystem/RpgAbilitySystemComponent.h"
 #include "SurvivalRpg/AbilitySystem/Attributes/RpgHealthSet.h"
 #include "SurvivalRpg/Camera/RpgCameraComponent.h"
 #include "SurvivalRpg/Core/Game/RpgGameModeBase.h"
 #include "SurvivalRpg/Core/Corpse/RpgCorpseLifecycleComponent.h"
 #include "SurvivalRpg/Equipment/RpgEquipmentManagerComponent.h"
+#include "SurvivalRpg/Equipment/RpgWeaponInstance.h"
 #include "SurvivalRpg/Core/Player/RpgPlayerController.h"
 #include "SurvivalRpg/Core/Player/RpgPlayerState.h"
 #include "SurvivalRpg/GameplayTags/RpgGameplayTags.h"
@@ -96,6 +102,7 @@ ARpgCharacter::ARpgCharacter(const FObjectInitializer& ObjectInitializer) :
 	PawnExtensionComponent->OnAbilitySystemUninitialized_Register(FSimpleMulticastDelegate::FDelegate::CreateUObject(this, &ThisClass::OnAbilitySystemUninitialized));
 	
 	EquipmentManagerComponent = CreateDefaultSubobject<URpgEquipmentManagerComponent>(TEXT("EquipmentManagerComponent"));
+	EquipmentManagerComponent->OnEquipmentChanged.AddUObject(this, &ThisClass::HandleEquipmentChanged);
 	
 	HealthComponent = CreateDefaultSubobject<URpgHealthComponent>(TEXT("HealthComponent"));
 	HealthComponent->OnDeathStarted.AddDynamic(this, &ThisClass::OnDeathStarted);
@@ -153,11 +160,310 @@ void ARpgCharacter::ToggleCrouch()
 	}
 }
 
+ERpgCharacterRotationMode ARpgCharacter::GetRotationMode() const
+{
+	// Predicted activation-owned tags may upgrade the owning client's presentation before the
+	// replicated server mode arrives. In their absence the server value remains the reconciliation baseline.
+	if (GetLocalRole() == ROLE_AutonomousProxy && IsLocallyControlled())
+	{
+		if (RotationMode == ERpgCharacterRotationMode::Aim)
+		{
+			return ERpgCharacterRotationMode::Aim;
+		}
+
+		if (const URpgAbilitySystemComponent* Asc = RotationModeAbilitySystem.Get())
+		{
+			if (Asc->HasMatchingGameplayTag(RpgGameplayTags::State_Rotation_Aim))
+			{
+				return ERpgCharacterRotationMode::Aim;
+			}
+
+			if (Asc->HasMatchingGameplayTag(RpgGameplayTags::State_Rotation_CombatStrafe))
+			{
+				return ERpgCharacterRotationMode::CombatStrafe;
+			}
+		}
+	}
+
+	return RotationMode;
+}
+
+ERpgCharacterRotationMode ARpgCharacter::ResolveRotationMode(
+	bool bAimRequested,
+	bool bCombatStrafeRequested,
+	ERpgCharacterRotationMode DefaultMode)
+{
+	if (bAimRequested || DefaultMode == ERpgCharacterRotationMode::Aim)
+	{
+		return ERpgCharacterRotationMode::Aim;
+	}
+
+	if (bCombatStrafeRequested || DefaultMode == ERpgCharacterRotationMode::CombatStrafe)
+	{
+		return ERpgCharacterRotationMode::CombatStrafe;
+	}
+
+	return ERpgCharacterRotationMode::Free;
+}
+
+FRpgCharacterRotationPolicy ARpgCharacter::GetRotationPolicy(ERpgCharacterRotationMode InRotationMode)
+{
+	FRpgCharacterRotationPolicy Policy;
+	if (InRotationMode == ERpgCharacterRotationMode::Free)
+	{
+		Policy.bUseControllerRotationYaw = false;
+		Policy.bOrientRotationToMovement = true;
+		Policy.bUseControllerDesiredRotation = false;
+		Policy.RotationRateYaw = -1.0f;
+	}
+	else
+	{
+		Policy.bUseControllerRotationYaw = true;
+		Policy.bOrientRotationToMovement = false;
+		Policy.bUseControllerDesiredRotation = false;
+		Policy.RotationRateYaw = 720.0f;
+	}
+
+	return Policy;
+}
+
+bool ARpgCharacter::CanApplyExplicitCombatStanceRequest(
+	bool bEnable,
+	bool bHasWeapon,
+	bool bHasBlockingState,
+	bool bIsMovingOnGround,
+	bool bIsCrouched,
+	bool bWantsToCrouch,
+	bool bIsAnyMontagePlaying)
+{
+	return !bEnable ||
+		(bHasWeapon &&
+			!bHasBlockingState &&
+			bIsMovingOnGround &&
+			!bIsCrouched &&
+			!bWantsToCrouch &&
+			!bIsAnyMontagePlaying);
+}
+
+void ARpgCharacter::ToggleCombatStance()
+{
+	if (HasAuthority())
+	{
+		SetExplicitCombatStance(!bExplicitCombatStanceRequested);
+		return;
+	}
+
+	if (GetLocalRole() == ROLE_AutonomousProxy && IsLocallyControlled())
+	{
+		ServerToggleCombatStance();
+	}
+}
+
+void ARpgCharacter::ServerToggleCombatStance_Implementation()
+{
+	SetExplicitCombatStance(!bExplicitCombatStanceRequested);
+}
+
+ERpgCharacterRotationMode ARpgCharacter::ResolveRequestedRotationMode() const
+{
+	const URpgAbilitySystemComponent* Asc = RotationModeAbilitySystem.Get();
+	return ResolveRotationMode(
+		Asc && Asc->HasMatchingGameplayTag(RpgGameplayTags::State_Rotation_Aim),
+		Asc && Asc->HasMatchingGameplayTag(RpgGameplayTags::State_Rotation_CombatStrafe),
+		GetDefaultRotationMode());
+}
+
+ERpgCharacterRotationMode ARpgCharacter::GetDefaultRotationMode() const
+{
+	if (PawnExtensionComponent)
+	{
+		if (const URpgPawnData* PawnData = PawnExtensionComponent->GetPawnData<URpgPawnData>())
+		{
+			return PawnData->DefaultRotationMode;
+		}
+	}
+
+	return ERpgCharacterRotationMode::CombatStrafe;
+}
+
+void ARpgCharacter::RefreshRotationMode()
+{
+	if (HasAuthority())
+	{
+		const ERpgCharacterRotationMode ResolvedMode = ResolveRequestedRotationMode();
+		if (RotationMode != ResolvedMode)
+		{
+			RotationMode = ResolvedMode;
+			ForceNetUpdate();
+		}
+	}
+
+	ApplyRotationPolicy(GetRotationMode());
+}
+
+void ARpgCharacter::ApplyRotationPolicy(ERpgCharacterRotationMode InRotationMode)
+{
+	const FRpgCharacterRotationPolicy Policy = GetRotationPolicy(InRotationMode);
+	const bool bEnteringControllerFacingMode =
+		bHasAppliedRotationPolicy &&
+		LastAppliedRotationMode == ERpgCharacterRotationMode::Free &&
+		InRotationMode != ERpgCharacterRotationMode::Free;
+
+	bUseControllerRotationYaw = Policy.bUseControllerRotationYaw;
+	if (UCharacterMovementComponent* MovementComponent = GetCharacterMovement())
+	{
+		MovementComponent->bOrientRotationToMovement = Policy.bOrientRotationToMovement;
+		MovementComponent->bUseControllerDesiredRotation = Policy.bUseControllerDesiredRotation;
+		MovementComponent->RotationRate.Yaw = Policy.RotationRateYaw;
+	}
+
+	if (bEnteringControllerFacingMode &&
+		(HasAuthority() || GetLocalRole() == ROLE_AutonomousProxy) &&
+		GetController())
+	{
+		FaceRotation(GetController()->GetControlRotation(), 0.0f);
+	}
+
+	LastAppliedRotationMode = InRotationMode;
+	bHasAppliedRotationPolicy = true;
+}
+
+void ARpgCharacter::BindRotationModeAbilitySystem(URpgAbilitySystemComponent* AbilitySystemComponent)
+{
+	if (RotationModeAbilitySystem.Get() == AbilitySystemComponent)
+	{
+		RefreshRotationMode();
+		return;
+	}
+
+	UnbindRotationModeAbilitySystem();
+	RotationModeAbilitySystem = AbilitySystemComponent;
+	if (AbilitySystemComponent)
+	{
+		AbilitySystemComponent->RegisterGameplayTagEvent(
+			RpgGameplayTags::State_Rotation_CombatStrafe,
+			EGameplayTagEventType::NewOrRemoved).AddUObject(
+				this,
+				&ThisClass::HandleRotationRequestTagChanged);
+		AbilitySystemComponent->RegisterGameplayTagEvent(
+			RpgGameplayTags::State_Rotation_Aim,
+			EGameplayTagEventType::NewOrRemoved).AddUObject(
+				this,
+				&ThisClass::HandleRotationRequestTagChanged);
+	}
+
+	RefreshRotationMode();
+}
+
+void ARpgCharacter::UnbindRotationModeAbilitySystem()
+{
+	if (URpgAbilitySystemComponent* AbilitySystemComponent = RotationModeAbilitySystem.Get())
+	{
+		AbilitySystemComponent->RegisterGameplayTagEvent(
+			RpgGameplayTags::State_Rotation_CombatStrafe,
+			EGameplayTagEventType::NewOrRemoved).RemoveAll(this);
+		AbilitySystemComponent->RegisterGameplayTagEvent(
+			RpgGameplayTags::State_Rotation_Aim,
+			EGameplayTagEventType::NewOrRemoved).RemoveAll(this);
+	}
+
+	RotationModeAbilitySystem.Reset();
+}
+
+void ARpgCharacter::HandleRotationRequestTagChanged(const FGameplayTag Tag, int32 NewCount)
+{
+	(void)Tag;
+	(void)NewCount;
+	RefreshRotationMode();
+}
+
+bool ARpgCharacter::CanEnterExplicitCombatStance() const
+{
+	if (!HasAuthority())
+	{
+		return false;
+	}
+
+	const URpgAbilitySystemComponent* Asc = RotationModeAbilitySystem.Get();
+	static const FGameplayTag MovementStoppedTag =
+		FGameplayTag::RequestGameplayTag(FName(TEXT("Gameplay.MovementStopped")), false);
+	const bool bHasBlockingState = !Asc ||
+		Asc->HasMatchingGameplayTag(RpgGameplayTags::State_Dead) ||
+		Asc->HasMatchingGameplayTag(RpgGameplayTags::State_Staggered) ||
+		Asc->HasMatchingGameplayTag(RpgGameplayTags::State_GuardBroken) ||
+		Asc->HasMatchingGameplayTag(RpgGameplayTags::Status_Downed) ||
+		(MovementStoppedTag.IsValid() && Asc->HasMatchingGameplayTag(MovementStoppedTag));
+	const UCharacterMovementComponent* MovementComponent = GetCharacterMovement();
+	const UAnimInstance* AnimInstance = GetMesh() ? GetMesh()->GetAnimInstance() : nullptr;
+
+	return CanApplyExplicitCombatStanceRequest(
+		/*bEnable=*/ true,
+		EquipmentManagerComponent &&
+			EquipmentManagerComponent->GetFirstInstanceOfType(URpgWeaponInstance::StaticClass()) != nullptr,
+		bHasBlockingState,
+		MovementComponent && MovementComponent->IsMovingOnGround(),
+		IsCrouched(),
+		MovementComponent && MovementComponent->bWantsToCrouch,
+		AnimInstance && AnimInstance->IsAnyMontagePlaying());
+}
+
+void ARpgCharacter::SetExplicitCombatStance(bool bEnabled)
+{
+	if (!HasAuthority() || bExplicitCombatStanceRequested == bEnabled)
+	{
+		return;
+	}
+
+	URpgAbilitySystemComponent* Asc = RotationModeAbilitySystem.Get();
+	if (bEnabled)
+	{
+		if (!Asc || !CanEnterExplicitCombatStance())
+		{
+			return;
+		}
+
+		bExplicitCombatStanceRequested = true;
+		Asc->AddLooseGameplayTag(
+			RpgGameplayTags::State_Rotation_CombatStrafe,
+			1,
+			EGameplayTagReplicationState::None);
+	}
+	else
+	{
+		bExplicitCombatStanceRequested = false;
+		if (Asc)
+		{
+			Asc->RemoveLooseGameplayTag(
+				RpgGameplayTags::State_Rotation_CombatStrafe,
+				1,
+				EGameplayTagReplicationState::None);
+		}
+	}
+
+	RefreshRotationMode();
+}
+
+void ARpgCharacter::HandleEquipmentChanged()
+{
+	if (HasAuthority() &&
+		bExplicitCombatStanceRequested &&
+		(!EquipmentManagerComponent ||
+			!EquipmentManagerComponent->GetFirstInstanceOfType(URpgWeaponInstance::StaticClass())))
+	{
+		SetExplicitCombatStance(false);
+	}
+}
+
+void ARpgCharacter::OnRep_RotationMode()
+{
+	ApplyRotationPolicy(GetRotationMode());
+}
+
 // Called when the game starts or when spawned
 void ARpgCharacter::BeginPlay()
 {
 	Super::BeginPlay();
-	
+	RefreshRotationMode();
 }
 
 void ARpgCharacter::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
@@ -165,6 +471,7 @@ void ARpgCharacter::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLif
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 
 	DOREPLIFETIME_CONDITION(ThisClass, ReplicatedAcceleration, COND_SimulatedOnly);
+	DOREPLIFETIME_CONDITION_NOTIFY(ThisClass, RotationMode, COND_None, REPNOTIFY_Always);
 }
 
 void ARpgCharacter::PreReplication(IRepChangedPropertyTracker& ChangedPropertyTracker)
@@ -198,6 +505,7 @@ void ARpgCharacter::OnAbilitySystemInitialized()
 {
 	URpgAbilitySystemComponent* Asc = GetRpgAbilitySystemComponent();
 	check(Asc);
+	BindRotationModeAbilitySystem(Asc);
 
 	HealthComponent->InitializeWithAbilitySystem(Asc);
 	DeathComponent->InitializeWithAbilitySystem(Asc);
@@ -216,6 +524,12 @@ void ARpgCharacter::OnAbilitySystemInitialized()
 
 void ARpgCharacter::OnAbilitySystemUninitialized()
 {
+	if (HasAuthority())
+	{
+		SetExplicitCombatStance(false);
+	}
+	UnbindRotationModeAbilitySystem();
+
 	HealthComponent->UninitializeFromAbilitySystem();
 	DeathComponent->UninitializeFromAbilitySystem();
 	DownedComponent->UninitializeFromAbilitySystem();
@@ -230,6 +544,7 @@ void ARpgCharacter::PossessedBy(AController* NewController)
 {
 	Super::PossessedBy(NewController);
 	PawnExtensionComponent->HandleControllerChanged();
+	RefreshRotationMode();
 }
 
 void ARpgCharacter::UnPossessed()
@@ -242,6 +557,7 @@ void ARpgCharacter::OnRep_Controller()
 {
 	Super::OnRep_Controller();
 	PawnExtensionComponent->HandleControllerChanged();
+	RefreshRotationMode();
 }
 
 void ARpgCharacter::OnRep_PlayerState()
@@ -253,6 +569,8 @@ void ARpgCharacter::OnRep_PlayerState()
 	{
 		PawnGameplayComponent->CheckDefaultInitialization();
 	}
+
+	RefreshRotationMode();
 }
 
 void ARpgCharacter::FellOutOfWorld(const class UDamageType& dmgType)
@@ -262,6 +580,10 @@ void ARpgCharacter::FellOutOfWorld(const class UDamageType& dmgType)
 
 void ARpgCharacter::OnDeathStarted(AActor* OwningActor)
 {
+	if (HasAuthority())
+	{
+		SetExplicitCombatStance(false);
+	}
 	DisableMovementAndCollision();
 }
 
@@ -296,6 +618,10 @@ void ARpgCharacter::OnDownedStateChanged(ERpgDownedState NewState)
 {
 	if (NewState == ERpgDownedState::Downed)
 	{
+		if (HasAuthority())
+		{
+			SetExplicitCombatStance(false);
+		}
 		DisableMovementForDowned();
 		return;
 	}

--- a/Source/SurvivalRpg/Core/Character/RpgCharacter.h
+++ b/Source/SurvivalRpg/Core/Character/RpgCharacter.h
@@ -7,6 +7,7 @@
 #include "ModularCharacter.h"
 #include "GameFramework/Character.h"
 #include "RpgDownedComponent.h"
+#include "RpgCharacterRotationMode.h"
 #include "RpgCharacter.generated.h"
 
 class URpgCameraComponent;
@@ -21,6 +22,7 @@ class URpgPawnGameplayComponent;
 class URpgPawnExtensionComponent;
 class URpgCharacterMovementComponent;
 class URpgEquipmentManagerComponent;
+struct FGameplayTag;
 
 /**
  * Compact server-owned acceleration state replicated to simulated proxies for locomotion animation.
@@ -75,6 +77,39 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Rpg|Character")
 	void ToggleCrouch();
 
+	/**
+	 * Returns the rotation mode used for local presentation.
+	 * Autonomous proxies may resolve predicted activation-owned tags; simulated proxies return the replicated server value.
+	 */
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Rpg|Character|Rotation")
+	ERpgCharacterRotationMode GetRotationMode() const;
+
+	/** Pure Aim > CombatStrafe > Free priority resolver shared by runtime code and automation tests. */
+	static ERpgCharacterRotationMode ResolveRotationMode(
+		bool bAimRequested,
+		bool bCombatStrafeRequested,
+		ERpgCharacterRotationMode DefaultMode);
+
+	/** Returns the movement-component policy for the supplied rotation mode without mutating an actor. */
+	static FRpgCharacterRotationPolicy GetRotationPolicy(ERpgCharacterRotationMode InRotationMode);
+
+	/**
+	 * Pure server-request gate used by runtime validation and automation tests.
+	 * Disable requests are always allowed; enable requires a weapon, an unblocked grounded stance, and no montage.
+	 */
+	static bool CanApplyExplicitCombatStanceRequest(
+		bool bEnable,
+		bool bHasWeapon,
+		bool bHasBlockingState,
+		bool bIsMovingOnGround,
+		bool bIsCrouched,
+		bool bWantsToCrouch,
+		bool bIsAnyMontagePlaying);
+
+	/** Toggles the explicit combat-facing stance through the server-authoritative character request seam. */
+	UFUNCTION(BlueprintCallable, Category = "Rpg|Character|Rotation")
+	void ToggleCombatStance();
+
 	UFUNCTION(BlueprintCallable, Category = "Rpg|Equipment")
 	URpgEquipmentManagerComponent* GetEquipmentManagerComponent() const { return EquipmentManagerComponent; }
 	
@@ -118,6 +153,51 @@ protected:
 	void EnterDeadState();
 	
 private:
+	/** Reconciles the authoritative or locally predicted tag request into a presentation policy. */
+	void RefreshRotationMode();
+
+	/** Resolves request tags against the current PawnData fallback without mutating state. */
+	ERpgCharacterRotationMode ResolveRequestedRotationMode() const;
+
+	/** Returns the PawnData fallback, preserving CombatStrafe for legacy pawns without data. */
+	ERpgCharacterRotationMode GetDefaultRotationMode() const;
+
+	/** Applies one resolved controller/movement rotation contract. */
+	void ApplyRotationPolicy(ERpgCharacterRotationMode InRotationMode);
+
+	/** Binds request-tag changes on the ASC currently using this pawn as its avatar. */
+	void BindRotationModeAbilitySystem(URpgAbilitySystemComponent* AbilitySystemComponent);
+
+	/** Removes request-tag delegates from the previous avatar ASC. */
+	void UnbindRotationModeAbilitySystem();
+
+	void HandleRotationRequestTagChanged(const FGameplayTag Tag, int32 NewCount);
+	void HandleEquipmentChanged();
+	bool CanEnterExplicitCombatStance() const;
+	void SetExplicitCombatStance(bool bEnabled);
+
+	/** Reliable owning-client request; enable is validated against weapon equipment and blocking state on the server. */
+	UFUNCTION(Server, Reliable)
+	void ServerToggleCombatStance();
+
+	/** Server-owned rotation truth replicated to owners and simulated proxies for reconciliation and late join. */
+	UPROPERTY(Transient, ReplicatedUsing = OnRep_RotationMode)
+	ERpgCharacterRotationMode RotationMode = ERpgCharacterRotationMode::CombatStrafe;
+
+	/** Applies newly replicated server truth; autonomous proxies may still overlay predicted ability tags cosmetically. */
+	UFUNCTION()
+	void OnRep_RotationMode();
+
+	/** ASC whose rotation request-tag delegates are currently registered. */
+	TWeakObjectPtr<URpgAbilitySystemComponent> RotationModeAbilitySystem;
+
+	/** Server-only ownership bit for the single additive explicit-stance loose-tag count. */
+	bool bExplicitCombatStanceRequested = false;
+
+	/** Last policy applied to CharacterMovement, used to detect Free-to-controller-facing transitions. */
+	ERpgCharacterRotationMode LastAppliedRotationMode = ERpgCharacterRotationMode::CombatStrafe;
+	bool bHasAppliedRotationPolicy = false;
+
 	/** Latest server acceleration, replicated only to simulated proxies and consumed by CharacterMovement. */
 	UPROPERTY(Transient, ReplicatedUsing = OnRep_ReplicatedAcceleration)
 	FRpgReplicatedAcceleration ReplicatedAcceleration;

--- a/Source/SurvivalRpg/Core/Character/RpgCharacterRotationMode.h
+++ b/Source/SurvivalRpg/Core/Character/RpgCharacterRotationMode.h
@@ -1,0 +1,50 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+#include "RpgCharacterRotationMode.generated.h"
+
+/**
+ * Character rotation intent spanning exploration and controller-facing combat modes.
+ *
+ * The server owns the replicated mode. Autonomous proxies may temporarily resolve predicted
+ * GAS activation-owned tags for cosmetic presentation, while simulated proxies consume only
+ * the replicated value.
+ */
+UENUM(BlueprintType)
+enum class ERpgCharacterRotationMode : uint8
+{
+	/** Camera yaw is independent while movement direction turns the character. */
+	Free,
+
+	/** Character yaw follows control rotation for directional combat locomotion. */
+	CombatStrafe,
+
+	/** Highest-priority controller-facing mode reserved for explicit aiming. */
+	Aim
+};
+
+/** Pure movement-component policy associated with one rotation mode. */
+USTRUCT(BlueprintType)
+struct SURVIVALRPG_API FRpgCharacterRotationPolicy
+{
+	GENERATED_BODY()
+
+	/** Whether the character directly consumes controller yaw. */
+	UPROPERTY(BlueprintReadOnly, Category = "Rpg|Character|Rotation")
+	bool bUseControllerRotationYaw = true;
+
+	/** Whether CharacterMovement rotates toward acceleration. */
+	UPROPERTY(BlueprintReadOnly, Category = "Rpg|Character|Rotation")
+	bool bOrientRotationToMovement = false;
+
+	/** Whether CharacterMovement independently rotates toward controller yaw. */
+	UPROPERTY(BlueprintReadOnly, Category = "Rpg|Character|Rotation")
+	bool bUseControllerDesiredRotation = false;
+
+	/** CharacterMovement yaw rate in degrees per second; -1 means effectively immediate. */
+	UPROPERTY(BlueprintReadOnly, Category = "Rpg|Character|Rotation")
+	float RotationRateYaw = 720.0f;
+};

--- a/Source/SurvivalRpg/Core/Character/RpgPawnData.h
+++ b/Source/SurvivalRpg/Core/Character/RpgPawnData.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "Engine/DataAsset.h"
+#include "RpgCharacterRotationMode.h"
 #include "RpgPawnData.generated.h"
 
 class URpgCameraMode;
@@ -43,6 +44,13 @@ public:
 	// Default camera mode used by player controlled pawns.
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Camera")
 	TSubclassOf<URpgCameraMode> DefaultCameraMode;
+
+	/**
+	 * Fallback rotation mode used when no transient GAS aim or combat-strafe request is active.
+	 * Static designer-authored PawnData; runtime authority remains on ARpgCharacter.
+	 */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Character|Rotation")
+	ERpgCharacterRotationMode DefaultRotationMode = ERpgCharacterRotationMode::CombatStrafe;
 
 	/**
 	 * Static player-inventory layout selected by this PawnData.

--- a/Source/SurvivalRpg/Core/Character/RpgPawnGameplayComponent.cpp
+++ b/Source/SurvivalRpg/Core/Character/RpgPawnGameplayComponent.cpp
@@ -504,6 +504,14 @@ void URpgPawnGameplayComponent::Input_Crouch(const FInputActionValue& InputActio
 	}
 }
 
+void URpgPawnGameplayComponent::Input_ToggleCombatStance(const FInputActionValue& InputActionValue)
+{
+	if (ARpgCharacter* Character = GetPawn<ARpgCharacter>())
+	{
+		Character->ToggleCombatStance();
+	}
+}
+
 void URpgPawnGameplayComponent::Input_AutoRun(const FInputActionValue& InputActionValue)
 {
 	if (APawn* Pawn = GetPawn<APawn>())
@@ -614,6 +622,7 @@ void URpgPawnGameplayComponent::BindRoutedGameplayHotkeys(const URpgInputConfig*
 
 	if (BindHandles)
 	{
+		RpgIC->BindNativeAction(InputConfig, RpgGameplayTags::InputTag_RotationMode_ToggleCombat, ETriggerEvent::Started, this, &ThisClass::Input_ToggleCombatStance, *BindHandles, /*bLogIfNotFound=*/ false);
 		RpgIC->BindNativeAction(InputConfig, RpgGameplayTags::InputTag_UI_QuickAccessRadial_Hold, ETriggerEvent::Started, this, &ThisClass::Input_QuickAccessRadialStarted, *BindHandles, /*bLogIfNotFound=*/ false);
 		RpgIC->BindNativeAction(InputConfig, RpgGameplayTags::InputTag_UI_QuickAccessRadial_Hold, ETriggerEvent::Completed, this, &ThisClass::Input_QuickAccessRadialCompleted, *BindHandles, /*bLogIfNotFound=*/ false);
 		RpgIC->BindNativeAction(InputConfig, RpgGameplayTags::InputTag_UI_QuickAccessRadial_Hold, ETriggerEvent::Canceled, this, &ThisClass::Input_QuickAccessRadialCanceled, *BindHandles, /*bLogIfNotFound=*/ false);
@@ -624,6 +633,7 @@ void URpgPawnGameplayComponent::BindRoutedGameplayHotkeys(const URpgInputConfig*
 	}
 	else
 	{
+		RpgIC->BindNativeAction(InputConfig, RpgGameplayTags::InputTag_RotationMode_ToggleCombat, ETriggerEvent::Started, this, &ThisClass::Input_ToggleCombatStance, /*bLogIfNotFound=*/ false);
 		RpgIC->BindNativeAction(InputConfig, RpgGameplayTags::InputTag_UI_QuickAccessRadial_Hold, ETriggerEvent::Started, this, &ThisClass::Input_QuickAccessRadialStarted, /*bLogIfNotFound=*/ false);
 		RpgIC->BindNativeAction(InputConfig, RpgGameplayTags::InputTag_UI_QuickAccessRadial_Hold, ETriggerEvent::Completed, this, &ThisClass::Input_QuickAccessRadialCompleted, /*bLogIfNotFound=*/ false);
 		RpgIC->BindNativeAction(InputConfig, RpgGameplayTags::InputTag_UI_QuickAccessRadial_Hold, ETriggerEvent::Canceled, this, &ThisClass::Input_QuickAccessRadialCanceled, /*bLogIfNotFound=*/ false);

--- a/Source/SurvivalRpg/Core/Character/RpgPawnGameplayComponent.h
+++ b/Source/SurvivalRpg/Core/Character/RpgPawnGameplayComponent.h
@@ -79,6 +79,7 @@ public:
 	void Input_LookMouse(const FInputActionValue& InputActionValue);
 	void Input_LookStick(const FInputActionValue& InputActionValue);
 	void Input_Crouch(const FInputActionValue& InputActionValue);
+	void Input_ToggleCombatStance(const FInputActionValue& InputActionValue);
 	void Input_AutoRun(const FInputActionValue& InputActionValue);
 	void Input_Jump(const FInputActionValue& InputActionValue);
 	void Input_StopJump(const FInputActionValue& InputActionValue);

--- a/Source/SurvivalRpg/Equipment/RpgEquipmentManagerComponent.cpp
+++ b/Source/SurvivalRpg/Equipment/RpgEquipmentManagerComponent.cpp
@@ -135,6 +135,33 @@ void URpgEquipmentManagerComponent::GetLifetimeReplicatedProps(TArray<FLifetimeP
 	DOREPLIFETIME(ThisClass, EquipmentList);
 }
 
+void URpgEquipmentManagerComponent::BeginEquipmentChangeBatch()
+{
+	++EquipmentChangeBatchDepth;
+}
+
+void URpgEquipmentManagerComponent::EndEquipmentChangeBatch()
+{
+	check(EquipmentChangeBatchDepth > 0);
+	--EquipmentChangeBatchDepth;
+	if (EquipmentChangeBatchDepth == 0 && bEquipmentChangePending)
+	{
+		bEquipmentChangePending = false;
+		OnEquipmentChanged.Broadcast();
+	}
+}
+
+void URpgEquipmentManagerComponent::NotifyEquipmentChanged()
+{
+	if (EquipmentChangeBatchDepth > 0)
+	{
+		bEquipmentChangePending = true;
+		return;
+	}
+
+	OnEquipmentChanged.Broadcast();
+}
+
 URpgEquipmentInstance* URpgEquipmentManagerComponent::EquipItem(TSubclassOf<URpgEquipmentDefinition> EquipmentDefinition)
 {
 	if (!GetOwner() || !GetOwner()->HasAuthority())
@@ -162,6 +189,7 @@ URpgEquipmentInstance* URpgEquipmentManagerComponent::EquipItemInSlotWithInstiga
 		return Result;
 	}
 
+	BeginEquipmentChangeBatch();
 	if (CanEquipItemInSlot(EquipmentDefinition, Slot))
 	{
 		UnequipConflictingItems(EquipmentDefinition, Slot);
@@ -182,8 +210,11 @@ URpgEquipmentInstance* URpgEquipmentManagerComponent::EquipItemInSlotWithInstiga
 			{
 				AddReplicatedSubObject(Result);
 			}
+
+			NotifyEquipmentChanged();
 		}
 	}
+	EndEquipmentChangeBatch();
 
 	return Result;
 }
@@ -209,6 +240,7 @@ void URpgEquipmentManagerComponent::UnequipItem(URpgEquipmentInstance* ItemInsta
 	ItemInstance->OnUnequipped();
 	EquipmentList.RemoveEntry(ItemInstance);
 	RebuildEquipmentAbilityGrants();
+	NotifyEquipmentChanged();
 }
 
 void URpgEquipmentManagerComponent::UnequipItemInSlot(ERpgEquipmentSlot Slot)
@@ -227,10 +259,12 @@ void URpgEquipmentManagerComponent::UnequipItemInSlot(ERpgEquipmentSlot Slot)
 		}
 	}
 
+	BeginEquipmentChangeBatch();
 	for (URpgEquipmentInstance* Instance : InstancesToUnequip)
 	{
 		UnequipItem(Instance);
 	}
+	EndEquipmentChangeBatch();
 }
 
 URpgEquipmentInstance* URpgEquipmentManagerComponent::GetFirstInstanceOfType(TSubclassOf<URpgEquipmentInstance> InstanceType) const

--- a/Source/SurvivalRpg/Equipment/RpgEquipmentManagerComponent.h
+++ b/Source/SurvivalRpg/Equipment/RpgEquipmentManagerComponent.h
@@ -109,6 +109,9 @@ struct TStructOpsTypeTraits<FRpgEquipmentList> : public TStructOpsTypeTraitsBase
 	enum { WithNetDeltaSerializer = true };
 };
 
+/** Native notification fired after an authoritative equipment mutation is fully applied. */
+DECLARE_MULTICAST_DELEGATE(FRpgEquipmentChangedDelegate);
+
 UCLASS(BlueprintType, Const, meta = (BlueprintSpawnableComponent))
 class SURVIVALRPG_API URpgEquipmentManagerComponent : public UPawnComponent
 {
@@ -116,6 +119,12 @@ class SURVIVALRPG_API URpgEquipmentManagerComponent : public UPawnComponent
 
 public:
 	URpgEquipmentManagerComponent(const FObjectInitializer& ObjectInitializer = FObjectInitializer::Get());
+
+	/**
+	 * Authority-side seam for systems that must reconcile state after equipment changes.
+	 * Batched replacements emit once after the complete transaction, never for their temporary unequipped midpoint.
+	 */
+	FRpgEquipmentChangedDelegate OnEquipmentChanged;
 
 	/** Native authority seam that equips the definition into its default slot. */
 	URpgEquipmentInstance* EquipItem(TSubclassOf<URpgEquipmentDefinition> EquipmentDefinition);
@@ -179,6 +188,21 @@ private:
 	void RefreshEquipmentItemizationEffect(FRpgAppliedEquipmentEntry& Entry);
 	void RebuildEquipmentItemizationEffects();
 	void RebuildEquipmentAbilityGrants();
+
+	/** Starts a nested authority-side equipment mutation transaction. */
+	void BeginEquipmentChangeBatch();
+
+	/** Ends a mutation transaction and emits one deferred notification at the outermost boundary. */
+	void EndEquipmentChangeBatch();
+
+	/** Emits immediately outside a batch or marks the current transaction dirty. */
+	void NotifyEquipmentChanged();
+
+	/** Nested transaction depth used to coalesce replacement and multi-slot mutations. */
+	int32 EquipmentChangeBatchDepth = 0;
+
+	/** True when at least one successful mutation occurred inside the active transaction. */
+	bool bEquipmentChangePending = false;
 
 	UPROPERTY(Replicated)
 	FRpgEquipmentList EquipmentList;

--- a/Source/SurvivalRpg/GameplayTags/RpgGameplayTags.cpp
+++ b/Source/SurvivalRpg/GameplayTags/RpgGameplayTags.cpp
@@ -48,6 +48,7 @@ namespace RpgGameplayTags
 	UE_DEFINE_GAMEPLAY_TAG_COMMENT(InputTag_Weapon_Primary, "InputTag.Weapon.Primary", "Primary weapon attack input.");
 	UE_DEFINE_GAMEPLAY_TAG_COMMENT(InputTag_Weapon_Secondary, "InputTag.Weapon.Secondary", "Secondary weapon attack input.");
 	UE_DEFINE_GAMEPLAY_TAG_COMMENT(InputTag_Weapon_Block, "InputTag.Weapon.Block", "Hold block input for the equipped weapon.");
+	UE_DEFINE_GAMEPLAY_TAG_COMMENT(InputTag_RotationMode_ToggleCombat, "InputTag.RotationMode.ToggleCombat", "Toggle the explicit weapon-gated combat-facing stance.");
 	
 	
 	UE_DEFINE_GAMEPLAY_TAG_COMMENT(GameplayEvent_Death, "GameplayEvent.Death", "Event that fires on death. This event only fires on the server.");
@@ -87,6 +88,8 @@ namespace RpgGameplayTags
 	UE_DEFINE_GAMEPLAY_TAG_COMMENT(State_Staggered, "State.Staggered", "Target is staggered.");
 	UE_DEFINE_GAMEPLAY_TAG_COMMENT(State_GuardBroken, "State.GuardBroken", "Target's guard is broken.");
 	UE_DEFINE_GAMEPLAY_TAG_COMMENT(State_StaggerImmune, "State.StaggerImmune", "Target is temporarily immune to new stagger buildup.");
+	UE_DEFINE_GAMEPLAY_TAG_COMMENT(State_Rotation_CombatStrafe, "State.Rotation.CombatStrafe", "Target requests controller-facing combat locomotion.");
+	UE_DEFINE_GAMEPLAY_TAG_COMMENT(State_Rotation_Aim, "State.Rotation.Aim", "Target requests controller-facing aim locomotion.");
 	UE_DEFINE_GAMEPLAY_TAG_COMMENT(Trait_Staggerable, "Trait.Staggerable", "Target can build stagger and enter stagger reactions.");
 	UE_DEFINE_GAMEPLAY_TAG_COMMENT(Status_Death, "Status.Death", "Target has the death status.");
 	UE_DEFINE_GAMEPLAY_TAG_COMMENT(Status_Death_Dying, "Status.Death.Dying", "Target has begun the death process.");

--- a/Source/SurvivalRpg/GameplayTags/RpgGameplayTags.h
+++ b/Source/SurvivalRpg/GameplayTags/RpgGameplayTags.h
@@ -53,6 +53,8 @@ namespace RpgGameplayTags
 	UE_DECLARE_GAMEPLAY_TAG_EXTERN(InputTag_Weapon_Primary);
 	UE_DECLARE_GAMEPLAY_TAG_EXTERN(InputTag_Weapon_Secondary);
 	UE_DECLARE_GAMEPLAY_TAG_EXTERN(InputTag_Weapon_Block);
+	// Exported because the combat GameFeature input config and editor contracts consume this native action tag.
+	extern SURVIVALRPG_API FNativeGameplayTag InputTag_RotationMode_ToggleCombat;
 	
 	UE_DECLARE_GAMEPLAY_TAG_EXTERN(GameplayEvent_Death);
 	UE_DECLARE_GAMEPLAY_TAG_EXTERN(GameplayEvent_HitReaction);
@@ -94,6 +96,9 @@ namespace RpgGameplayTags
 	UE_DECLARE_GAMEPLAY_TAG_EXTERN(State_Staggered);
 	UE_DECLARE_GAMEPLAY_TAG_EXTERN(State_GuardBroken);
 	UE_DECLARE_GAMEPLAY_TAG_EXTERN(State_StaggerImmune);
+	// Exported because editor contracts and runtime GameFeature content consume rotation intent.
+	extern SURVIVALRPG_API FNativeGameplayTag State_Rotation_CombatStrafe;
+	extern SURVIVALRPG_API FNativeGameplayTag State_Rotation_Aim;
 	UE_DECLARE_GAMEPLAY_TAG_EXTERN(Trait_Staggerable);
 	// Exported because runtime GameFeature modules use the canonical death gate.
 	extern SURVIVALRPG_API FNativeGameplayTag Status_Death;

--- a/Source/SurvivalRpgEditor/Private/Animation/RpgGaspPilotAssetTests.cpp
+++ b/Source/SurvivalRpgEditor/Private/Animation/RpgGaspPilotAssetTests.cpp
@@ -3,6 +3,7 @@
 #if WITH_DEV_AUTOMATION_TESTS
 
 #include "AlphaBlend.h"
+#include "Abilities/GameplayAbility.h"
 #include "AnimGraph/AnimGraphNode_OrientationWarping.h"
 #include "AnimGraph/AnimGraphNode_Steering.h"
 #include "AnimGraphNode_BlendStackInput.h"
@@ -34,6 +35,9 @@
 #include "GameFeatureAction.h"
 #include "GameFramework/Character.h"
 #include "GameplayTagContainer.h"
+#include "InputAction.h"
+#include "InputCoreTypes.h"
+#include "InputMappingContext.h"
 #include "K2Node_AnimNodeReference.h"
 #include "K2Node_CallFunction.h"
 #include "K2Node_VariableGet.h"
@@ -48,6 +52,7 @@
 #include "SurvivalRpg/Core/Character/RpgCharacter.h"
 #include "SurvivalRpg/Core/Character/RpgPawnData.h"
 #include "SurvivalRpg/Core/Game/Experience/RpgExperienceDefinition.h"
+#include "SurvivalRpg/Input/RpgInputConfig.h"
 #include "UObject/PropertyPortFlags.h"
 #include "UObject/UnrealType.h"
 
@@ -71,6 +76,18 @@ namespace RpgGaspPilotAssetTests
 		TEXT("/Game/SurvivalRpg/Characters/Mannequins/Meshes/SK_Mannequin.SK_Mannequin");
 	constexpr TCHAR TurnInPlaceDatabaseObject[] =
 		TEXT("/RpgGaspLocomotion/MotionMatching/Databases/PSD_Rpg_Stand_TurnInPlace.PSD_Rpg_Stand_TurnInPlace");
+	constexpr TCHAR CombatStanceInputActionObject[] =
+		TEXT("/GF_Combat_Core/Input/IA_ToggleCombatStance.IA_ToggleCombatStance");
+	constexpr TCHAR CombatInputMappingContextObject[] =
+		TEXT("/GF_Combat_Core/Input/IMC_Combat.IMC_Combat");
+	constexpr TCHAR CombatInputConfigObject[] =
+		TEXT("/GF_Combat_Core/Input/DA_InputConfig_Combat.DA_InputConfig_Combat");
+	constexpr TCHAR BasicWeaponAttackAbilityObject[] =
+		TEXT("/GF_Combat_Core/GAS/Abilities/GA_BasicWeaponAttack.GA_BasicWeaponAttack");
+	constexpr TCHAR CombatBlockAbilityObject[] =
+		TEXT("/GF_Combat_Core/GAS/Abilities/GA_Combat_Block.GA_Combat_Block");
+	constexpr TCHAR CombatStrafeTagName[] = TEXT("State.Rotation.CombatStrafe");
+	constexpr TCHAR ToggleCombatInputTagName[] = TEXT("InputTag.RotationMode.ToggleCombat");
 
 	constexpr TCHAR PilotAnimBlueprintPackage[] =
 		TEXT("/Game/SurvivalRpg/Characters/Mannequins/Anims/GASP/ABP_RpgCharacter_GASP");
@@ -306,6 +323,20 @@ namespace RpgGaspPilotAssetTests
 
 		OutValue = Property->GetPropertyValue_InContainer(Object);
 		return true;
+	}
+
+	const FGameplayTagContainer* ReadGameplayTagContainerProperty(
+		const UObject* Object,
+		FName PropertyName)
+	{
+		const FStructProperty* Property =
+			Object ? FindFProperty<FStructProperty>(Object->GetClass(), PropertyName) : nullptr;
+		if (!Property || Property->Struct != FGameplayTagContainer::StaticStruct())
+		{
+			return nullptr;
+		}
+
+		return Property->ContainerPtrToValuePtr<FGameplayTagContainer>(Object);
 	}
 
 	bool ReadMemberReferenceProperty(
@@ -1486,6 +1517,13 @@ bool FRpgGaspPilotAssetContractTest::RunTest(const FString& Parameters)
 		TEXT("The pilot PawnData selects the isolated character"),
 		PilotPawnData->PawnClass.Get(),
 		PilotCharacterBlueprint->GeneratedClass.Get());
+	TestTrue(
+		TEXT("The default PawnData keeps legacy-safe CombatStrafe rotation"),
+		BasePawnData->DefaultRotationMode ==
+			ERpgCharacterRotationMode::CombatStrafe);
+	TestTrue(
+		TEXT("Only the GASP pilot PawnData opts into Free rotation"),
+		PilotPawnData->DefaultRotationMode == ERpgCharacterRotationMode::Free);
 	TestEqual(TEXT("PawnData TeamId is unchanged"), PilotPawnData->TeamId, BasePawnData->TeamId);
 	TestEqual(
 		TEXT("PawnData TagRelationshipMapping is unchanged"),
@@ -1608,6 +1646,197 @@ bool FRpgGaspPilotAssetContractTest::RunTest(const FString& Parameters)
 				*PackageName.ToString()),
 			IsForbiddenPilotDependency(PackageName.ToString()));
 	}
+
+	return !HasAnyErrors();
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FRpgGaspRotationModeAssetContractTest,
+	"SurvivalRpg.Animation.Gasp.RotationModeAssetContract",
+	EAutomationTestFlags::EditorContext |
+		EAutomationTestFlags::EngineFilter)
+
+bool FRpgGaspRotationModeAssetContractTest::RunTest(const FString& Parameters)
+{
+	using namespace RpgGaspPilotAssetTests;
+
+	const UInputAction* CombatStanceAction = LoadRequiredAsset<UInputAction>(
+		*this,
+		CombatStanceInputActionObject,
+		TEXT("The project-local combat-stance InputAction loads"));
+	const UInputMappingContext* CombatInputMappingContext =
+		LoadRequiredAsset<UInputMappingContext>(
+			*this,
+			CombatInputMappingContextObject,
+			TEXT("The combat InputMappingContext loads"));
+	const URpgInputConfig* CombatInputConfig = LoadRequiredAsset<URpgInputConfig>(
+		*this,
+		CombatInputConfigObject,
+		TEXT("The combat InputConfig loads"));
+	const UBlueprint* BasicWeaponAttackAbility = LoadRequiredAsset<UBlueprint>(
+		*this,
+		BasicWeaponAttackAbilityObject,
+		TEXT("The basic weapon attack ability Blueprint loads"));
+	const UBlueprint* CombatBlockAbility = LoadRequiredAsset<UBlueprint>(
+		*this,
+		CombatBlockAbilityObject,
+		TEXT("The combat block ability Blueprint loads"));
+
+	const UGameplayAbility* BasicWeaponAttackDefaults =
+		BasicWeaponAttackAbility && BasicWeaponAttackAbility->GeneratedClass
+			? Cast<UGameplayAbility>(
+				BasicWeaponAttackAbility->GeneratedClass->GetDefaultObject())
+			: nullptr;
+	const UGameplayAbility* CombatBlockDefaults =
+		CombatBlockAbility && CombatBlockAbility->GeneratedClass
+			? Cast<UGameplayAbility>(
+				CombatBlockAbility->GeneratedClass->GetDefaultObject())
+			: nullptr;
+	TestNotNull(
+		TEXT("The basic weapon attack ability defaults load"),
+		BasicWeaponAttackDefaults);
+	TestNotNull(
+		TEXT("The combat block ability defaults load"),
+		CombatBlockDefaults);
+
+	if (!CombatStanceAction ||
+		!CombatInputMappingContext ||
+		!CombatInputConfig ||
+		!BasicWeaponAttackDefaults ||
+		!CombatBlockDefaults)
+	{
+		return false;
+	}
+
+	TestTrue(
+		TEXT("The combat-stance InputAction is a Boolean action"),
+		CombatStanceAction->ValueType == EInputActionValueType::Boolean);
+
+	int32 RelatedEnhancedInputMappings = 0;
+	for (const FEnhancedActionKeyMapping& Mapping :
+		CombatInputMappingContext->GetMappings())
+	{
+		const bool bUsesCombatStanceAction =
+			Mapping.Action.Get() == CombatStanceAction;
+		const bool bUsesMiddleMouseButton =
+			Mapping.Key == EKeys::MiddleMouseButton;
+		if (!bUsesCombatStanceAction && !bUsesMiddleMouseButton)
+		{
+			continue;
+		}
+
+		++RelatedEnhancedInputMappings;
+		TestTrue(
+			TEXT("The combat-stance mapping uses IA_ToggleCombatStance"),
+			bUsesCombatStanceAction);
+		TestTrue(
+			TEXT("The combat-stance mapping uses exactly MiddleMouseButton"),
+			bUsesMiddleMouseButton);
+	}
+	TestEqual(
+		TEXT("IMC_Combat owns one exclusive combat-stance Action-Key mapping"),
+		RelatedEnhancedInputMappings,
+		1);
+
+	const FGameplayTag ToggleCombatInputTag =
+		FGameplayTag::RequestGameplayTag(
+			FName(ToggleCombatInputTagName),
+			/*ErrorIfNotFound=*/ false);
+	if (!TestTrue(
+			TEXT("The native combat-stance input tag is registered"),
+			ToggleCombatInputTag.IsValid()))
+	{
+		return false;
+	}
+	TestEqual(
+		TEXT("The native combat-stance input tag keeps its exact name"),
+		ToggleCombatInputTag.ToString(),
+		FString(ToggleCombatInputTagName));
+
+	int32 RelatedNativeMappings = 0;
+	for (const FRpgInputAction& Mapping : CombatInputConfig->NativeInputActions)
+	{
+		const bool bUsesCombatStanceAction =
+			Mapping.InputAction.Get() == CombatStanceAction;
+		const bool bUsesToggleCombatTag =
+			Mapping.InputTag == ToggleCombatInputTag;
+		if (!bUsesCombatStanceAction && !bUsesToggleCombatTag)
+		{
+			continue;
+		}
+
+		++RelatedNativeMappings;
+		TestTrue(
+			TEXT("The native combat-stance mapping uses its exact InputAction"),
+			bUsesCombatStanceAction);
+		TestTrue(
+			TEXT("The native combat-stance mapping uses its exact input tag"),
+			bUsesToggleCombatTag);
+	}
+	TestEqual(
+		TEXT("DA_InputConfig_Combat owns one combat-stance native mapping"),
+		RelatedNativeMappings,
+		1);
+	TestEqual(
+		TEXT("The combat-stance native tag resolves to its exact InputAction"),
+		CombatInputConfig->FindNativeInputActionForTag(
+			ToggleCombatInputTag,
+			/*bLogNotFound=*/ false),
+		CombatStanceAction);
+
+	int32 RelatedAbilityInputMappings = 0;
+	for (const FRpgInputAction& Mapping : CombatInputConfig->AbilityInputActions)
+	{
+		RelatedAbilityInputMappings +=
+			Mapping.InputAction.Get() == CombatStanceAction ||
+				Mapping.InputTag == ToggleCombatInputTag
+				? 1
+				: 0;
+	}
+	TestEqual(
+		TEXT("The combat-stance toggle is not routed through GAS ability input"),
+		RelatedAbilityInputMappings,
+		0);
+
+	const FGameplayTag CombatStrafeTag =
+		FGameplayTag::RequestGameplayTag(
+			FName(CombatStrafeTagName),
+			/*ErrorIfNotFound=*/ false);
+	if (!TestTrue(
+			TEXT("The CombatStrafe state tag is registered"),
+			CombatStrafeTag.IsValid()))
+	{
+		return false;
+	}
+
+	const auto TestCombatStrafeActivationTag =
+		[this, CombatStrafeTag](
+			const TCHAR* AbilityLabel,
+			const UGameplayAbility* AbilityDefaults)
+		{
+			const FGameplayTagContainer* ActivationOwnedTags =
+				ReadGameplayTagContainerProperty(
+					AbilityDefaults,
+					TEXT("ActivationOwnedTags"));
+			if (TestNotNull(
+					*FString::Printf(
+						TEXT("%s exposes ActivationOwnedTags"),
+						AbilityLabel),
+					ActivationOwnedTags))
+			{
+				TestTrue(
+					*FString::Printf(
+						TEXT("%s owns CombatStrafe while active"),
+						AbilityLabel),
+					ActivationOwnedTags->HasTagExact(CombatStrafeTag));
+			}
+		};
+	TestCombatStrafeActivationTag(
+		TEXT("GA_BasicWeaponAttack"),
+		BasicWeaponAttackDefaults);
+	TestCombatStrafeActivationTag(
+		TEXT("GA_Combat_Block"),
+		CombatBlockDefaults);
 
 	return !HasAnyErrors();
 }

--- a/Source/SurvivalRpgEditor/Private/Animation/RpgTurnInPlaceRuntimeTests.cpp
+++ b/Source/SurvivalRpgEditor/Private/Animation/RpgTurnInPlaceRuntimeTests.cpp
@@ -156,6 +156,7 @@ bool FRpgTurnInPlaceStateMachineTest::RunTest(const FString& Parameters)
 	FRpgAnimInstanceProxy Proxy;
 	Proxy.MovementState = ERpgLocomotionMovementState::Grounded;
 	Proxy.Gait = ERpgLocomotionGait::Idle;
+	Proxy.RotationMode = ERpgCharacterRotationMode::CombatStrafe;
 	Proxy.bIsMovingOnGround = true;
 	Proxy.GroundSpeed = 0.0f;
 	Proxy.bHasAcceleration = false;
@@ -167,6 +168,14 @@ bool FRpgTurnInPlaceStateMachineTest::RunTest(const FString& Parameters)
 	CurrentTrajectorySample.TimeInSeconds = 0.0f;
 	CurrentTrajectorySample.Position = FVector::ZeroVector;
 	CurrentTrajectorySample.Facing = FQuat::Identity;
+
+	Proxy.RotationMode = ERpgCharacterRotationMode::Free;
+	TestFalse(TEXT("Free rotation mode disables turn-in-place eligibility"), AnimInstance->IsTurnInPlaceEligible(Proxy));
+	Proxy.RotationMode = ERpgCharacterRotationMode::CombatStrafe;
+	TestTrue(TEXT("Combat strafe rotation mode allows turn-in-place eligibility"), AnimInstance->IsTurnInPlaceEligible(Proxy));
+	Proxy.RotationMode = ERpgCharacterRotationMode::Aim;
+	TestTrue(TEXT("Aim rotation mode allows turn-in-place eligibility"), AnimInstance->IsTurnInPlaceEligible(Proxy));
+	Proxy.RotationMode = ERpgCharacterRotationMode::CombatStrafe;
 
 	AnimInstance->ResetTurnInPlaceRuntime(false);
 	Proxy.ActorYawDelta = 20.0f;
@@ -506,7 +515,16 @@ bool FRpgTurnInPlaceStateMachineTest::RunTest(const FString& Parameters)
 		Proxy.bIsAnyMontagePlaying = false;
 		Proxy.bIsCrouching = false;
 		Proxy.MovementState = ERpgLocomotionMovementState::Grounded;
+		Proxy.RotationMode = ERpgCharacterRotationMode::CombatStrafe;
 	};
+
+	ActivateTurnForReset();
+	Proxy.RotationMode = ERpgCharacterRotationMode::Free;
+	AnimInstance->UpdateTurnInPlaceRuntime(0.01f, Proxy);
+	TestEqual(TEXT("Switching an active turn to Free hard-resets turn-in-place"), AnimInstance->TurnInPlaceState, ERpgTurnInPlaceState::Inactive);
+	TestTrue(TEXT("The first Active-to-Free frame emits an Offset Root reset pulse"), AnimInstance->bResetOffsetRootEveryFrame);
+	AnimInstance->UpdateTurnInPlaceRuntime(0.01f, Proxy);
+	TestFalse(TEXT("Persistent Free mode does not repeat the Offset Root reset pulse"), AnimInstance->bResetOffsetRootEveryFrame);
 
 	ActivateTurnForReset();
 	Proxy.bIsCrouching = true;
@@ -557,6 +575,7 @@ bool FRpgTurnInPlaceStateMachineTest::RunTest(const FString& Parameters)
 		FRpgAnimInstanceProxy FrameRateProxy;
 		FrameRateProxy.MovementState = ERpgLocomotionMovementState::Grounded;
 		FrameRateProxy.Gait = ERpgLocomotionGait::Idle;
+		FrameRateProxy.RotationMode = ERpgCharacterRotationMode::CombatStrafe;
 		FrameRateProxy.bIsMovingOnGround = true;
 		FrameRateProxy.GroundSpeed = 0.0f;
 		FrameRateProxy.bTurnInPlaceHardReset = false;

--- a/Source/SurvivalRpgEditor/Private/Animation/RpgTurnInPlaceRuntimeTests.cpp
+++ b/Source/SurvivalRpgEditor/Private/Animation/RpgTurnInPlaceRuntimeTests.cpp
@@ -139,6 +139,43 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 
 bool FRpgTurnInPlaceStateMachineTest::RunTest(const FString& Parameters)
 {
+	TestFalse(
+		TEXT("The first owner snapshot cannot report a turn-in-place policy transition"),
+		URpgAnimInstance::DidTurnInPlaceSupportChange(
+			false,
+			ERpgCharacterRotationMode::Free,
+			ERpgCharacterRotationMode::CombatStrafe));
+	TestTrue(
+		TEXT("Free to CombatStrafe crosses the turn-in-place policy boundary"),
+		URpgAnimInstance::DidTurnInPlaceSupportChange(
+			true,
+			ERpgCharacterRotationMode::Free,
+			ERpgCharacterRotationMode::CombatStrafe));
+	TestTrue(
+		TEXT("Aim to Free crosses the turn-in-place policy boundary"),
+		URpgAnimInstance::DidTurnInPlaceSupportChange(
+			true,
+			ERpgCharacterRotationMode::Aim,
+			ERpgCharacterRotationMode::Free));
+	TestFalse(
+		TEXT("CombatStrafe to Aim preserves the shared controller-facing policy"),
+		URpgAnimInstance::DidTurnInPlaceSupportChange(
+			true,
+			ERpgCharacterRotationMode::CombatStrafe,
+			ERpgCharacterRotationMode::Aim));
+	TestTrue(
+		TEXT("A policy-boundary snapshot discards even a 180-degree actor-yaw jump"),
+		FMath::IsNearlyZero(URpgAnimInstance::CalculateTurnInPlaceSnapshotYawDelta(
+			0.0f,
+			180.0f,
+			false,
+			true)));
+	TestTrue(
+		TEXT("An established controller-facing snapshot retains normal authored turn intent"),
+		FMath::IsNearlyEqual(
+			URpgAnimInstance::CalculateTurnInPlaceSnapshotYawDelta(0.0f, 90.0f, false, false),
+			90.0f));
+
 	USkeletalMeshComponent* AnimInstanceOuter = NewObject<USkeletalMeshComponent>();
 	URpgAnimInstance* AnimInstance = NewObject<URpgAnimInstance>(AnimInstanceOuter);
 	UPoseSearchDatabase* TurnDatabase = NewObject<UPoseSearchDatabase>();
@@ -525,6 +562,43 @@ bool FRpgTurnInPlaceStateMachineTest::RunTest(const FString& Parameters)
 	TestTrue(TEXT("The first Active-to-Free frame emits an Offset Root reset pulse"), AnimInstance->bResetOffsetRootEveryFrame);
 	AnimInstance->UpdateTurnInPlaceRuntime(0.01f, Proxy);
 	TestFalse(TEXT("Persistent Free mode does not repeat the Offset Root reset pulse"), AnimInstance->bResetOffsetRootEveryFrame);
+
+	Proxy.RotationMode = ERpgCharacterRotationMode::CombatStrafe;
+	Proxy.bTurnInPlaceSupportChanged = true;
+	Proxy.ActorYawDelta = 180.0f;
+	AnimInstance->UpdateTurnInPlaceRuntime(0.01f, Proxy);
+	TestEqual(
+		TEXT("Free-to-combat policy entry recovers instead of selecting a turn clip"),
+		AnimInstance->TurnInPlaceState,
+		ERpgTurnInPlaceState::Recovering);
+	TestTrue(TEXT("Rotation-mode entry hard-resets stale Offset Root state"), AnimInstance->bResetOffsetRootEveryFrame);
+	const float ModeEntryAccumulatedYaw = AnimInstance->TurnInPlaceAccumulatedYaw;
+	Proxy.bTurnInPlaceSupportChanged = false;
+	Proxy.ActorYawDelta = 90.0f;
+	AnimInstance->UpdateTurnInPlaceRuntime(0.05f, Proxy);
+	TestFalse(TEXT("The Offset Root reset pulse clears on the first recovery update"), AnimInstance->bResetOffsetRootEveryFrame);
+	AnimInstance->UpdateTurnInPlaceRuntime(0.05f, Proxy);
+	TestEqual(
+		TEXT("Mode-entry recovery remains active after two 20-FPS updates"),
+		AnimInstance->TurnInPlaceState,
+		ERpgTurnInPlaceState::Recovering);
+	TestTrue(
+		TEXT("Mode-entry recovery never accumulates network-smoothed yaw"),
+		FMath::IsNearlyEqual(AnimInstance->TurnInPlaceAccumulatedYaw, ModeEntryAccumulatedYaw));
+	AnimInstance->UpdateTurnInPlaceRuntime(0.05f, Proxy);
+	TestEqual(
+		TEXT("Mode-entry recovery returns to normal combat idle on the third 20-FPS update"),
+		AnimInstance->TurnInPlaceState,
+		ERpgTurnInPlaceState::Inactive);
+	TestTrue(
+		TEXT("Mode-entry recovery clears discarded yaw before normal TIR resumes"),
+		FMath::IsNearlyZero(AnimInstance->TurnInPlaceAccumulatedYaw));
+	Proxy.ActorYawDelta = 20.0f;
+	AnimInstance->UpdateTurnInPlaceRuntime(0.01f, Proxy);
+	TestEqual(
+		TEXT("Normal combat turn-in-place collection resumes after the bounded mode-entry recovery"),
+		AnimInstance->TurnInPlaceState,
+		ERpgTurnInPlaceState::Collecting);
 
 	ActivateTurnForReset();
 	Proxy.bIsCrouching = true;

--- a/Source/SurvivalRpgEditor/Private/Character/RpgCharacterRotationModeTests.cpp
+++ b/Source/SurvivalRpgEditor/Private/Character/RpgCharacterRotationModeTests.cpp
@@ -1,0 +1,142 @@
+#include "CoreMinimal.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "GameplayAbilitiesDeveloperSettings.h"
+#include "Misc/AutomationTest.h"
+#include "SurvivalRpg/Core/Character/RpgCharacter.h"
+#include "SurvivalRpg/Core/Character/RpgPawnData.h"
+#include "SurvivalRpg/GameplayTags/RpgGameplayTags.h"
+#include "UObject/UnrealType.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FRpgCharacterRotationModeResolverTest,
+	"SurvivalRpg.Character.RotationMode.ResolverAndPolicy",
+	EAutomationTestFlags::EditorContext |
+		EAutomationTestFlags::EngineFilter)
+
+bool FRpgCharacterRotationModeResolverTest::RunTest(const FString& Parameters)
+{
+	TestTrue(
+		TEXT("Aim request has priority over combat strafe and PawnData"),
+		ARpgCharacter::ResolveRotationMode(true, true, ERpgCharacterRotationMode::Free) ==
+			ERpgCharacterRotationMode::Aim);
+	TestTrue(
+		TEXT("Combat strafe request has priority over PawnData"),
+		ARpgCharacter::ResolveRotationMode(false, true, ERpgCharacterRotationMode::Free) ==
+			ERpgCharacterRotationMode::CombatStrafe);
+	TestTrue(
+		TEXT("PawnData free mode is preserved without request tags"),
+		ARpgCharacter::ResolveRotationMode(false, false, ERpgCharacterRotationMode::Free) ==
+			ERpgCharacterRotationMode::Free);
+	TestTrue(
+		TEXT("PawnData aim mode is preserved without request tags"),
+		ARpgCharacter::ResolveRotationMode(false, false, ERpgCharacterRotationMode::Aim) ==
+			ERpgCharacterRotationMode::Aim);
+	TestTrue(
+		TEXT("PawnData aim mode retains priority over a combat-strafe request"),
+		ARpgCharacter::ResolveRotationMode(false, true, ERpgCharacterRotationMode::Aim) ==
+			ERpgCharacterRotationMode::Aim);
+
+	const FRpgCharacterRotationPolicy FreePolicy =
+		ARpgCharacter::GetRotationPolicy(ERpgCharacterRotationMode::Free);
+	TestFalse(TEXT("Free mode does not consume controller yaw"), FreePolicy.bUseControllerRotationYaw);
+	TestTrue(TEXT("Free mode orients to movement"), FreePolicy.bOrientRotationToMovement);
+	TestFalse(TEXT("Free mode does not use controller-desired movement rotation"), FreePolicy.bUseControllerDesiredRotation);
+	TestTrue(TEXT("Free mode uses immediate movement-facing yaw"), FMath::IsNearlyEqual(FreePolicy.RotationRateYaw, -1.0f));
+
+	for (const ERpgCharacterRotationMode ControllerFacingMode : {
+		ERpgCharacterRotationMode::CombatStrafe,
+		ERpgCharacterRotationMode::Aim })
+	{
+		const FRpgCharacterRotationPolicy Policy =
+			ARpgCharacter::GetRotationPolicy(ControllerFacingMode);
+		TestTrue(TEXT("Controller-facing mode consumes controller yaw"), Policy.bUseControllerRotationYaw);
+		TestFalse(TEXT("Controller-facing mode does not orient to movement"), Policy.bOrientRotationToMovement);
+		TestFalse(TEXT("Controller-facing mode does not duplicate controller-desired rotation"), Policy.bUseControllerDesiredRotation);
+		TestTrue(TEXT("Controller-facing mode preserves the 720 degree yaw contract"), FMath::IsNearlyEqual(Policy.RotationRateYaw, 720.0f));
+	}
+
+	struct FExplicitStanceGateCase
+	{
+		const TCHAR* Label;
+		bool bEnable;
+		bool bHasWeapon;
+		bool bHasBlockingState;
+		bool bIsMovingOnGround;
+		bool bIsCrouched;
+		bool bWantsToCrouch;
+		bool bIsAnyMontagePlaying;
+		bool bExpected;
+	};
+	const FExplicitStanceGateCase GateCases[] = {
+		{ TEXT("Valid grounded weapon stance enables"), true, true, false, true, false, false, false, true },
+		{ TEXT("Weapon is required for enable"), true, false, false, true, false, false, false, false },
+		{ TEXT("Blocking gameplay state rejects enable"), true, true, true, true, false, false, false, false },
+		{ TEXT("Airborne character rejects enable"), true, true, false, false, false, false, false, false },
+		{ TEXT("Already crouched character rejects enable"), true, true, false, true, true, false, false, false },
+		{ TEXT("Pending crouch rejects enable"), true, true, false, true, false, true, false, false },
+		{ TEXT("Running montage rejects enable"), true, true, false, true, false, false, true, false },
+		{ TEXT("Disable remains allowed when every enable prerequisite fails"), false, false, true, false, true, true, true, true },
+	};
+	for (const FExplicitStanceGateCase& GateCase : GateCases)
+	{
+		TestEqual(
+			GateCase.Label,
+			ARpgCharacter::CanApplyExplicitCombatStanceRequest(
+				GateCase.bEnable,
+				GateCase.bHasWeapon,
+				GateCase.bHasBlockingState,
+				GateCase.bIsMovingOnGround,
+				GateCase.bIsCrouched,
+				GateCase.bWantsToCrouch,
+				GateCase.bIsAnyMontagePlaying),
+			GateCase.bExpected);
+	}
+
+	const URpgPawnData* PawnDataDefaults = GetDefault<URpgPawnData>();
+	TestNotNull(TEXT("PawnData CDO is available"), PawnDataDefaults);
+	if (PawnDataDefaults)
+	{
+		TestTrue(
+			TEXT("Legacy-compatible PawnData default is CombatStrafe"),
+			PawnDataDefaults->DefaultRotationMode == ERpgCharacterRotationMode::CombatStrafe);
+	}
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FRpgCharacterRotationModeReplicationContractTest,
+	"SurvivalRpg.Character.RotationMode.ReplicationContract",
+	EAutomationTestFlags::EditorContext |
+		EAutomationTestFlags::EngineFilter)
+
+bool FRpgCharacterRotationModeReplicationContractTest::RunTest(const FString& Parameters)
+{
+	const FProperty* RotationModeProperty =
+		ARpgCharacter::StaticClass()->FindPropertyByName(TEXT("RotationMode"));
+	TestNotNull(TEXT("Character exposes reflected rotation mode state"), RotationModeProperty);
+	if (RotationModeProperty)
+	{
+		TestTrue(TEXT("Rotation mode participates in actor replication"), RotationModeProperty->HasAnyPropertyFlags(CPF_Net));
+		TestEqual(TEXT("Rotation mode reconciles through OnRep_RotationMode"), RotationModeProperty->RepNotifyFunc, FName(TEXT("OnRep_RotationMode")));
+	}
+
+	TestTrue(TEXT("Combat-strafe request tag is registered"), RpgGameplayTags::State_Rotation_CombatStrafe.GetTag().IsValid());
+	TestTrue(TEXT("Aim request tag is registered"), RpgGameplayTags::State_Rotation_Aim.GetTag().IsValid());
+	TestTrue(TEXT("Combat stance input tag is registered"), RpgGameplayTags::InputTag_RotationMode_ToggleCombat.GetTag().IsValid());
+
+	const UGameplayAbilitiesDeveloperSettings* AbilitySettings =
+		GetDefault<UGameplayAbilitiesDeveloperSettings>();
+	TestNotNull(TEXT("GameplayAbilities developer settings CDO is available"), AbilitySettings);
+	if (AbilitySettings)
+	{
+		TestTrue(TEXT("Target gameplay effects remain predicted"), AbilitySettings->PredictTargetGameplayEffects);
+		TestTrue(TEXT("Activation-owned rotation tags replicate for server reconciliation"), AbilitySettings->ReplicateActivationOwnedTags);
+	}
+
+	return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS


### PR DESCRIPTION
Closes #63

## Ergebnis

- Replizierter, serverautoritativer `ERpgCharacterRotationMode`: `Free`, `CombatStrafe`, `Aim`.
- Der GASP-Pilot startet in `Free`: Kameraorbit im Stand, movement-facing beim Laufen, kein Idle-TIR.
- `CombatStrafe` und `Aim` behalten controller-facing 8-Wege-Locomotion und das TIR aus #54.
- Mittelmaus schaltet eine explizite, waffengegatete Kampfhaltung; Crouch, Airborne, Montage und blockierende States verhindern das Einschalten.
- Attack und Block setzen über vorhergesagte `ActivationOwnedTags` den Combat-facing-State vor richtungsabhängigen Ability-Prüfungen.
- Equipment-Replacements melden nur den finalen Zustand und löschen die Haltung nicht am Zwischen-Unequip.
- `URpgAnimInstance` konsumiert ausschließlich den Game-Thread-Proxy-Snapshot.
- Das Basis-PawnData bleibt `CombatStrafe`; der alte Experience-/Rollback-Pfad bleibt unverändert.

## Assets

- `DA_PawnData_GASP.DefaultRotationMode = Free`
- neue boolesche `IA_ToggleCombatStance`
- exklusive Mittelmaus-Zuordnung in `IMC_Combat`
- native Zuordnung zu `InputTag.RotationMode.ToggleCombat` in `DA_InputConfig_Combat`
- keine Map-, Experience-, AnimBP-, PoseSearch-DB- oder Locomotion-Content-Änderung

## Verifiziert

- [x] UE 5.8 `SurvivalRpgEditor Win64 Development -NoLiveCoding`
- [x] idempotenter Asset-Zweitlauf: `changed_assets=0`, 0 Errors
- [x] `SurvivalRpg.Character.RotationMode`: 2/2 erfolgreich
- [x] `SurvivalRpg.Animation`: 8/8 erfolgreich
- [x] vier erwartete LFS-Assets hochgeladen
- [x] finaler Runtime-/Scope-Review ohne P0/P1

## Manuelle visuelle Abnahme

- [x] Free: Maus bewegt im Stand nur die Kamera; Capsule und Beine bleiben ruhig.
- [x] Free: WASD dreht stabil in die camera-relative Bewegungsrichtung.
- [ ] Mit ausgerüsteter Waffe schaltet Mittelmaus CombatStrafe an/aus.
- [ ] CombatStrafe: Idle-TIR sowie F/B/L/R und Diagonalen funktionieren.
- [ ] Attack/Block aus Free richten Owner und Server vor dem Gameplaycheck gleich aus und kehren danach zu Free zurück, sofern die Haltung nicht explizit aktiv ist.
- [ ] Mittelmaus während Crouch, Jump/Fall oder Montage erzeugt keinen Moduswechsel/OffsetRoot-Snap.
- [ ] Listen Server + Client: Authority, Autonomous Proxy und Simulated Proxy stimmen überein; Late Join rekonstruiert den Modus.

`Aim` ist als autoritative GAS-/Runtime-Seam vorhanden, erhält in diesem Slice bewusst keinen physischen Key. Target-Lock, bewaffnete Spezialposen und Aim-Offsets bleiben Folgeslices.