### PR TITLE
GASP CMC: thread-sicheres Foot Placement und Leg IK

### DIFF
--- a/Content/SurvivalRpg/Characters/Mannequins/Anims/GASP/ABP_RpgCharacter_GASP.uasset
+++ b/Content/SurvivalRpg/Characters/Mannequins/Anims/GASP/ABP_RpgCharacter_GASP.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4ff784b01c54ea3c65adcd2615562fb85c7ff10ab11dfcc524188ab87889a7d9
-size 282928
+oid sha256:c4c7536679fbcc4d068159024a12b6651e70872e7c64c35f481b80415db74513
+size 337617

--- a/Content/SurvivalRpg/Characters/Mannequins/Anims/GASP/ABP_RpgCharacter_GASP.uasset
+++ b/Content/SurvivalRpg/Characters/Mannequins/Anims/GASP/ABP_RpgCharacter_GASP.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c4c7536679fbcc4d068159024a12b6651e70872e7c64c35f481b80415db74513
-size 337617
+oid sha256:3685a3246ddac5e8c9e15cc38bbf144f4bd67a57d67ad604c4eb5f49b2c75877
+size 340075

--- a/Source/SurvivalRpg/Animation/AnimNode_RpgFootPlacement.cpp
+++ b/Source/SurvivalRpg/Animation/AnimNode_RpgFootPlacement.cpp
@@ -1,0 +1,155 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+#include "AnimNode_RpgFootPlacement.h"
+
+#include "Animation/AnimInstanceProxy.h"
+
+#include UE_INLINE_GENERATED_CPP_BY_NAME(AnimNode_RpgFootPlacement)
+
+FAnimNode_RpgFootPlacement::FAnimNode_RpgFootPlacement()
+{
+	AlphaInputType = EAnimAlphaInputType::Float;
+}
+
+void FAnimNode_RpgFootPlacement::GatherDebugData(FNodeDebugData& DebugData)
+{
+	FString DebugLine = DebugData.GetNodeName(this);
+	DebugLine += FString::Printf(
+		TEXT("(Valid=%s, Left=%.2f, Right=%.2f)"),
+		Snapshot.bValid ? TEXT("true") : TEXT("false"),
+		Snapshot.LeftFoot.Weight,
+		Snapshot.RightFoot.Weight);
+	DebugData.AddDebugItem(DebugLine);
+	ComponentPose.GatherDebugData(DebugData);
+}
+
+void FAnimNode_RpgFootPlacement::EvaluateSkeletalControl_AnyThread(
+	FComponentSpacePoseContext& Output,
+	TArray<FBoneTransform>& OutBoneTransforms)
+{
+	DECLARE_SCOPE_HIERARCHICAL_COUNTER_ANIMNODE(EvaluateSkeletalControl_AnyThread)
+	ANIM_MT_SCOPE_CYCLE_COUNTER_VERBOSE(RpgFootPlacement, !IsInGameThread());
+	check(OutBoneTransforms.IsEmpty());
+
+	if (!Snapshot.bValid || !Snapshot.bGrounded || Snapshot.bReset || LegsDefinition.Num() != 2)
+	{
+		return;
+	}
+
+	const FBoneContainer& BoneContainer = Output.Pose.GetPose().GetBoneContainer();
+	const FVector ComponentUpWorld = Snapshot.ComponentToWorld.GetUnitAxis(EAxis::Z);
+	float FootOffsets[2] = {0.0f, 0.0f};
+	const FRpgFootPlacementLegSnapshot* LegSnapshots[2] = {
+		&Snapshot.LeftFoot,
+		&Snapshot.RightFoot,
+	};
+
+	for (int32 LegIndex = 0; LegIndex < 2; ++LegIndex)
+	{
+		const FRpgFootPlacementNodeLegDefinition& LegDefinition = LegsDefinition[LegIndex];
+		const FRpgFootPlacementLegSnapshot& LegSnapshot = *LegSnapshots[LegIndex];
+		const float LegWeight = FMath::Clamp(LegSnapshot.Weight, 0.0f, 1.0f);
+		if (!LegSnapshot.bHasWalkableGround || LegWeight <= UE_KINDA_SMALL_NUMBER)
+		{
+			continue;
+		}
+
+		const FCompactPoseBoneIndex IKFootIndex = LegDefinition.IKFootBone.GetCompactPoseIndex(BoneContainer);
+		const FCompactPoseBoneIndex BallIndex = LegDefinition.BallBone.GetCompactPoseIndex(BoneContainer);
+		if (!IKFootIndex.IsValid() || !BallIndex.IsValid())
+		{
+			continue;
+		}
+
+		const FTransform CurrentIKTransformCS = Output.Pose.GetComponentSpaceTransform(IKFootIndex);
+		const FTransform BallTransformCS = Output.Pose.GetComponentSpaceTransform(BallIndex);
+		const FTransform CurrentIKTransformWorld = CurrentIKTransformCS * Snapshot.ComponentToWorld;
+		const FTransform BallTransformWorld = BallTransformCS * Snapshot.ComponentToWorld;
+		FTransform TargetTransformWorld = LegSnapshot.bLocked
+			? LegSnapshot.LockedFootTransformWorld
+			: RpgFootPlacement::AlignFootToGroundPlane(
+				CurrentIKTransformWorld,
+				BallTransformWorld,
+				LegSnapshot.GroundPointWorld,
+				LegSnapshot.GroundNormalWorld,
+				ComponentUpWorld,
+				MaxFootTranslation,
+				MaxFootRotation);
+		const FVector ClampedTargetOffset = (
+			TargetTransformWorld.GetLocation() - CurrentIKTransformWorld.GetLocation())
+			.GetClampedToMaxSize(FMath::Max(MaxFootTranslation, 0.0f));
+		TargetTransformWorld.SetLocation(CurrentIKTransformWorld.GetLocation() + ClampedTargetOffset);
+		const float TargetRotationDegrees = FMath::RadiansToDegrees(
+			CurrentIKTransformWorld.GetRotation().AngularDistance(TargetTransformWorld.GetRotation()));
+		if (TargetRotationDegrees > MaxFootRotation && TargetRotationDegrees > UE_SMALL_NUMBER)
+		{
+			TargetTransformWorld.SetRotation(FQuat::Slerp(
+				CurrentIKTransformWorld.GetRotation(),
+				TargetTransformWorld.GetRotation(),
+				MaxFootRotation / TargetRotationDegrees).GetNormalized());
+		}
+
+		const FTransform TargetTransformCS = TargetTransformWorld.GetRelativeTransform(Snapshot.ComponentToWorld);
+		FTransform BlendedTransformCS = CurrentIKTransformCS;
+		BlendedTransformCS.SetLocation(FMath::Lerp(
+			CurrentIKTransformCS.GetLocation(),
+			TargetTransformCS.GetLocation(),
+			LegWeight));
+		BlendedTransformCS.SetRotation(FQuat::Slerp(
+			CurrentIKTransformCS.GetRotation(),
+			TargetTransformCS.GetRotation(),
+			LegWeight).GetNormalized());
+
+		FootOffsets[LegIndex] = FVector::DotProduct(
+			TargetTransformWorld.GetLocation() - CurrentIKTransformWorld.GetLocation(),
+			ComponentUpWorld) * LegWeight;
+		OutBoneTransforms.Emplace(IKFootIndex, BlendedTransformCS);
+	}
+
+	const FCompactPoseBoneIndex PelvisIndex = PelvisBone.GetCompactPoseIndex(BoneContainer);
+	if (PelvisIndex.IsValid())
+	{
+		const float PelvisOffset = RpgFootPlacement::CalculatePelvisOffset(
+			FootOffsets[0],
+			FootOffsets[1],
+			MaxPelvisOffset);
+		if (!FMath::IsNearlyZero(PelvisOffset))
+		{
+			FTransform PelvisTransformCS = Output.Pose.GetComponentSpaceTransform(PelvisIndex);
+			const FVector ComponentUpCS = Snapshot.ComponentToWorld.InverseTransformVectorNoScale(ComponentUpWorld);
+			PelvisTransformCS.AddToTranslation(ComponentUpCS * PelvisOffset);
+			OutBoneTransforms.Emplace(PelvisIndex, PelvisTransformCS);
+		}
+	}
+
+	OutBoneTransforms.Sort(FCompareBoneTransformIndex());
+}
+
+bool FAnimNode_RpgFootPlacement::IsValidToEvaluate(
+	const USkeleton* Skeleton,
+	const FBoneContainer& RequiredBones)
+{
+	if (!PelvisBone.IsValidToEvaluate(RequiredBones) || LegsDefinition.Num() != 2)
+	{
+		return false;
+	}
+	for (const FRpgFootPlacementNodeLegDefinition& LegDefinition : LegsDefinition)
+	{
+		if (!LegDefinition.IKFootBone.IsValidToEvaluate(RequiredBones) ||
+			!LegDefinition.BallBone.IsValidToEvaluate(RequiredBones))
+		{
+			return false;
+		}
+	}
+	return true;
+}
+
+void FAnimNode_RpgFootPlacement::InitializeBoneReferences(const FBoneContainer& RequiredBones)
+{
+	PelvisBone.Initialize(RequiredBones);
+	for (FRpgFootPlacementNodeLegDefinition& LegDefinition : LegsDefinition)
+	{
+		LegDefinition.IKFootBone.Initialize(RequiredBones);
+		LegDefinition.BallBone.Initialize(RequiredBones);
+	}
+}

--- a/Source/SurvivalRpg/Animation/AnimNode_RpgFootPlacement.cpp
+++ b/Source/SurvivalRpg/Animation/AnimNode_RpgFootPlacement.cpp
@@ -15,12 +15,32 @@ void FAnimNode_RpgFootPlacement::GatherDebugData(FNodeDebugData& DebugData)
 {
 	FString DebugLine = DebugData.GetNodeName(this);
 	DebugLine += FString::Printf(
-		TEXT("(Valid=%s, Left=%.2f, Right=%.2f)"),
+		TEXT("(Valid=%s, Left=%.2f, Right=%.2f, Pelvis=%.2f)"),
 		Snapshot.bValid ? TEXT("true") : TEXT("false"),
 		Snapshot.LeftFoot.Weight,
-		Snapshot.RightFoot.Weight);
+		Snapshot.RightFoot.Weight,
+		SmoothedPelvisOffset);
 	DebugData.AddDebugItem(DebugLine);
 	ComponentPose.GatherDebugData(DebugData);
+}
+
+void FAnimNode_RpgFootPlacement::UpdateInternal(const FAnimationUpdateContext& Context)
+{
+	FAnimNode_SkeletalControlBase::UpdateInternal(Context);
+	const FGraphTraversalCounter& ProxyUpdateCounter = Context.AnimInstanceProxy->GetUpdateCounter();
+	const bool bSkippedRelevantUpdate =
+		UpdateCounter.HasEverBeenUpdated() &&
+		!UpdateCounter.WasSynchronizedCounter(ProxyUpdateCounter);
+	UpdateCounter.SynchronizeWith(ProxyUpdateCounter);
+
+	if (bSkippedRelevantUpdate || !Snapshot.bValid || !Snapshot.bGrounded || Snapshot.bReset)
+	{
+		CachedDeltaTime = 0.0f;
+		SmoothedPelvisOffset = 0.0f;
+		return;
+	}
+
+	CachedDeltaTime += FMath::Max(Context.GetDeltaTime(), 0.0f);
 }
 
 void FAnimNode_RpgFootPlacement::EvaluateSkeletalControl_AnyThread(
@@ -33,6 +53,8 @@ void FAnimNode_RpgFootPlacement::EvaluateSkeletalControl_AnyThread(
 
 	if (!Snapshot.bValid || !Snapshot.bGrounded || Snapshot.bReset || LegsDefinition.Num() != 2)
 	{
+		CachedDeltaTime = 0.0f;
+		SmoothedPelvisOffset = 0.0f;
 		return;
 	}
 
@@ -48,79 +70,130 @@ void FAnimNode_RpgFootPlacement::EvaluateSkeletalControl_AnyThread(
 	{
 		const FRpgFootPlacementNodeLegDefinition& LegDefinition = LegsDefinition[LegIndex];
 		const FRpgFootPlacementLegSnapshot& LegSnapshot = *LegSnapshots[LegIndex];
-		const float LegWeight = FMath::Clamp(LegSnapshot.Weight, 0.0f, 1.0f);
-		if (!LegSnapshot.bHasWalkableGround || LegWeight <= UE_KINDA_SMALL_NUMBER)
-		{
-			continue;
-		}
-
 		const FCompactPoseBoneIndex IKFootIndex = LegDefinition.IKFootBone.GetCompactPoseIndex(BoneContainer);
+		const FCompactPoseBoneIndex FKFootIndex = LegDefinition.FKFootBone.GetCompactPoseIndex(BoneContainer);
 		const FCompactPoseBoneIndex BallIndex = LegDefinition.BallBone.GetCompactPoseIndex(BoneContainer);
-		if (!IKFootIndex.IsValid() || !BallIndex.IsValid())
+		if (!IKFootIndex.IsValid() || !FKFootIndex.IsValid() || !BallIndex.IsValid())
 		{
 			continue;
 		}
 
-		const FTransform CurrentIKTransformCS = Output.Pose.GetComponentSpaceTransform(IKFootIndex);
-		const FTransform BallTransformCS = Output.Pose.GetComponentSpaceTransform(BallIndex);
-		const FTransform CurrentIKTransformWorld = CurrentIKTransformCS * Snapshot.ComponentToWorld;
-		const FTransform BallTransformWorld = BallTransformCS * Snapshot.ComponentToWorld;
-		FTransform TargetTransformWorld = LegSnapshot.bLocked
-			? LegSnapshot.LockedFootTransformWorld
-			: RpgFootPlacement::AlignFootToGroundPlane(
-				CurrentIKTransformWorld,
-				BallTransformWorld,
+		const FTransform FKFootTransformCS = Output.Pose.GetComponentSpaceTransform(FKFootIndex);
+		const FTransform AuthoredBallTransformCS = Output.Pose.GetComponentSpaceTransform(BallIndex);
+		const FTransform FKFootTransformWorld = FKFootTransformCS * Snapshot.ComponentToWorld;
+		const FTransform AuthoredBallTransformWorld =
+			AuthoredBallTransformCS * Snapshot.ComponentToWorld;
+		FTransform ProceduralTargetWorld = FKFootTransformWorld;
+		float GeometryWeight = 0.0f;
+
+		const float LegWeight = FMath::Clamp(LegSnapshot.Weight, 0.0f, 1.0f);
+		if (LegSnapshot.bHasWalkableGround && LegWeight > UE_KINDA_SMALL_NUMBER)
+		{
+			const FTransform LiveAlignedTargetWorld = RpgFootPlacement::AlignFootToGroundPlane(
+				FKFootTransformWorld,
+				AuthoredBallTransformWorld,
 				LegSnapshot.GroundPointWorld,
 				LegSnapshot.GroundNormalWorld,
 				ComponentUpWorld,
 				MaxFootTranslation,
 				MaxFootRotation);
-		const FVector ClampedTargetOffset = (
-			TargetTransformWorld.GetLocation() - CurrentIKTransformWorld.GetLocation())
-			.GetClampedToMaxSize(FMath::Max(MaxFootTranslation, 0.0f));
-		TargetTransformWorld.SetLocation(CurrentIKTransformWorld.GetLocation() + ClampedTargetOffset);
-		const float TargetRotationDegrees = FMath::RadiansToDegrees(
-			CurrentIKTransformWorld.GetRotation().AngularDistance(TargetTransformWorld.GetRotation()));
-		if (TargetRotationDegrees > MaxFootRotation && TargetRotationDegrees > UE_SMALL_NUMBER)
-		{
-			TargetTransformWorld.SetRotation(FQuat::Slerp(
-				CurrentIKTransformWorld.GetRotation(),
-				TargetTransformWorld.GetRotation(),
-				MaxFootRotation / TargetRotationDegrees).GetNormalized());
+			const FTransform UnalignedTargetWorld = LegSnapshot.bLocked
+				? RpgFootPlacement::PivotFootAroundBall(
+					FKFootTransformWorld,
+					AuthoredBallTransformWorld,
+					LegSnapshot.LockedFootTransformWorld)
+				: FKFootTransformWorld;
+			const FTransform TargetBallTransformWorld = RpgFootPlacement::DeriveIKBallTransform(
+				FKFootTransformWorld,
+				AuthoredBallTransformWorld,
+				UnalignedTargetWorld);
+			ProceduralTargetWorld = RpgFootPlacement::AlignFootToGroundPlane(
+				UnalignedTargetWorld,
+				TargetBallTransformWorld,
+				LegSnapshot.GroundPointWorld,
+				LegSnapshot.GroundNormalWorld,
+				ComponentUpWorld,
+				MaxFootTranslation,
+				MaxFootRotation);
+			const FVector SafeGroundNormal = LegSnapshot.GroundNormalWorld.GetSafeNormal(
+				UE_SMALL_NUMBER,
+				FVector::UpVector);
+			const float BallDistanceToPlane = FVector::DotProduct(
+				AuthoredBallTransformWorld.GetLocation() - LegSnapshot.GroundPointWorld,
+				SafeGroundNormal);
+			const float PlanarLockDrift = (
+				LiveAlignedTargetWorld.GetLocation() - ProceduralTargetWorld.GetLocation()).Size2D();
+			GeometryWeight = RpgFootPlacement::CalculateGeometryWeight(
+				BallDistanceToPlane,
+				PlanarLockDrift,
+				LegSnapshot.bLocked,
+				PlantDistanceThreshold,
+				UnplantRadius);
 		}
 
-		const FTransform TargetTransformCS = TargetTransformWorld.GetRelativeTransform(Snapshot.ComponentToWorld);
-		FTransform BlendedTransformCS = CurrentIKTransformCS;
-		BlendedTransformCS.SetLocation(FMath::Lerp(
-			CurrentIKTransformCS.GetLocation(),
-			TargetTransformCS.GetLocation(),
-			LegWeight));
-		BlendedTransformCS.SetRotation(FQuat::Slerp(
-			CurrentIKTransformCS.GetRotation(),
-			TargetTransformCS.GetRotation(),
-			LegWeight).GetNormalized());
+		const float EffectiveLegWeight = RpgFootPlacement::CalculateEffectivePlacementWeight(
+			LegSnapshot.bHasWalkableGround,
+			LegWeight,
+			GeometryWeight);
+		if (EffectiveLegWeight > UE_KINDA_SMALL_NUMBER)
+		{
+			const FVector ClampedTargetOffset = (
+				ProceduralTargetWorld.GetLocation() - FKFootTransformWorld.GetLocation())
+				.GetClampedToMaxSize(FMath::Max(MaxFootTranslation, 0.0f));
+			ProceduralTargetWorld.SetLocation(FKFootTransformWorld.GetLocation() + ClampedTargetOffset);
+			const float TargetRotationDegrees = FMath::RadiansToDegrees(
+				FKFootTransformWorld.GetRotation().AngularDistance(ProceduralTargetWorld.GetRotation()));
+			if (TargetRotationDegrees > MaxFootRotation && TargetRotationDegrees > UE_SMALL_NUMBER)
+			{
+				ProceduralTargetWorld.SetRotation(FQuat::Slerp(
+					FKFootTransformWorld.GetRotation(),
+					ProceduralTargetWorld.GetRotation(),
+					MaxFootRotation / TargetRotationDegrees).GetNormalized());
+			}
 
-		FootOffsets[LegIndex] = FVector::DotProduct(
-			TargetTransformWorld.GetLocation() - CurrentIKTransformWorld.GetLocation(),
-			ComponentUpWorld) * LegWeight;
-		OutBoneTransforms.Emplace(IKFootIndex, BlendedTransformCS);
+			FootOffsets[LegIndex] = FVector::DotProduct(
+				ProceduralTargetWorld.GetLocation() - FKFootTransformWorld.GetLocation(),
+				ComponentUpWorld) * EffectiveLegWeight;
+		}
+
+		const FTransform ProceduralTargetCS =
+			ProceduralTargetWorld.GetRelativeTransform(Snapshot.ComponentToWorld);
+		// Stock Leg IK has one global alpha and always solves both legs. Writing the current
+		// FK ankle here prevents a static or unsuitable authored IK track from pinning a swing leg.
+		OutBoneTransforms.Emplace(
+			IKFootIndex,
+			RpgFootPlacement::ResolveIKFootTarget(
+				FKFootTransformCS,
+				ProceduralTargetCS,
+				EffectiveLegWeight));
 	}
 
 	const FCompactPoseBoneIndex PelvisIndex = PelvisBone.GetCompactPoseIndex(BoneContainer);
 	if (PelvisIndex.IsValid())
 	{
-		const float PelvisOffset = RpgFootPlacement::CalculatePelvisOffset(
+		const float TargetPelvisOffset = RpgFootPlacement::CalculatePelvisOffset(
 			FootOffsets[0],
 			FootOffsets[1],
 			MaxPelvisOffset);
-		if (!FMath::IsNearlyZero(PelvisOffset))
+		SmoothedPelvisOffset = RpgFootPlacement::SmoothPelvisOffset(
+			SmoothedPelvisOffset,
+			TargetPelvisOffset,
+			CachedDeltaTime,
+			PelvisBlendHalfLife,
+			MaxPelvisSpeed);
+		if (!FMath::IsNearlyZero(SmoothedPelvisOffset))
 		{
 			FTransform PelvisTransformCS = Output.Pose.GetComponentSpaceTransform(PelvisIndex);
 			const FVector ComponentUpCS = Snapshot.ComponentToWorld.InverseTransformVectorNoScale(ComponentUpWorld);
-			PelvisTransformCS.AddToTranslation(ComponentUpCS * PelvisOffset);
+			PelvisTransformCS.AddToTranslation(ComponentUpCS * SmoothedPelvisOffset);
 			OutBoneTransforms.Emplace(PelvisIndex, PelvisTransformCS);
 		}
 	}
+	else
+	{
+		SmoothedPelvisOffset = 0.0f;
+	}
+	CachedDeltaTime = 0.0f;
 
 	OutBoneTransforms.Sort(FCompareBoneTransformIndex());
 }
@@ -135,7 +208,8 @@ bool FAnimNode_RpgFootPlacement::IsValidToEvaluate(
 	}
 	for (const FRpgFootPlacementNodeLegDefinition& LegDefinition : LegsDefinition)
 	{
-		if (!LegDefinition.IKFootBone.IsValidToEvaluate(RequiredBones) ||
+		if (!LegDefinition.FKFootBone.IsValidToEvaluate(RequiredBones) ||
+			!LegDefinition.IKFootBone.IsValidToEvaluate(RequiredBones) ||
 			!LegDefinition.BallBone.IsValidToEvaluate(RequiredBones))
 		{
 			return false;
@@ -149,6 +223,7 @@ void FAnimNode_RpgFootPlacement::InitializeBoneReferences(const FBoneContainer& 
 	PelvisBone.Initialize(RequiredBones);
 	for (FRpgFootPlacementNodeLegDefinition& LegDefinition : LegsDefinition)
 	{
+		LegDefinition.FKFootBone.Initialize(RequiredBones);
 		LegDefinition.IKFootBone.Initialize(RequiredBones);
 		LegDefinition.BallBone.Initialize(RequiredBones);
 	}

--- a/Source/SurvivalRpg/Animation/AnimNode_RpgFootPlacement.h
+++ b/Source/SurvivalRpg/Animation/AnimNode_RpgFootPlacement.h
@@ -13,6 +13,10 @@ struct SURVIVALRPG_API FRpgFootPlacementNodeLegDefinition
 {
 	GENERATED_BODY()
 
+	/** Same-frame FK ankle used as the neutral Leg IK target and with BallBone for foot geometry. */
+	UPROPERTY(EditAnywhere, Category = "Settings")
+	FBoneReference FKFootBone;
+
 	/** IK target bone adjusted before the downstream Leg IK solve. */
 	UPROPERTY(EditAnywhere, Category = "Settings")
 	FBoneReference IKFootBone;
@@ -56,11 +60,28 @@ struct SURVIVALRPG_API FAnimNode_RpgFootPlacement : public FAnimNode_SkeletalCon
 	UPROPERTY(EditAnywhere, Category = "Settings", meta = (ClampMin = "0.0", ClampMax = "90.0", Units = "deg"))
 	float MaxFootRotation = 60.0f;
 
+	/** Same-frame authored FK-ball distance at which raw-pose placement reaches zero weight, in centimeters. */
+	UPROPERTY(EditAnywhere, Category = "Settings", meta = (ClampMin = "0.0", Units = "cm"))
+	float PlantDistanceThreshold = 10.0f;
+
+	/** Same-frame planar live-to-locked target drift at which a plant reaches zero weight, in centimeters. */
+	UPROPERTY(EditAnywhere, Category = "Settings", meta = (ClampMin = "0.0", Units = "cm"))
+	float UnplantRadius = 20.0f;
+
 	/** Maximum downward pelvis correction, in centimeters. */
 	UPROPERTY(EditAnywhere, Category = "Settings", meta = (ClampMin = "0.0", Units = "cm"))
 	float MaxPelvisOffset = 50.0f;
 
+	/** Frame-rate-independent half-life used to smooth cosmetic pelvis correction, in seconds. */
+	UPROPERTY(EditAnywhere, Category = "Settings", meta = (ClampMin = "0.001", Units = "s"))
+	float PelvisBlendHalfLife = 0.08f;
+
+	/** Hard speed limit for cosmetic pelvis correction, in centimeters per second. */
+	UPROPERTY(EditAnywhere, Category = "Settings", meta = (ClampMin = "0.0", Units = "cm/s"))
+	float MaxPelvisSpeed = 120.0f;
+
 	virtual void GatherDebugData(FNodeDebugData& DebugData) override;
+	virtual void UpdateInternal(const FAnimationUpdateContext& Context) override;
 	virtual void EvaluateSkeletalControl_AnyThread(
 		FComponentSpacePoseContext& Output,
 		TArray<FBoneTransform>& OutBoneTransforms) override;
@@ -68,4 +89,13 @@ struct SURVIVALRPG_API FAnimNode_RpgFootPlacement : public FAnimNode_SkeletalCon
 
 private:
 	virtual void InitializeBoneReferences(const FBoneContainer& RequiredBones) override;
+
+	/** Update time accumulated until the next evaluation, matching stateful skeletal-control semantics. */
+	float CachedDeltaTime = 0.0f;
+
+	/** Persistent value-only pelvis state owned by this proxy's worker-thread node instance. */
+	float SmoothedPelvisOffset = 0.0f;
+
+	/** Detects updates skipped while the graph alpha is zero so persistent state can reset safely. */
+	FGraphTraversalCounter UpdateCounter;
 };

--- a/Source/SurvivalRpg/Animation/AnimNode_RpgFootPlacement.h
+++ b/Source/SurvivalRpg/Animation/AnimNode_RpgFootPlacement.h
@@ -1,0 +1,71 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "BoneControllers/AnimNode_SkeletalControlBase.h"
+#include "BoneControllers/BoneControllerTypes.h"
+#include "RpgFootPlacementTypes.h"
+#include "AnimNode_RpgFootPlacement.generated.h"
+
+/** Bone configuration consumed only by the pointer-free RPG foot-placement skeletal control. */
+USTRUCT(BlueprintType)
+struct SURVIVALRPG_API FRpgFootPlacementNodeLegDefinition
+{
+	GENERATED_BODY()
+
+	/** IK target bone adjusted before the downstream Leg IK solve. */
+	UPROPERTY(EditAnywhere, Category = "Settings")
+	FBoneReference IKFootBone;
+
+	/** Ball bone used as the pivot for ground-alignment rotation. */
+	UPROPERTY(EditAnywhere, Category = "Settings")
+	FBoneReference BallBone;
+};
+
+/**
+ * Worker-thread-safe foot-placement node backed exclusively by a game-thread POD snapshot.
+ *
+ * The node performs no traces and never reads an actor, world, movement component, skeletal
+ * mesh component, or UObject during AnyThread evaluation. A downstream Leg IK node resolves
+ * the FK leg chains toward the IK targets authored here.
+ */
+USTRUCT(BlueprintInternalUseOnly)
+struct SURVIVALRPG_API FAnimNode_RpgFootPlacement : public FAnimNode_SkeletalControlBase
+{
+	GENERATED_BODY()
+
+	FAnimNode_RpgFootPlacement();
+
+	/** Pelvis bone lowered when one planted target lies below the current animation. */
+	UPROPERTY(EditAnywhere, Category = "Settings")
+	FBoneReference PelvisBone;
+
+	/** Left and right IK/ball definitions; the pilot graph requires exactly two entries. */
+	UPROPERTY(EditAnywhere, Category = "Settings")
+	TArray<FRpgFootPlacementNodeLegDefinition> LegsDefinition;
+
+	/** Immutable snapshot copied from FRpgAnimInstanceProxy::PreUpdate. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Snapshot", meta = (PinShownByDefault))
+	FRpgFootPlacementSnapshot Snapshot;
+
+	/** Maximum translation applied to one IK target, in centimeters. */
+	UPROPERTY(EditAnywhere, Category = "Settings", meta = (ClampMin = "0.0", Units = "cm"))
+	float MaxFootTranslation = 50.0f;
+
+	/** Maximum ground-alignment rotation applied to one IK target, in degrees. */
+	UPROPERTY(EditAnywhere, Category = "Settings", meta = (ClampMin = "0.0", ClampMax = "90.0", Units = "deg"))
+	float MaxFootRotation = 60.0f;
+
+	/** Maximum downward pelvis correction, in centimeters. */
+	UPROPERTY(EditAnywhere, Category = "Settings", meta = (ClampMin = "0.0", Units = "cm"))
+	float MaxPelvisOffset = 50.0f;
+
+	virtual void GatherDebugData(FNodeDebugData& DebugData) override;
+	virtual void EvaluateSkeletalControl_AnyThread(
+		FComponentSpacePoseContext& Output,
+		TArray<FBoneTransform>& OutBoneTransforms) override;
+	virtual bool IsValidToEvaluate(const USkeleton* Skeleton, const FBoneContainer& RequiredBones) override;
+
+private:
+	virtual void InitializeBoneReferences(const FBoneContainer& RequiredBones) override;
+};

--- a/Source/SurvivalRpg/Animation/RpgAnimInstance.cpp
+++ b/Source/SurvivalRpg/Animation/RpgAnimInstance.cpp
@@ -5,9 +5,12 @@
 #include "Animation/AnimSequenceBase.h"
 #include "AnimationWarpingLibrary.h"
 #include "BlendStack/BlendStackAnimNodeLibrary.h"
+#include "Components/PrimitiveComponent.h"
 #include "Components/SkeletalMeshComponent.h"
 #include "Engine/World.h"
+#include "GameFramework/Character.h"
 #include "GameFramework/CharacterMovementComponent.h"
+#include "Interfaces/MovementBaseInterface.h"
 #include "PoseSearch/AnimNode_MotionMatching.h"
 #include "PoseSearch/PoseSearchTrajectoryLibrary.h"
 
@@ -58,6 +61,457 @@ float CalculateTurnInPlacePlaybackWatchdogDuration(
 		TurnInPlaceActiveTimeout,
 		FMath::Max(RemainingAnimationTime, 0.0f) / FMath::Abs(PlayRate) +
 			TurnInPlacePlaybackWatchdogSafetyMargin);
+}
+
+struct FRpgFootPlacementTraceResult
+{
+	FVector GroundPointWorld = FVector::ZeroVector;
+	FVector GroundNormalWorld = FVector::UpVector;
+	FTransform HitComponentTransform = FTransform::Identity;
+	uint32 HitComponentId = 0;
+	float DistanceToGround = 0.0f;
+	bool bWalkable = false;
+};
+
+void ResetFootPlacementLegState(FRpgAnimInstanceProxy::FFootPlacementLegState& State)
+{
+	State = FRpgAnimInstanceProxy::FFootPlacementLegState();
+}
+
+void ResetFootPlacementState(FRpgAnimInstanceProxy& Proxy)
+{
+	ResetFootPlacementLegState(Proxy.FootPlacementLegStates[0]);
+	ResetFootPlacementLegState(Proxy.FootPlacementLegStates[1]);
+	Proxy.FootPlacementAlpha = 0.0f;
+}
+
+void ResetFootPlacementInitializationState(FRpgAnimInstanceProxy& Proxy)
+{
+	ResetFootPlacementState(Proxy);
+	Proxy.FootPlacementSnapshot = FRpgFootPlacementSnapshot();
+	Proxy.PreviousFootPlacementComponentTransform = FTransform::Identity;
+	Proxy.PreviousMovementBaseTransform = FTransform::Identity;
+	Proxy.PreviousMovementBaseId = 0;
+	Proxy.bHasPreviousFootPlacementComponentTransform = false;
+	Proxy.bHasPreviousMovementBaseTransform = false;
+	Proxy.bPreviousFootPlacementSourceEligible = false;
+}
+
+FRpgFootPlacementTraceResult TraceFootGround(
+	const ARpgCharacter& Character,
+	const URpgCharacterMovementComponent& MovementComponent,
+	const FRpgFootPlacementSettings& Settings,
+	const FVector& BallLocationWorld)
+{
+	check(IsInGameThread());
+	FRpgFootPlacementTraceResult Result;
+	UWorld* World = Character.GetWorld();
+	if (!World)
+	{
+		return Result;
+	}
+
+	const FVector TraceStart = BallLocationWorld + FVector::UpVector * Settings.TraceStartHeight;
+	const FVector TraceEnd = BallLocationWorld - FVector::UpVector * Settings.TraceEndDepth;
+	FCollisionQueryParams QueryParams(SCENE_QUERY_STAT(RpgFootPlacement), true, &Character);
+	QueryParams.AddIgnoredActor(&Character);
+	FHitResult HitResult;
+	const bool bHit = World->SweepSingleByChannel(
+		HitResult,
+		TraceStart,
+		TraceEnd,
+		FQuat::Identity,
+		ECC_Visibility,
+		FCollisionShape::MakeSphere(FMath::Max(Settings.SweepRadius, 0.0f)),
+		QueryParams);
+	if (!bHit || !HitResult.bBlockingHit || !MovementComponent.IsWalkable(HitResult))
+	{
+		return Result;
+	}
+
+	Result.GroundPointWorld = HitResult.ImpactPoint;
+	Result.GroundNormalWorld = HitResult.ImpactNormal.GetSafeNormal(UE_SMALL_NUMBER, FVector::UpVector);
+	Result.DistanceToGround = FVector::DotProduct(
+		BallLocationWorld - Result.GroundPointWorld,
+		Result.GroundNormalWorld);
+	if (const UPrimitiveComponent* HitComponent = HitResult.GetComponent())
+	{
+		Result.HitComponentId = HitComponent->GetUniqueID();
+		Result.HitComponentTransform = HitComponent->GetComponentTransform();
+	}
+	Result.bWalkable = true;
+	return Result;
+}
+
+bool TryGetMovementBaseSnapshot(
+	const ARpgCharacter& Character,
+	uint32& OutBaseId,
+	FTransform& OutBaseTransform)
+{
+	check(IsInGameThread());
+	OutBaseId = 0;
+	OutBaseTransform = FTransform::Identity;
+	const FMovementBaseInterfaceData* BaseData = Character.GetMovementBaseInterfaceData();
+	if (!BaseData || !BaseData->IsValid())
+	{
+		return false;
+	}
+
+	UObject* BaseObject = BaseData->GetMovementBaseObject();
+	FVector BaseLocation = FVector::ZeroVector;
+	FQuat BaseRotation = FQuat::Identity;
+	if (!BaseObject || !MovementBaseUtility::GetMovementBaseTransform(
+		BaseData,
+		Character.GetBasedMovement().BoneName,
+		BaseLocation,
+		BaseRotation))
+	{
+		return false;
+	}
+
+	OutBaseId = BaseObject->GetUniqueID();
+	OutBaseTransform = FTransform(BaseRotation, BaseLocation);
+	return true;
+}
+
+void UpdateFootPlacementLeg(
+	FRpgAnimInstanceProxy::FFootPlacementLegState& State,
+	FRpgFootPlacementLegSnapshot& Snapshot,
+	const FRpgFootPlacementLegDefinition& Definition,
+	const FRpgFootPlacementSettings& Settings,
+	const URpgAnimInstance& AnimInstance,
+	const ARpgCharacter& Character,
+	const URpgCharacterMovementComponent& MovementComponent,
+	const USkeletalMeshComponent& MeshComponent,
+	const FTransform& ComponentToWorld,
+	uint32 MovementBaseId,
+	const FTransform& PreviousBaseTransform,
+	const FTransform& CurrentBaseTransform,
+	bool bHasBaseDelta,
+	float DeltaSeconds)
+{
+	check(IsInGameThread());
+	if (Definition.IKFootBone.IsNone() || Definition.BallBone.IsNone() ||
+		!MeshComponent.DoesSocketExist(Definition.IKFootBone) ||
+		!MeshComponent.DoesSocketExist(Definition.BallBone))
+	{
+		ResetFootPlacementLegState(State);
+		return;
+	}
+
+	const FTransform IKFootTransformWorld = MeshComponent.GetSocketTransform(
+		Definition.IKFootBone,
+		RTS_World);
+	const FTransform BallTransformWorld = MeshComponent.GetSocketTransform(
+		Definition.BallBone,
+		RTS_World);
+	float ContactCurveValue = 0.0f;
+	const bool bHasSpeedCurve =
+		!Definition.SpeedCurveName.IsNone() &&
+		AnimInstance.GetCurveValue(Definition.SpeedCurveName, ContactCurveValue);
+	const float FootSpeed = bHasSpeedCurve
+		? RpgFootPlacement::ConvertContactCurveToSpeed(ContactCurveValue)
+		: MAX_flt;
+	// Contact is the primary authored plant/release signal. Socket transforms are the previous
+	// completed pose (including this cosmetic tail), so geometric bounds are defensive limits,
+	// not a replacement for the curated contact curves.
+	const FRpgFootPlacementTraceResult TraceResult = TraceFootGround(
+		Character,
+		MovementComponent,
+		Settings,
+		BallTransformWorld.GetLocation());
+	const bool bWantsToPlantNow = bHasSpeedCurve && RpgFootPlacement::ShouldPlantFoot(
+		TraceResult.bWalkable,
+		FootSpeed,
+		TraceResult.DistanceToGround,
+		Settings);
+	bool bReleasedThisFrame = false;
+	float AnchorDistance = MAX_flt;
+	float GroundNormalDelta = 180.0f;
+	FTransform CurrentAlignedFoot = IKFootTransformWorld;
+
+	if (TraceResult.bWalkable)
+	{
+		if (State.bLocked && State.HitComponentId != 0 &&
+			State.HitComponentId == TraceResult.HitComponentId &&
+			State.bHasPreviousHitComponentTransform)
+		{
+			State.LockedFootTransformWorld = RpgFootPlacement::RebaseTransformThroughSurface(
+				State.LockedFootTransformWorld,
+				State.PreviousHitComponentTransform,
+				TraceResult.HitComponentTransform);
+			State.LockedGroundPointWorld = RpgFootPlacement::RebasePointThroughSurface(
+				State.LockedGroundPointWorld,
+				State.PreviousHitComponentTransform,
+				TraceResult.HitComponentTransform);
+			State.LockedGroundNormalWorld = RpgFootPlacement::RebaseNormalThroughSurface(
+				State.LockedGroundNormalWorld,
+				State.PreviousHitComponentTransform,
+				TraceResult.HitComponentTransform);
+		}
+
+		CurrentAlignedFoot = RpgFootPlacement::AlignFootToGroundPlane(
+			IKFootTransformWorld,
+			BallTransformWorld,
+			TraceResult.GroundPointWorld,
+			TraceResult.GroundNormalWorld,
+			ComponentToWorld.GetUnitAxis(EAxis::Z),
+			Settings.MaxFootTranslation,
+			Settings.MaxFootAlignmentAngle);
+		AnchorDistance = (
+			CurrentAlignedFoot.GetLocation() - State.LockedFootTransformWorld.GetLocation()).Size2D();
+		GroundNormalDelta = FMath::RadiansToDegrees(FMath::Acos(FMath::Clamp(
+			FVector::DotProduct(
+				State.LockedGroundNormalWorld.GetSafeNormal(),
+				TraceResult.GroundNormalWorld.GetSafeNormal()),
+			-1.0f,
+			1.0f)));
+		if (State.bLocked && (State.HitComponentId != TraceResult.HitComponentId ||
+			RpgFootPlacement::ShouldUnplantFoot(
+				FootSpeed,
+				AnchorDistance,
+				GroundNormalDelta,
+				Settings)))
+		{
+			State.bLocked = false;
+			bReleasedThisFrame = true;
+		}
+		State.TraceMissElapsed = 0.0f;
+	}
+	else if (State.bLocked)
+	{
+		State.TraceMissElapsed += FMath::Max(DeltaSeconds, 0.0f);
+		if (bHasBaseDelta && State.HitComponentId == MovementBaseId)
+		{
+			State.LockedFootTransformWorld = RpgFootPlacement::RebaseTransformThroughSurface(
+				State.LockedFootTransformWorld,
+				PreviousBaseTransform,
+				CurrentBaseTransform);
+			State.LockedGroundPointWorld = RpgFootPlacement::RebasePointThroughSurface(
+				State.LockedGroundPointWorld,
+				PreviousBaseTransform,
+				CurrentBaseTransform);
+			State.LockedGroundNormalWorld = RpgFootPlacement::RebaseNormalThroughSurface(
+				State.LockedGroundNormalWorld,
+				PreviousBaseTransform,
+				CurrentBaseTransform);
+			if (State.bHasRetainedGroundTarget)
+			{
+				State.RetainedGroundPointWorld = RpgFootPlacement::RebasePointThroughSurface(
+					State.RetainedGroundPointWorld,
+					PreviousBaseTransform,
+					CurrentBaseTransform);
+				State.RetainedGroundNormalWorld = RpgFootPlacement::RebaseNormalThroughSurface(
+					State.RetainedGroundNormalWorld,
+					PreviousBaseTransform,
+					CurrentBaseTransform);
+			}
+		}
+		if (State.TraceMissElapsed > Settings.TraceMissGracePeriod)
+		{
+			State.bLocked = false;
+			bReleasedThisFrame = true;
+		}
+	}
+
+	const bool bMayPlantFresh = !State.bWantedToPlantLastFrame;
+	const bool bMayReplant =
+		!bReleasedThisFrame &&
+		RpgFootPlacement::ShouldReplantFoot(AnchorDistance, GroundNormalDelta, Settings);
+	if (!State.bLocked && bWantsToPlantNow && (bMayPlantFresh || bMayReplant))
+	{
+		State.bLocked = true;
+		State.LockedGroundPointWorld = TraceResult.GroundPointWorld;
+		State.LockedGroundNormalWorld = TraceResult.GroundNormalWorld;
+		State.LockedFootTransformWorld = CurrentAlignedFoot;
+		State.HitComponentId = TraceResult.HitComponentId;
+		State.TraceMissElapsed = 0.0f;
+	}
+	State.bWantedToPlantLastFrame = bWantsToPlantNow;
+
+	if (TraceResult.bWalkable)
+	{
+		State.RetainedGroundPointWorld = TraceResult.GroundPointWorld;
+		State.RetainedGroundNormalWorld = TraceResult.GroundNormalWorld;
+		State.bHasRetainedGroundTarget = true;
+		State.HitComponentId = TraceResult.HitComponentId;
+		State.PreviousHitComponentTransform = TraceResult.HitComponentTransform;
+		State.bHasPreviousHitComponentTransform = TraceResult.HitComponentId != 0;
+	}
+	else if (!State.bLocked)
+	{
+		State.HitComponentId = 0;
+		State.bHasPreviousHitComponentTransform = false;
+	}
+
+	const bool bHasGround = TraceResult.bWalkable || State.bLocked;
+	const float TargetWeight = bHasGround && bHasSpeedCurve
+		? FMath::Clamp(ContactCurveValue, 0.0f, 1.0f) *
+			RpgFootPlacement::CalculateAlignmentAlpha(FootSpeed, Settings)
+		: 0.0f;
+	const float WeightAlpha = RpgFootPlacement::CalculateHalfLifeAlpha(
+		DeltaSeconds,
+		Settings.WeightBlendHalfLife);
+	State.Weight = FMath::Lerp(State.Weight, TargetWeight, WeightAlpha);
+	if (!TraceResult.bWalkable && !State.bLocked && State.Weight <= UE_KINDA_SMALL_NUMBER)
+	{
+		State.bHasRetainedGroundTarget = false;
+	}
+
+	Snapshot.GroundPointWorld = State.bLocked
+		? State.LockedGroundPointWorld
+		: (TraceResult.bWalkable
+			? TraceResult.GroundPointWorld
+			: State.RetainedGroundPointWorld);
+	Snapshot.GroundNormalWorld = State.bLocked
+		? State.LockedGroundNormalWorld
+		: (TraceResult.bWalkable
+			? TraceResult.GroundNormalWorld
+			: State.RetainedGroundNormalWorld);
+	Snapshot.LockedFootTransformWorld = State.LockedFootTransformWorld;
+	Snapshot.Weight = State.Weight;
+	Snapshot.DistanceToGround = TraceResult.DistanceToGround;
+	Snapshot.HitComponentId = State.HitComponentId;
+	Snapshot.bHasWalkableGround = bHasGround ||
+		(State.bHasRetainedGroundTarget && State.Weight > UE_KINDA_SMALL_NUMBER);
+	Snapshot.bLocked = State.bLocked;
+	Snapshot.bHasSpeedCurve = bHasSpeedCurve;
+}
+
+void UpdateFootPlacementSnapshot(
+	FRpgAnimInstanceProxy& Proxy,
+	const FRpgFootPlacementSettings& Settings,
+	const URpgAnimInstance& AnimInstance,
+	const ARpgCharacter& Character,
+	const URpgCharacterMovementComponent& MovementComponent,
+	float DeltaSeconds)
+{
+	check(IsInGameThread());
+	Proxy.FootPlacementSnapshot = FRpgFootPlacementSnapshot();
+	FRpgFootPlacementSnapshot& Snapshot = Proxy.FootPlacementSnapshot;
+	Snapshot.OwnerId = Character.GetUniqueID();
+	Snapshot.LocalRole = static_cast<uint8>(Character.GetLocalRole());
+	Snapshot.RemoteRole = static_cast<uint8>(Character.GetRemoteRole());
+	Snapshot.VelocityWorld = MovementComponent.Velocity;
+	Snapshot.bGrounded = Proxy.MovementState == ERpgLocomotionMovementState::Grounded &&
+		Proxy.bIsMovingOnGround;
+
+	const USkeletalMeshComponent* MeshComponent = AnimInstance.GetSkelMeshComponent();
+	if (!MeshComponent)
+	{
+		Snapshot.bReset = true;
+		ResetFootPlacementState(Proxy);
+		Proxy.bPreviousFootPlacementSourceEligible = false;
+		return;
+	}
+
+	const FTransform ComponentToWorld = MeshComponent->GetComponentTransform();
+	const bool bHadPreviousComponentTransform = Proxy.bHasPreviousFootPlacementComponentTransform;
+	const bool bHadPreviousBaseTransform = Proxy.bHasPreviousMovementBaseTransform;
+	const uint32 PreviousMovementBaseId = Proxy.PreviousMovementBaseId;
+	const FTransform PreviousMovementBaseTransform = Proxy.PreviousMovementBaseTransform;
+	Snapshot.ComponentToWorld = ComponentToWorld;
+	if (bHadPreviousComponentTransform)
+	{
+		Snapshot.ComponentDeltaWorld =
+			ComponentToWorld.GetLocation() - Proxy.PreviousFootPlacementComponentTransform.GetLocation();
+	}
+
+	uint32 MovementBaseId = 0;
+	FTransform CurrentBaseTransform = FTransform::Identity;
+	const bool bHasCurrentBase = TryGetMovementBaseSnapshot(
+		Character,
+		MovementBaseId,
+		CurrentBaseTransform);
+	Snapshot.MovementBaseId = MovementBaseId;
+	const bool bHasBaseDelta =
+		bHasCurrentBase &&
+		bHadPreviousBaseTransform &&
+		MovementBaseId != 0 &&
+		MovementBaseId == PreviousMovementBaseId;
+	if (bHasBaseDelta)
+	{
+		Snapshot.BaseDeltaTranslationWorld =
+			CurrentBaseTransform.GetLocation() - PreviousMovementBaseTransform.GetLocation();
+		Snapshot.BaseDeltaRotationWorld = (
+			CurrentBaseTransform.GetRotation() *
+			PreviousMovementBaseTransform.GetRotation().Inverse()).GetNormalized();
+	}
+
+	if (MovementComponent.CurrentFloor.bBlockingHit)
+	{
+		Snapshot.FloorPointWorld = MovementComponent.CurrentFloor.HitResult.ImpactPoint;
+		Snapshot.FloorNormalWorld = MovementComponent.CurrentFloor.HitResult.ImpactNormal.GetSafeNormal(
+			UE_SMALL_NUMBER,
+			FVector::UpVector);
+	}
+
+	const bool bLargeComponentJump =
+		bHadPreviousComponentTransform &&
+		Snapshot.ComponentDeltaWorld.SizeSquared() > FMath::Square(TurnInPlaceLargePositionDelta);
+	const bool bBaseIdentityChanged =
+		bHadPreviousComponentTransform &&
+		PreviousMovementBaseId != MovementBaseId;
+	const bool bSourceEligible =
+		Settings.bEnabled &&
+		Snapshot.bGrounded &&
+		(!Proxy.bIsCrouching || Settings.bApplyWhileCrouching) &&
+		!Proxy.bIsAnyMontagePlaying &&
+		!Proxy.bHasTurnInPlaceBlockingGameplayTag;
+	const bool bSourceBecameEligible =
+		bSourceEligible && !Proxy.bPreviousFootPlacementSourceEligible;
+	Snapshot.bReset =
+		Proxy.bTurnInPlaceHardReset ||
+		bLargeComponentJump ||
+		bBaseIdentityChanged ||
+		bSourceBecameEligible ||
+		!bSourceEligible;
+
+	Proxy.PreviousFootPlacementComponentTransform = ComponentToWorld;
+	Proxy.bHasPreviousFootPlacementComponentTransform = true;
+	Proxy.PreviousMovementBaseId = MovementBaseId;
+	Proxy.PreviousMovementBaseTransform = CurrentBaseTransform;
+	Proxy.bHasPreviousMovementBaseTransform = bHasCurrentBase;
+	Proxy.bPreviousFootPlacementSourceEligible = bSourceEligible;
+
+	if (Snapshot.bReset)
+	{
+		ResetFootPlacementState(Proxy);
+		return;
+	}
+
+	UpdateFootPlacementLeg(
+		Proxy.FootPlacementLegStates[0],
+		Snapshot.LeftFoot,
+		Settings.LeftLeg,
+		Settings,
+		AnimInstance,
+		Character,
+		MovementComponent,
+		*MeshComponent,
+		ComponentToWorld,
+		MovementBaseId,
+		PreviousMovementBaseTransform,
+		CurrentBaseTransform,
+		bHasBaseDelta,
+		DeltaSeconds);
+	UpdateFootPlacementLeg(
+		Proxy.FootPlacementLegStates[1],
+		Snapshot.RightFoot,
+		Settings.RightLeg,
+		Settings,
+		AnimInstance,
+		Character,
+		MovementComponent,
+		*MeshComponent,
+		ComponentToWorld,
+		MovementBaseId,
+		PreviousMovementBaseTransform,
+		CurrentBaseTransform,
+		bHasBaseDelta,
+		DeltaSeconds);
+	Snapshot.bValid = true;
+	Proxy.FootPlacementAlpha = 1.0f;
 }
 }
 
@@ -215,6 +669,8 @@ void FRpgAnimInstanceProxy::PreUpdate(UAnimInstance* InAnimInstance, float Delta
 	ActorYaw = 0.0f;
 	ActorYawDelta = 0.0f;
 	ActorLocation = FVector::ZeroVector;
+	FootPlacementSnapshot = FRpgFootPlacementSnapshot();
+	FootPlacementAlpha = 0.0f;
 
 	const URpgAnimInstance* RpgAnimInstance = Cast<URpgAnimInstance>(InAnimInstance);
 	bHasTurnInPlaceBlockingGameplayTag =
@@ -352,6 +808,14 @@ void FRpgAnimInstanceProxy::PreUpdate(UAnimInstance* InAnimInstance, float Delta
 	ProceduralLocomotionAlpha =
 		bIsMovingOnGround && !bIsCrouching && !bIsAnyMontagePlaying ? 1.0f : 0.0f;
 
+	UpdateFootPlacementSnapshot(
+		*this,
+		RpgAnimInstance->FootPlacementSettings,
+		*RpgAnimInstance,
+		*Character,
+		*MovementComponent,
+		DeltaSeconds);
+
 	const FRotator AimDelta = (Character->GetBaseAimRotation() - Character->GetActorRotation()).GetNormalized();
 	AimYaw = AimDelta.Yaw;
 	AimPitch = AimDelta.Pitch;
@@ -435,6 +899,24 @@ EDataValidationResult URpgAnimInstance::IsDataValid(FDataValidationContext& Cont
 			Context.AddError(FText::FromString(
 				TEXT("Motion Matching is enabled, but no turn-in-place Pose Search database is configured.")));
 		}
+		if (FootPlacementSettings.bEnabled)
+		{
+			const FRpgFootPlacementLegDefinition* LegDefinitions[] = {
+				&FootPlacementSettings.LeftLeg,
+				&FootPlacementSettings.RightLeg,
+			};
+			for (int32 LegIndex = 0; LegIndex < UE_ARRAY_COUNT(LegDefinitions); ++LegIndex)
+			{
+				const FRpgFootPlacementLegDefinition& Leg = *LegDefinitions[LegIndex];
+				if (Leg.FKFootBone.IsNone() || Leg.IKFootBone.IsNone() ||
+					Leg.BallBone.IsNone() || Leg.SpeedCurveName.IsNone())
+				{
+					Context.AddError(FText::FromString(FString::Printf(
+						TEXT("Foot Placement leg %d requires FK foot, IK foot, ball, and speed-curve names."),
+						LegIndex)));
+				}
+			}
+		}
 
 		const auto ValidateDatabases = [&Context](
 			const TArray<TObjectPtr<UPoseSearchDatabase>>& Databases,
@@ -462,11 +944,14 @@ EDataValidationResult URpgAnimInstance::IsDataValid(FDataValidationContext& Cont
 void URpgAnimInstance::NativeInitializeAnimation()
 {
 	Super::NativeInitializeAnimation();
+	ResetFootPlacementInitializationState(GetProxyOnGameThread<FRpgAnimInstanceProxy>());
 	TurnInPlaceRequestSerial = 0;
 	TurnInPlaceInterruptedRequestSerial = 0;
 	bTurnInPlaceHardResetConditionLastFrame = false;
 	bResetOffsetRootEveryFrame = false;
 	bTurnInPlaceInitializationResetPending = true;
+	FootPlacementSnapshot = FRpgFootPlacementSnapshot();
+	FootPlacementAlpha = 0.0f;
 	ResetTurnInPlaceRuntime(false);
 
 	if (AActor* OwningActor = GetOwningActor())
@@ -912,6 +1397,8 @@ void URpgAnimInstance::NativeThreadSafeUpdateAnimation(float DeltaSeconds)
 	LocomotionGroundSpeed = Proxy.GroundSpeed;
 	VerticalVelocity = Proxy.VerticalVelocity;
 	GroundDistance = Proxy.GroundDistance;
+	FootPlacementSnapshot = Proxy.FootPlacementSnapshot;
+	FootPlacementAlpha = Proxy.FootPlacementAlpha;
 	AimYaw = Proxy.AimYaw;
 	AimPitch = Proxy.AimPitch;
 	LocomotionAngle = Proxy.LocomotionAngle;

--- a/Source/SurvivalRpg/Animation/RpgAnimInstance.cpp
+++ b/Source/SurvivalRpg/Animation/RpgAnimInstance.cpp
@@ -191,7 +191,8 @@ void UpdateFootPlacementLeg(
 	float DeltaSeconds)
 {
 	check(IsInGameThread());
-	if (Definition.IKFootBone.IsNone() || Definition.BallBone.IsNone() ||
+	if (Definition.FKFootBone.IsNone() || Definition.IKFootBone.IsNone() || Definition.BallBone.IsNone() ||
+		!MeshComponent.DoesSocketExist(Definition.FKFootBone) ||
 		!MeshComponent.DoesSocketExist(Definition.IKFootBone) ||
 		!MeshComponent.DoesSocketExist(Definition.BallBone))
 	{
@@ -199,10 +200,10 @@ void UpdateFootPlacementLeg(
 		return;
 	}
 
-	const FTransform IKFootTransformWorld = MeshComponent.GetSocketTransform(
-		Definition.IKFootBone,
+	const FTransform FKFootTransformWorld = MeshComponent.GetSocketTransform(
+		Definition.FKFootBone,
 		RTS_World);
-	const FTransform BallTransformWorld = MeshComponent.GetSocketTransform(
+	const FTransform AuthoredBallTransformWorld = MeshComponent.GetSocketTransform(
 		Definition.BallBone,
 		RTS_World);
 	float ContactCurveValue = 0.0f;
@@ -219,7 +220,7 @@ void UpdateFootPlacementLeg(
 		Character,
 		MovementComponent,
 		Settings,
-		BallTransformWorld.GetLocation());
+		AuthoredBallTransformWorld.GetLocation());
 	const bool bWantsToPlantNow = bHasSpeedCurve && RpgFootPlacement::ShouldPlantFoot(
 		TraceResult.bWalkable,
 		FootSpeed,
@@ -228,7 +229,7 @@ void UpdateFootPlacementLeg(
 	bool bReleasedThisFrame = false;
 	float AnchorDistance = MAX_flt;
 	float GroundNormalDelta = 180.0f;
-	FTransform CurrentAlignedFoot = IKFootTransformWorld;
+	FTransform CurrentAlignedFoot = FKFootTransformWorld;
 
 	if (TraceResult.bWalkable)
 	{
@@ -251,8 +252,8 @@ void UpdateFootPlacementLeg(
 		}
 
 		CurrentAlignedFoot = RpgFootPlacement::AlignFootToGroundPlane(
-			IKFootTransformWorld,
-			BallTransformWorld,
+			FKFootTransformWorld,
+			AuthoredBallTransformWorld,
 			TraceResult.GroundPointWorld,
 			TraceResult.GroundNormalWorld,
 			ComponentToWorld.GetUnitAxis(EAxis::Z),

--- a/Source/SurvivalRpg/Animation/RpgAnimInstance.h
+++ b/Source/SurvivalRpg/Animation/RpgAnimInstance.h
@@ -10,6 +10,7 @@
 #include "AnimationWarpingTypes.h"
 #include "GameplayEffectTypes.h"
 #include "PoseSearch/PoseSearchTrajectoryLibrary.h"
+#include "RpgFootPlacementTypes.h"
 #include "SurvivalRpg/Core/Character/RpgCharacterRotationMode.h"
 #include "RpgAnimInstance.generated.h"
 
@@ -71,6 +72,24 @@ struct SURVIVALRPG_API FRpgAnimInstanceProxy : public FAnimInstanceProxy
 {
 	GENERATED_BODY()
 
+	/** Persistent value-only state owned and touched exclusively by game-thread PreUpdate. */
+	struct FFootPlacementLegState
+	{
+		FTransform LockedFootTransformWorld = FTransform::Identity;
+		FVector LockedGroundPointWorld = FVector::ZeroVector;
+		FVector LockedGroundNormalWorld = FVector::UpVector;
+		FVector RetainedGroundPointWorld = FVector::ZeroVector;
+		FVector RetainedGroundNormalWorld = FVector::UpVector;
+		FTransform PreviousHitComponentTransform = FTransform::Identity;
+		uint32 HitComponentId = 0;
+		float TraceMissElapsed = 0.0f;
+		float Weight = 0.0f;
+		bool bLocked = false;
+		bool bWantedToPlantLastFrame = false;
+		bool bHasRetainedGroundTarget = false;
+		bool bHasPreviousHitComponentTransform = false;
+	};
+
 	FRpgAnimInstanceProxy() = default;
 	explicit FRpgAnimInstanceProxy(UAnimInstance* InAnimInstance)
 		: FAnimInstanceProxy(InAnimInstance)
@@ -101,6 +120,8 @@ struct SURVIVALRPG_API FRpgAnimInstanceProxy : public FAnimInstanceProxy
 	ERpgCharacterRotationMode RotationMode = ERpgCharacterRotationMode::Free;
 	FPoseSearchTrajectoryData TrajectoryGenerationData;
 	FTransformTrajectory TransformTrajectory;
+	FRpgFootPlacementSnapshot FootPlacementSnapshot;
+	float FootPlacementAlpha = 0.0f;
 	bool bHasVelocity = false;
 	bool bHasAcceleration = false;
 	bool bHasGroundedMoveIntent = false;
@@ -121,6 +142,15 @@ struct SURVIVALRPG_API FRpgAnimInstanceProxy : public FAnimInstanceProxy
 	FVector PreviousActorLocation = FVector::ZeroVector;
 	ERpgCharacterRotationMode PreviousRotationMode = ERpgCharacterRotationMode::Free;
 	bool bHasPreviousOwnerSnapshot = false;
+
+	// Previous foot-placement data is maintained and consumed only by game-thread PreUpdate.
+	FFootPlacementLegState FootPlacementLegStates[2];
+	FTransform PreviousFootPlacementComponentTransform = FTransform::Identity;
+	FTransform PreviousMovementBaseTransform = FTransform::Identity;
+	uint32 PreviousMovementBaseId = 0;
+	bool bHasPreviousFootPlacementComponentTransform = false;
+	bool bHasPreviousMovementBaseTransform = false;
+	bool bPreviousFootPlacementSourceEligible = false;
 };
 
 
@@ -217,6 +247,13 @@ protected:
 	UPROPERTY(EditDefaultsOnly, Category = "GameplayTags")
 	FGameplayTagBlueprintPropertyMap GameplayTagPropertyMap;
 
+	/**
+	 * Static game-thread trace and plant-lock policy for the project-local Foot Placement node.
+	 * Disabled defaults keep non-GASP AnimBPs free of trace cost; runtime results are cosmetic only.
+	 */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	FRpgFootPlacementSettings FootPlacementSettings;
+
 	/** Mirrored `Gameplay.MovementStopped` state; game-thread authored and snapshotted before parallel evaluation. */
 	UPROPERTY(BlueprintReadOnly, Transient, Category = "Rpg|Animation|Gameplay Tags")
 	bool bGameplayMovementStopped = false;
@@ -306,6 +343,14 @@ protected:
 	/** Distance from the capsule bottom to the ground in centimeters; -1 means no valid owner snapshot. */
 	UPROPERTY(BlueprintReadOnly, Transient, Category = "Rpg|Animation|Locomotion", Meta = (Units = "cm"))
 	float GroundDistance = -1.0f;
+
+	/** Pointer-free game-thread trace/lock snapshot consumed by the parallel Foot Placement node. */
+	UPROPERTY(BlueprintReadOnly, Transient, Category = "Rpg|Animation|Foot Placement")
+	FRpgFootPlacementSnapshot FootPlacementSnapshot;
+
+	/** Global cosmetic alpha shared by project-local Foot Placement and downstream Leg IK. */
+	UPROPERTY(BlueprintReadOnly, Transient, Category = "Rpg|Animation|Foot Placement", meta = (ClampMin = "0.0", ClampMax = "1.0"))
+	float FootPlacementAlpha = 0.0f;
 
 	/** Controller aim yaw relative to the character in degrees, normalized to [-180, 180]. */
 	UPROPERTY(BlueprintReadOnly, Transient, Category = "Rpg|Animation|Aim", Meta = (Units = "deg"))

--- a/Source/SurvivalRpg/Animation/RpgFootPlacementTypes.cpp
+++ b/Source/SurvivalRpg/Animation/RpgFootPlacementTypes.cpp
@@ -1,0 +1,160 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+#include "RpgFootPlacementTypes.h"
+
+#include "Math/UnrealMathUtility.h"
+
+#include UE_INLINE_GENERATED_CPP_BY_NAME(RpgFootPlacementTypes)
+
+FRpgFootPlacementSettings::FRpgFootPlacementSettings()
+{
+	LeftLeg.FKFootBone = TEXT("foot_l");
+	LeftLeg.IKFootBone = TEXT("ik_foot_l");
+	LeftLeg.BallBone = TEXT("ball_l");
+	LeftLeg.SpeedCurveName = TEXT("contact_l");
+	RightLeg.FKFootBone = TEXT("foot_r");
+	RightLeg.IKFootBone = TEXT("ik_foot_r");
+	RightLeg.BallBone = TEXT("ball_r");
+	RightLeg.SpeedCurveName = TEXT("contact_r");
+}
+
+namespace RpgFootPlacement
+{
+	float ConvertContactCurveToSpeed(float ContactCurveValue)
+	{
+		return (1.0f - FMath::Clamp(ContactCurveValue, 0.0f, 1.0f)) * 100.0f;
+	}
+
+	float CalculateHalfLifeAlpha(float DeltaSeconds, float HalfLifeSeconds)
+	{
+		if (DeltaSeconds <= 0.0f)
+		{
+			return 0.0f;
+		}
+		if (HalfLifeSeconds <= UE_SMALL_NUMBER)
+		{
+			return 1.0f;
+		}
+		return 1.0f - FMath::Exp2(-DeltaSeconds / HalfLifeSeconds);
+	}
+
+	float CalculateAlignmentAlpha(float FootSpeed, const FRpgFootPlacementSettings& Settings)
+	{
+		if (FootSpeed <= Settings.PlantSpeedThreshold)
+		{
+			return 1.0f;
+		}
+		if (FootSpeed >= Settings.UnalignmentSpeedThreshold)
+		{
+			return 0.0f;
+		}
+		const float SpeedRange = Settings.UnalignmentSpeedThreshold - Settings.PlantSpeedThreshold;
+		if (SpeedRange <= UE_SMALL_NUMBER)
+		{
+			return 0.0f;
+		}
+		return 1.0f - (FootSpeed - Settings.PlantSpeedThreshold) / SpeedRange;
+	}
+
+	bool ShouldPlantFoot(
+		bool bHasWalkableGround,
+		float FootSpeed,
+		float DistanceToGround,
+		const FRpgFootPlacementSettings& Settings)
+	{
+		return bHasWalkableGround &&
+			FootSpeed <= Settings.PlantSpeedThreshold &&
+			FMath::Abs(DistanceToGround) <= Settings.PlantDistanceThreshold;
+	}
+
+	bool ShouldUnplantFoot(
+		float FootSpeed,
+		float AnchorDistance,
+		float GroundNormalDeltaDegrees,
+		const FRpgFootPlacementSettings& Settings)
+	{
+		return FootSpeed > Settings.PlantSpeedThreshold ||
+			AnchorDistance > Settings.UnplantRadius ||
+			GroundNormalDeltaDegrees > Settings.UnplantAngle;
+	}
+
+	bool ShouldReplantFoot(
+		float AnchorDistance,
+		float GroundNormalDeltaDegrees,
+		const FRpgFootPlacementSettings& Settings)
+	{
+		return AnchorDistance <= Settings.UnplantRadius * Settings.ReplantRadiusRatio &&
+			GroundNormalDeltaDegrees <= Settings.UnplantAngle * Settings.ReplantAngleRatio;
+	}
+
+	FTransform RebaseTransformThroughSurface(
+		const FTransform& TransformWorld,
+		const FTransform& PreviousSurfaceTransform,
+		const FTransform& CurrentSurfaceTransform)
+	{
+		return TransformWorld.GetRelativeTransform(PreviousSurfaceTransform) * CurrentSurfaceTransform;
+	}
+
+	FVector RebasePointThroughSurface(
+		const FVector& PointWorld,
+		const FTransform& PreviousSurfaceTransform,
+		const FTransform& CurrentSurfaceTransform)
+	{
+		return CurrentSurfaceTransform.TransformPosition(
+			PreviousSurfaceTransform.InverseTransformPosition(PointWorld));
+	}
+
+	FVector RebaseNormalThroughSurface(
+		const FVector& NormalWorld,
+		const FTransform& PreviousSurfaceTransform,
+		const FTransform& CurrentSurfaceTransform)
+	{
+		return CurrentSurfaceTransform.TransformVectorNoScale(
+			PreviousSurfaceTransform.InverseTransformVectorNoScale(NormalWorld))
+			.GetSafeNormal(UE_SMALL_NUMBER, FVector::UpVector);
+	}
+
+	FTransform AlignFootToGroundPlane(
+		const FTransform& IKFootTransformWorld,
+		const FTransform& BallTransformWorld,
+		const FVector& GroundPointWorld,
+		const FVector& GroundNormalWorld,
+		const FVector& ComponentUpWorld,
+		float MaxTranslationOffset,
+		float MaxRotationDegrees)
+	{
+		const FVector SafeNormal = GroundNormalWorld.GetSafeNormal(UE_SMALL_NUMBER, FVector::UpVector);
+		const FVector SafeUp = ComponentUpWorld.GetSafeNormal(UE_SMALL_NUMBER, FVector::UpVector);
+		FQuat Alignment = FQuat::FindBetweenNormals(SafeUp, SafeNormal);
+		const float AlignmentAngleDegrees = FMath::RadiansToDegrees(Alignment.GetAngle());
+		if (AlignmentAngleDegrees > MaxRotationDegrees && AlignmentAngleDegrees > UE_SMALL_NUMBER)
+		{
+			Alignment = FQuat::Slerp(FQuat::Identity, Alignment, MaxRotationDegrees / AlignmentAngleDegrees);
+			Alignment.Normalize();
+		}
+
+		const FVector BallLocation = BallTransformWorld.GetLocation();
+		const FVector IKLocation = IKFootTransformWorld.GetLocation();
+		const float Denominator = FVector::DotProduct(-SafeUp, SafeNormal);
+		FVector ProjectedBall = BallLocation;
+		if (FMath::Abs(Denominator) > UE_SMALL_NUMBER)
+		{
+			const float DistanceAlongDown = FVector::DotProduct(GroundPointWorld - BallLocation, SafeNormal) / Denominator;
+			ProjectedBall += -SafeUp * DistanceAlongDown;
+		}
+
+		FTransform Result = IKFootTransformWorld;
+		Result.SetRotation((Alignment * IKFootTransformWorld.GetRotation()).GetNormalized());
+		FVector TargetLocation = ProjectedBall + Alignment.RotateVector(IKLocation - BallLocation);
+		const FVector TranslationOffset = (TargetLocation - IKLocation).GetClampedToMaxSize(
+			FMath::Max(MaxTranslationOffset, 0.0f));
+		Result.SetLocation(IKLocation + TranslationOffset);
+		return Result;
+	}
+
+	float CalculatePelvisOffset(float LeftOffset, float RightOffset, float MaxDownwardOffset)
+	{
+		const float RequestedOffset = FMath::Min3(LeftOffset, RightOffset, 0.0f);
+		return FMath::Clamp(RequestedOffset, -FMath::Max(MaxDownwardOffset, 0.0f), 0.0f);
+	}
+}

--- a/Source/SurvivalRpg/Animation/RpgFootPlacementTypes.cpp
+++ b/Source/SurvivalRpg/Animation/RpgFootPlacementTypes.cpp
@@ -152,9 +152,135 @@ namespace RpgFootPlacement
 		return Result;
 	}
 
+	FTransform DeriveIKBallTransform(
+		const FTransform& FKFootTransform,
+		const FTransform& BallTransform,
+		const FTransform& IKFootTransform)
+	{
+		const FTransform FootToBall = BallTransform.GetRelativeTransform(FKFootTransform);
+		return FootToBall * IKFootTransform;
+	}
+
+	FTransform PivotFootAroundBall(
+		const FTransform& IKFootTransform,
+		const FTransform& IKBallTransform,
+		const FTransform& LockedFootTransform)
+	{
+		const FTransform FootToBall = IKBallTransform.GetRelativeTransform(IKFootTransform);
+		const FTransform BallToFoot = IKFootTransform.GetRelativeTransform(IKBallTransform);
+		const FTransform LockedBallTransform = FootToBall * LockedFootTransform;
+		const FTransform PinnedBallTransform(
+			IKBallTransform.GetRotation(),
+			LockedBallTransform.GetLocation(),
+			IKBallTransform.GetScale3D());
+		return BallToFoot * PinnedBallTransform;
+	}
+
+	float CalculateGeometryWeight(
+		float BallDistanceToPlane,
+		float PlanarLockDrift,
+		bool bLocked,
+		float PlantDistanceThreshold,
+		float UnplantRadius)
+	{
+		auto CalculateBoundWeight = [](float Value, float Bound)
+		{
+			const float SafeBound = FMath::Max(Bound, 0.0f);
+			const float AbsoluteValue = FMath::Abs(Value);
+			if (SafeBound <= UE_SMALL_NUMBER)
+			{
+				return AbsoluteValue <= UE_SMALL_NUMBER ? 1.0f : 0.0f;
+			}
+			if (AbsoluteValue >= SafeBound)
+			{
+				return 0.0f;
+			}
+
+			const float FadeAlpha = FMath::Clamp(
+				(AbsoluteValue - SafeBound * 0.5f) / (SafeBound * 0.5f),
+				0.0f,
+				1.0f);
+			const float SmoothFadeAlpha = FadeAlpha * FadeAlpha * (3.0f - 2.0f * FadeAlpha);
+			return 1.0f - SmoothFadeAlpha;
+		};
+
+		const float PlaneWeight = CalculateBoundWeight(BallDistanceToPlane, PlantDistanceThreshold);
+		const float LockWeight = bLocked
+			? CalculateBoundWeight(PlanarLockDrift, UnplantRadius)
+			: 1.0f;
+		return PlaneWeight * LockWeight;
+	}
+
+	float CalculateEffectivePlacementWeight(
+		bool bHasWalkableGround,
+		float SnapshotWeight,
+		float GeometryWeight)
+	{
+		if (!bHasWalkableGround)
+		{
+			return 0.0f;
+		}
+
+		return FMath::Clamp(SnapshotWeight, 0.0f, 1.0f) *
+			FMath::Clamp(GeometryWeight, 0.0f, 1.0f);
+	}
+
+	FTransform ResolveIKFootTarget(
+		const FTransform& FKFootTransform,
+		const FTransform& ProceduralTargetTransform,
+		float EffectivePlacementWeight)
+	{
+		const float SafeWeight = FMath::Clamp(EffectivePlacementWeight, 0.0f, 1.0f);
+		if (SafeWeight <= UE_KINDA_SMALL_NUMBER)
+		{
+			return FKFootTransform;
+		}
+		if (SafeWeight >= 1.0f - UE_KINDA_SMALL_NUMBER)
+		{
+			return ProceduralTargetTransform;
+		}
+
+		FTransform Result = FKFootTransform;
+		Result.SetLocation(FMath::Lerp(
+			FKFootTransform.GetLocation(),
+			ProceduralTargetTransform.GetLocation(),
+			SafeWeight));
+		Result.SetRotation(FQuat::Slerp(
+			FKFootTransform.GetRotation(),
+			ProceduralTargetTransform.GetRotation(),
+			SafeWeight).GetNormalized());
+		Result.SetScale3D(FMath::Lerp(
+			FKFootTransform.GetScale3D(),
+			ProceduralTargetTransform.GetScale3D(),
+			SafeWeight));
+		return Result;
+	}
+
 	float CalculatePelvisOffset(float LeftOffset, float RightOffset, float MaxDownwardOffset)
 	{
 		const float RequestedOffset = FMath::Min3(LeftOffset, RightOffset, 0.0f);
 		return FMath::Clamp(RequestedOffset, -FMath::Max(MaxDownwardOffset, 0.0f), 0.0f);
+	}
+
+	float SmoothPelvisOffset(
+		float CurrentOffset,
+		float TargetOffset,
+		float DeltaSeconds,
+		float HalfLifeSeconds,
+		float MaxSpeed)
+	{
+		const float SafeDeltaSeconds = FMath::Max(DeltaSeconds, 0.0f);
+		if (SafeDeltaSeconds <= 0.0f)
+		{
+			return CurrentOffset;
+		}
+
+		const float InterpolationAlpha = CalculateHalfLifeAlpha(SafeDeltaSeconds, HalfLifeSeconds);
+		const float InterpolatedOffset = FMath::Lerp(CurrentOffset, TargetOffset, InterpolationAlpha);
+		const float MaxStep = FMath::Max(MaxSpeed, 0.0f) * SafeDeltaSeconds;
+		return CurrentOffset + FMath::Clamp(
+			InterpolatedOffset - CurrentOffset,
+			-MaxStep,
+			MaxStep);
 	}
 }

--- a/Source/SurvivalRpg/Animation/RpgFootPlacementTypes.h
+++ b/Source/SurvivalRpg/Animation/RpgFootPlacementTypes.h
@@ -1,0 +1,299 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "RpgFootPlacementTypes.generated.h"
+
+/** Static per-leg names used by the game-thread foot-placement sampler. */
+USTRUCT(BlueprintType)
+struct SURVIVALRPG_API FRpgFootPlacementLegDefinition
+{
+	GENERATED_BODY()
+
+	/** FK ankle bone used by the downstream Leg IK solver. */
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	FName FKFootBone = NAME_None;
+
+	/** IK target bone moved by the project-local foot-placement node. */
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	FName IKFootBone = NAME_None;
+
+	/** Toe/ball bone whose previous evaluated world position seeds the ground sweep. */
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	FName BallBone = NAME_None;
+
+	/** Previous-frame GASP contact curve; the game thread remaps it to the pseudo-speed used for planting. */
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	FName SpeedCurveName = NAME_None;
+};
+
+/**
+ * Designer-tuned game-thread trace and lock policy for project-local foot placement.
+ *
+ * The settings are static AnimBP defaults. Runtime traces remain cosmetic and never
+ * influence authoritative character movement or collision.
+ */
+USTRUCT(BlueprintType)
+struct SURVIVALRPG_API FRpgFootPlacementSettings
+{
+	GENERATED_BODY()
+
+	FRpgFootPlacementSettings();
+
+	/** Enables game-thread ground sampling for this AnimBP; disabled by default for legacy graphs. */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	bool bEnabled = false;
+
+	/** Opts crouch clips into procedural placement; false preserves the validated authored crouch pose. */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	bool bApplyWhileCrouching = false;
+
+	/** Left mannequin leg sampled on the game thread. */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	FRpgFootPlacementLegDefinition LeftLeg;
+
+	/** Right mannequin leg sampled on the game thread. */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	FRpgFootPlacementLegDefinition RightLeg;
+
+	/** Height above the ball bone at which each downward sweep starts, in centimeters. */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement", meta = (ClampMin = "0.0", Units = "cm"))
+	float TraceStartHeight = 75.0f;
+
+	/** Distance below the ball bone covered by each downward sweep, in centimeters. */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement", meta = (ClampMin = "0.0", Units = "cm"))
+	float TraceEndDepth = 100.0f;
+
+	/** Radius of the game-thread sphere sweep, in centimeters. */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement", meta = (ClampMin = "0.0", Units = "cm"))
+	float SweepRadius = 5.0f;
+
+	/** Foot speed below which a nearby walkable surface may establish a plant lock, in centimeters per second. */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement", meta = (ClampMin = "0.0", Units = "cm/s"))
+	float PlantSpeedThreshold = 60.0f;
+
+	/** Foot speed above which ground-alignment weight is fully released, in centimeters per second. */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement", meta = (ClampMin = "0.0", Units = "cm/s"))
+	float UnalignmentSpeedThreshold = 200.0f;
+
+	/** Maximum ball-to-plane distance that may establish a plant lock, in centimeters. */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement", meta = (ClampMin = "0.0", Units = "cm"))
+	float PlantDistanceThreshold = 10.0f;
+
+	/** Maximum distance between a planted target and the animated foot before the lock releases, in centimeters. */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement", meta = (ClampMin = "0.0", Units = "cm"))
+	float UnplantRadius = 35.0f;
+
+	/** Fraction of UnplantRadius below which an already-requested contact may replant. */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement", meta = (ClampMin = "0.0", ClampMax = "1.0"))
+	float ReplantRadiusRatio = 0.35f;
+
+	/** Maximum ground-normal change retained by a plant lock, in degrees. */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement", meta = (ClampMin = "0.0", ClampMax = "90.0", Units = "deg"))
+	float UnplantAngle = 45.0f;
+
+	/** Fraction of UnplantAngle below which an already-requested contact may replant. */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement", meta = (ClampMin = "0.0", ClampMax = "1.0"))
+	float ReplantAngleRatio = 0.5f;
+
+	/** Maximum slope-alignment rotation authored into a locked IK target, in degrees. */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement", meta = (ClampMin = "0.0", ClampMax = "90.0", Units = "deg"))
+	float MaxFootAlignmentAngle = 60.0f;
+
+	/** Maximum world-space correction authored into a locked IK target, in centimeters. */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement", meta = (ClampMin = "0.0", Units = "cm"))
+	float MaxFootTranslation = 50.0f;
+
+	/** Maximum time a planted foot keeps its last plane across a transient trace miss, in seconds. */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement", meta = (ClampMin = "0.0", Units = "s"))
+	float TraceMissGracePeriod = 0.10f;
+
+	/** Half-life used to blend per-foot placement weights after valid grounded sampling begins, in seconds. */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement", meta = (ClampMin = "0.001", Units = "s"))
+	float WeightBlendHalfLife = 0.08f;
+};
+
+/** Pointer-free result of one game-thread foot sweep and plant-lock update. */
+USTRUCT(BlueprintType)
+struct SURVIVALRPG_API FRpgFootPlacementLegSnapshot
+{
+	GENERATED_BODY()
+
+	/** Walkable plane point in world space. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	FVector GroundPointWorld = FVector::ZeroVector;
+
+	/** Normalized walkable plane normal in world space. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	FVector GroundNormalWorld = FVector::UpVector;
+
+	/** World-space IK target retained while this foot is planted. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	FTransform LockedFootTransformWorld = FTransform::Identity;
+
+	/** Per-leg placement weight in the range [0, 1]. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement", meta = (ClampMin = "0.0", ClampMax = "1.0"))
+	float Weight = 0.0f;
+
+	/** Distance from the animated ball bone to the sampled plane, in centimeters. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement", meta = (Units = "cm"))
+	float DistanceToGround = 0.0f;
+
+	/** Stable runtime identifier of the hit component; zero means no component was retained. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	int64 HitComponentId = 0;
+
+	/** True while a walkable surface, planted grace plane, or fading last-valid target remains usable. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	bool bHasWalkableGround = false;
+
+	/** True when the foot owns a world-space plant lock. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	bool bLocked = false;
+
+	/** True when the active animation supplied the authored speed curve required for safe locking. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	bool bHasSpeedCurve = false;
+};
+
+/**
+ * Immutable game-thread foot-placement snapshot consumed by parallel animation evaluation.
+ *
+ * This value deliberately contains no UObject, FHitResult, world, actor, or movement-component
+ * references. Authority, autonomous proxies, and simulated proxies each build a cosmetic local copy.
+ */
+USTRUCT(BlueprintType)
+struct SURVIVALRPG_API FRpgFootPlacementSnapshot
+{
+	GENERATED_BODY()
+
+	/** Mesh component transform used to convert the stored world-space planes during this update. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	FTransform ComponentToWorld = FTransform::Identity;
+
+	/** Mesh component translation delta since the previous valid game-thread sample. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	FVector ComponentDeltaWorld = FVector::ZeroVector;
+
+	/** Translation contributed by the current movement base since the previous sample. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	FVector BaseDeltaTranslationWorld = FVector::ZeroVector;
+
+	/** Rotation contributed by the current movement base since the previous sample. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	FQuat BaseDeltaRotationWorld = FQuat::Identity;
+
+	/** Character velocity captured on the game thread for debugging and deterministic tests. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	FVector VelocityWorld = FVector::ZeroVector;
+
+	/** Current CharacterMovement floor point, flattened from CurrentFloor on the game thread. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	FVector FloorPointWorld = FVector::ZeroVector;
+
+	/** Current CharacterMovement floor normal, flattened from CurrentFloor on the game thread. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	FVector FloorNormalWorld = FVector::UpVector;
+
+	/** Left-foot ground sample. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	FRpgFootPlacementLegSnapshot LeftFoot;
+
+	/** Right-foot ground sample. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	FRpgFootPlacementLegSnapshot RightFoot;
+
+	/** Owner identifier used to diagnose role/possession rebases without carrying an object pointer. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	int64 OwnerId = 0;
+
+	/** Movement-base identifier used to diagnose lock rebases without carrying an object pointer. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	int64 MovementBaseId = 0;
+
+	/** Local role flattened on the game thread for network-role validation. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	uint8 LocalRole = 0;
+
+	/** Remote role flattened on the game thread for network-role validation. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	uint8 RemoteRole = 0;
+
+	/** True while CharacterMovement has a valid grounded walking state. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	bool bGrounded = false;
+
+	/** True when teleport, owner/role, base, or large-transform changes require lock state to be discarded. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	bool bReset = true;
+
+	/** True when both the static configuration and current game-thread owner snapshot are usable. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
+	bool bValid = false;
+};
+
+namespace RpgFootPlacement
+{
+	/** Converts a normalized GASP contact curve into the pseudo-speed expected by the plant policy. */
+	SURVIVALRPG_API float ConvertContactCurveToSpeed(float ContactCurveValue);
+
+	/** Returns an exponential interpolation alpha for the supplied half-life. */
+	SURVIVALRPG_API float CalculateHalfLifeAlpha(float DeltaSeconds, float HalfLifeSeconds);
+
+	/** Maps the pseudo-speed range to the procedural alignment weight used by Epic's Foot Placement policy. */
+	SURVIVALRPG_API float CalculateAlignmentAlpha(
+		float FootSpeed,
+		const FRpgFootPlacementSettings& Settings);
+
+	/** Returns whether a walkable sample is close and slow enough to establish a foot lock. */
+	SURVIVALRPG_API bool ShouldPlantFoot(
+		bool bHasWalkableGround,
+		float FootSpeed,
+		float DistanceToGround,
+		const FRpgFootPlacementSettings& Settings);
+
+	/** Returns whether an existing lock must release because the animated foot or ground changed too far. */
+	SURVIVALRPG_API bool ShouldUnplantFoot(
+		float FootSpeed,
+		float AnchorDistance,
+		float GroundNormalDeltaDegrees,
+		const FRpgFootPlacementSettings& Settings);
+
+	/** Returns whether an uninterrupted plant request has returned inside the tighter replant bounds. */
+	SURVIVALRPG_API bool ShouldReplantFoot(
+		float AnchorDistance,
+		float GroundNormalDeltaDegrees,
+		const FRpgFootPlacementSettings& Settings);
+
+	/** Rebases a world transform through a moving surface's previous and current transforms. */
+	SURVIVALRPG_API FTransform RebaseTransformThroughSurface(
+		const FTransform& TransformWorld,
+		const FTransform& PreviousSurfaceTransform,
+		const FTransform& CurrentSurfaceTransform);
+
+	/** Rebases a world point through a moving surface's previous and current transforms. */
+	SURVIVALRPG_API FVector RebasePointThroughSurface(
+		const FVector& PointWorld,
+		const FTransform& PreviousSurfaceTransform,
+		const FTransform& CurrentSurfaceTransform);
+
+	/** Rebases a world normal through a moving surface's previous and current transforms. */
+	SURVIVALRPG_API FVector RebaseNormalThroughSurface(
+		const FVector& NormalWorld,
+		const FTransform& PreviousSurfaceTransform,
+		const FTransform& CurrentSurfaceTransform);
+
+	/** Aligns an IK-foot transform to a plane while pivoting around the current ball transform. */
+	SURVIVALRPG_API FTransform AlignFootToGroundPlane(
+		const FTransform& IKFootTransformWorld,
+		const FTransform& BallTransformWorld,
+		const FVector& GroundPointWorld,
+		const FVector& GroundNormalWorld,
+		const FVector& ComponentUpWorld,
+		float MaxTranslationOffset,
+		float MaxRotationDegrees);
+
+	/** Chooses the bounded downward pelvis correction required by the sampled feet. */
+	SURVIVALRPG_API float CalculatePelvisOffset(float LeftOffset, float RightOffset, float MaxDownwardOffset);
+}

--- a/Source/SurvivalRpg/Animation/RpgFootPlacementTypes.h
+++ b/Source/SurvivalRpg/Animation/RpgFootPlacementTypes.h
@@ -83,19 +83,19 @@ struct SURVIVALRPG_API FRpgFootPlacementSettings
 
 	/** Maximum distance between a planted target and the animated foot before the lock releases, in centimeters. */
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement", meta = (ClampMin = "0.0", Units = "cm"))
-	float UnplantRadius = 35.0f;
+	float UnplantRadius = 20.0f;
 
 	/** Fraction of UnplantRadius below which an already-requested contact may replant. */
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement", meta = (ClampMin = "0.0", ClampMax = "1.0"))
-	float ReplantRadiusRatio = 0.35f;
+	float ReplantRadiusRatio = 0.2f;
 
 	/** Maximum ground-normal change retained by a plant lock, in degrees. */
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement", meta = (ClampMin = "0.0", ClampMax = "90.0", Units = "deg"))
-	float UnplantAngle = 45.0f;
+	float UnplantAngle = 60.0f;
 
 	/** Fraction of UnplantAngle below which an already-requested contact may replant. */
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement", meta = (ClampMin = "0.0", ClampMax = "1.0"))
-	float ReplantAngleRatio = 0.5f;
+	float ReplantAngleRatio = 0.2f;
 
 	/** Maximum slope-alignment rotation authored into a locked IK target, in degrees. */
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement", meta = (ClampMin = "0.0", ClampMax = "90.0", Units = "deg"))
@@ -294,6 +294,62 @@ namespace RpgFootPlacement
 		float MaxTranslationOffset,
 		float MaxRotationDegrees);
 
+	/**
+	 * Reconstructs the ball transform that belongs to an IK-foot target.
+	 *
+	 * The authored FK-foot-to-ball relationship is transferred onto the IK foot, matching
+	 * Epic's Foot Placement input contract without assuming that FK and IK bones overlap.
+	 */
+	SURVIVALRPG_API FTransform DeriveIKBallTransform(
+		const FTransform& FKFootTransform,
+		const FTransform& BallTransform,
+		const FTransform& IKFootTransform);
+
+	/** Rebuilds a planted IK foot while retaining the authored pivot around its current ball. */
+	SURVIVALRPG_API FTransform PivotFootAroundBall(
+		const FTransform& IKFootTransform,
+		const FTransform& IKBallTransform,
+		const FTransform& LockedFootTransform);
+
+	/**
+	 * Returns the stateless raw-pose gate shared by IK output and pelvis contribution.
+	 *
+	 * Ball distance is always enforced. Planar drift is additionally enforced for a lock.
+	 * Each bound stays fully weighted through its inner half and smoothly reaches zero at
+	 * the configured GASP limit; values at or beyond that limit are guaranteed to return zero.
+	 */
+	SURVIVALRPG_API float CalculateGeometryWeight(
+		float BallDistanceToPlane,
+		float PlanarLockDrift,
+		bool bLocked,
+		float PlantDistanceThreshold,
+		float UnplantRadius);
+
+	/** Combines per-leg availability, snapshot weight, and raw-pose geometry into a safe [0, 1] weight. */
+	SURVIVALRPG_API float CalculateEffectivePlacementWeight(
+		bool bHasWalkableGround,
+		float SnapshotWeight,
+		float GeometryWeight);
+
+	/**
+	 * Resolves the IK target consumed by stock Leg IK from the same-frame FK ankle baseline.
+	 *
+	 * A zero placement weight returns the FK ankle exactly, so a downstream global-alpha Leg IK
+	 * can never pin a swing leg to an unrelated or static authored IK track.
+	 */
+	SURVIVALRPG_API FTransform ResolveIKFootTarget(
+		const FTransform& FKFootTransform,
+		const FTransform& ProceduralTargetTransform,
+		float EffectivePlacementWeight);
+
 	/** Chooses the bounded downward pelvis correction required by the sampled feet. */
 	SURVIVALRPG_API float CalculatePelvisOffset(float LeftOffset, float RightOffset, float MaxDownwardOffset);
+
+	/** Smooths a pelvis target with a frame-rate-independent half-life and a hard speed bound. */
+	SURVIVALRPG_API float SmoothPelvisOffset(
+		float CurrentOffset,
+		float TargetOffset,
+		float DeltaSeconds,
+		float HalfLifeSeconds,
+		float MaxSpeed);
 }

--- a/Source/SurvivalRpg/SurvivalRpg.Build.cs
+++ b/Source/SurvivalRpg/SurvivalRpg.Build.cs
@@ -11,6 +11,7 @@ public class SurvivalRpg : ModuleRules
 		PublicDependencyModuleNames.AddRange(new string[]
 		{
 			"AIModule",
+			"AnimGraphRuntime",
 			"AnimationWarpingRuntime",
 			"AssetRegistry",
 			"Core",

--- a/Source/SurvivalRpgEditor/Private/Animation/AnimGraphNode_RpgFootPlacement.cpp
+++ b/Source/SurvivalRpgEditor/Private/Animation/AnimGraphNode_RpgFootPlacement.cpp
@@ -1,0 +1,42 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+#include "Animation/AnimGraphNode_RpgFootPlacement.h"
+
+#include "Kismet2/CompilerResultsLog.h"
+
+#include UE_INLINE_GENERATED_CPP_BY_NAME(AnimGraphNode_RpgFootPlacement)
+
+#define LOCTEXT_NAMESPACE "RpgAnimGraphNodes"
+
+FText UAnimGraphNode_RpgFootPlacement::GetNodeTitle(ENodeTitleType::Type TitleType) const
+{
+	return GetControllerDescription();
+}
+
+FText UAnimGraphNode_RpgFootPlacement::GetTooltipText() const
+{
+	return LOCTEXT(
+		"RpgFootPlacementTooltip",
+		"Moves pelvis and IK-foot targets from a pointer-free game-thread snapshot. "
+		"This node performs no traces or gameplay-object access during parallel evaluation.");
+}
+
+void UAnimGraphNode_RpgFootPlacement::ValidateAnimNodeDuringCompilation(
+	USkeleton* ForSkeleton,
+	FCompilerResultsLog& MessageLog)
+{
+	if (Node.LegsDefinition.Num() != 2)
+	{
+		MessageLog.Error(
+			*LOCTEXT("RpgFootPlacementNeedsTwoLegs", "@@ requires exactly two leg definitions.").ToString(),
+			this);
+	}
+	Super::ValidateAnimNodeDuringCompilation(ForSkeleton, MessageLog);
+}
+
+FText UAnimGraphNode_RpgFootPlacement::GetControllerDescription() const
+{
+	return LOCTEXT("RpgFootPlacement", "RPG Foot Placement (Thread Safe)");
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/SurvivalRpgEditor/Private/Animation/RpgFootPlacementRuntimeTests.cpp
+++ b/Source/SurvivalRpgEditor/Private/Animation/RpgFootPlacementRuntimeTests.cpp
@@ -7,6 +7,7 @@
 #include "Misc/AutomationTest.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
+#include "SurvivalRpg/Animation/AnimNode_RpgFootPlacement.h"
 #include "SurvivalRpg/Animation/RpgFootPlacementTypes.h"
 #include "UObject/UnrealType.h"
 
@@ -51,12 +52,10 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 bool FRpgFootPlacementPlantPolicyTest::RunTest(const FString& Parameters)
 {
 	FRpgFootPlacementSettings Settings;
-	Settings.PlantSpeedThreshold = 60.0f;
-	Settings.PlantDistanceThreshold = 10.0f;
-	Settings.UnplantRadius = 35.0f;
-	Settings.ReplantRadiusRatio = 0.35f;
-	Settings.UnplantAngle = 45.0f;
-	Settings.ReplantAngleRatio = 0.5f;
+	TestEqual(TEXT("The GASP lock releases outside 20 cm"), Settings.UnplantRadius, 20.0f);
+	TestEqual(TEXT("The GASP lock replants inside 20 percent of its radius"), Settings.ReplantRadiusRatio, 0.2f);
+	TestEqual(TEXT("The GASP lock tolerates a 60-degree angular deviation"), Settings.UnplantAngle, 60.0f);
+	TestEqual(TEXT("The GASP angular replant bound is 20 percent"), Settings.ReplantAngleRatio, 0.2f);
 
 	TestEqual(
 		TEXT("Full GASP contact maps to zero pseudo-speed"),
@@ -97,25 +96,25 @@ bool FRpgFootPlacementPlantPolicyTest::RunTest(const FString& Parameters)
 
 	TestFalse(
 		TEXT("An existing lock remains planted at all three inclusive boundaries"),
-		RpgFootPlacement::ShouldUnplantFoot(60.0f, 35.0f, 45.0f, Settings));
+		RpgFootPlacement::ShouldUnplantFoot(60.0f, 20.0f, 60.0f, Settings));
 	TestTrue(
 		TEXT("Foot speed independently releases an existing lock"),
 		RpgFootPlacement::ShouldUnplantFoot(60.01f, 0.0f, 0.0f, Settings));
 	TestTrue(
 		TEXT("Anchor drift independently releases an existing lock"),
-		RpgFootPlacement::ShouldUnplantFoot(0.0f, 35.01f, 0.0f, Settings));
+		RpgFootPlacement::ShouldUnplantFoot(0.0f, 20.01f, 0.0f, Settings));
 	TestTrue(
 		TEXT("Ground-normal change independently releases an existing lock"),
-		RpgFootPlacement::ShouldUnplantFoot(0.0f, 0.0f, 45.01f, Settings));
+		RpgFootPlacement::ShouldUnplantFoot(0.0f, 0.0f, 60.01f, Settings));
 	TestTrue(
 		TEXT("A released lock replants inside the tighter radius and angle bounds"),
-		RpgFootPlacement::ShouldReplantFoot(12.25f, 22.5f, Settings));
+		RpgFootPlacement::ShouldReplantFoot(4.0f, 12.0f, Settings));
 	TestFalse(
 		TEXT("A released lock remains unplanted outside the replant radius"),
-		RpgFootPlacement::ShouldReplantFoot(12.26f, 0.0f, Settings));
+		RpgFootPlacement::ShouldReplantFoot(4.01f, 0.0f, Settings));
 	TestFalse(
 		TEXT("A released lock remains unplanted outside the replant angle"),
-		RpgFootPlacement::ShouldReplantFoot(0.0f, 22.51f, Settings));
+		RpgFootPlacement::ShouldReplantFoot(0.0f, 12.01f, Settings));
 	return true;
 }
 
@@ -169,6 +168,107 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 
 bool FRpgFootPlacementGroundAlignmentTest::RunTest(const FString& Parameters)
 {
+	const FTransform FKFootTransform(
+		FQuat(FVector::UpVector, FMath::DegreesToRadians(20.0f)),
+		FVector(100.0f, 50.0f, 20.0f));
+	const FTransform AuthoredFootToBall(
+		FQuat(FVector::RightVector, FMath::DegreesToRadians(15.0f)),
+		FVector(12.0f, 3.0f, -8.0f));
+	const FTransform AuthoredBallTransform = AuthoredFootToBall * FKFootTransform;
+	const FTransform IKFootTransform(
+		FQuat(FVector::UpVector, FMath::DegreesToRadians(-35.0f)),
+		FVector(-25.0f, 80.0f, 30.0f));
+	const FTransform DerivedIKBall = RpgFootPlacement::DeriveIKBallTransform(
+		FKFootTransform,
+		AuthoredBallTransform,
+		IKFootTransform);
+	TestTrue(
+		TEXT("The IK ball uses Stock FootPlacement's FootToBall-times-IKFoot order"),
+		DerivedIKBall.Equals(AuthoredFootToBall * IKFootTransform, 0.001f));
+	TestTrue(
+		TEXT("The IK ball preserves the authored FK-foot-to-ball relationship"),
+		DerivedIKBall.GetRelativeTransform(IKFootTransform).Equals(AuthoredFootToBall, 0.001f));
+	TestFalse(
+		TEXT("The derived IK ball does not reuse the unrelated FK ball world transform"),
+		DerivedIKBall.Equals(AuthoredBallTransform, 0.001f));
+	const FTransform LockedFootTransform(
+		FQuat(FVector::UpVector, FMath::DegreesToRadians(60.0f)),
+		FVector(40.0f, -30.0f, 15.0f));
+	const FTransform PivotedFoot = RpgFootPlacement::PivotFootAroundBall(
+		IKFootTransform,
+		DerivedIKBall,
+		LockedFootTransform);
+	const FTransform CurrentFootToBall = DerivedIKBall.GetRelativeTransform(IKFootTransform);
+	const FTransform CurrentBallToFoot = IKFootTransform.GetRelativeTransform(DerivedIKBall);
+	const FTransform LockedBallTransform = CurrentFootToBall * LockedFootTransform;
+	const FTransform ExpectedPinnedBallTransform(
+		DerivedIKBall.GetRotation(),
+		LockedBallTransform.GetLocation(),
+		DerivedIKBall.GetScale3D());
+	TestTrue(
+		TEXT("Pivot locking uses Stock FootPlacement's BallToFoot-times-PinnedBall order"),
+		PivotedFoot.Equals(CurrentBallToFoot * ExpectedPinnedBallTransform, 0.001f));
+	TestTrue(
+		TEXT("Pivot locking retains the ball location represented by the planted foot"),
+		(CurrentFootToBall * PivotedFoot).GetLocation().Equals(
+			(CurrentFootToBall * LockedFootTransform).GetLocation(),
+			0.001f));
+	TestFalse(
+		TEXT("Pivot locking does not freeze the complete planted ankle transform"),
+		PivotedFoot.GetRotation().Equals(LockedFootTransform.GetRotation(), 0.001f));
+
+	FAnimNode_RpgFootPlacement RuntimeNode;
+	TestEqual(TEXT("The worker raw-pose ball gate uses GASP's ten-centimeter bound"), RuntimeNode.PlantDistanceThreshold, 10.0f);
+	TestEqual(TEXT("The worker raw-pose lock gate uses GASP's twenty-centimeter bound"), RuntimeNode.UnplantRadius, 20.0f);
+	TestEqual(
+		TEXT("Raw geometry is fully weighted inside both inner bounds"),
+		RpgFootPlacement::CalculateGeometryWeight(5.0f, 10.0f, true, 10.0f, 20.0f),
+		1.0f);
+	TestTrue(
+		TEXT("Raw geometry fades smoothly through both outer halves"),
+		FMath::IsNearlyEqual(
+			RpgFootPlacement::CalculateGeometryWeight(7.5f, 15.0f, true, 10.0f, 20.0f),
+			0.25f,
+			0.001f));
+	TestEqual(
+		TEXT("The exact ball-distance limit suppresses placement"),
+		RpgFootPlacement::CalculateGeometryWeight(10.0f, 0.0f, false, 10.0f, 20.0f),
+		0.0f);
+	TestEqual(
+		TEXT("Ball distance outside the limit suppresses placement even without a lock"),
+		RpgFootPlacement::CalculateGeometryWeight(-10.01f, 0.0f, false, 10.0f, 20.0f),
+		0.0f);
+	TestEqual(
+		TEXT("The exact planar lock-drift limit suppresses a lock"),
+		RpgFootPlacement::CalculateGeometryWeight(0.0f, 20.0f, true, 10.0f, 20.0f),
+		0.0f);
+	TestEqual(
+		TEXT("Planar drift is deliberately ignored for an unlocked foot"),
+		RpgFootPlacement::CalculateGeometryWeight(0.0f, 200.0f, false, 10.0f, 20.0f),
+		1.0f);
+
+	float MaximumFlatGroundCorrection = 0.0f;
+	for (int32 SampleIndex = 0; SampleIndex <= 100; ++SampleIndex)
+	{
+		const float BallHeight = static_cast<float>(SampleIndex) * 0.1f;
+		const float GeometryWeight = RpgFootPlacement::CalculateGeometryWeight(
+			BallHeight,
+			0.0f,
+			false,
+			10.0f,
+			20.0f);
+		MaximumFlatGroundCorrection = FMath::Max(
+			MaximumFlatGroundCorrection,
+			BallHeight * GeometryWeight);
+	}
+	TestTrue(
+		TEXT("The same-frame gate bounds the flat-ground pelvis contribution below 5.5 cm"),
+		MaximumFlatGroundCorrection <= 5.5f);
+	TestEqual(
+		TEXT("A lifted raw foot outside the ten-centimeter bound cannot affect IK or pelvis"),
+		RpgFootPlacement::CalculateGeometryWeight(15.0f, 0.0f, false, 10.0f, 20.0f),
+		0.0f);
+
 	const FTransform FlatIKTransform(FQuat::Identity, FVector(0.0f, 0.0f, 20.0f));
 	const FTransform FlatBallTransform(FQuat::Identity, FVector(10.0f, 0.0f, 10.0f));
 	const FTransform FlatResult = RpgFootPlacement::AlignFootToGroundPlane(
@@ -251,6 +351,108 @@ bool FRpgFootPlacementGroundAlignmentTest::RunTest(const FString& Parameters)
 }
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FRpgFootPlacementNeutralIKTargetTest,
+	"SurvivalRpg.Animation.FootPlacement.Runtime.NeutralIKTarget",
+	EAutomationTestFlags::EditorContext |
+		EAutomationTestFlags::EngineFilter)
+
+bool FRpgFootPlacementNeutralIKTargetTest::RunTest(const FString& Parameters)
+{
+	const FTransform LeftFKTransform(
+		FQuat(FVector::UpVector, FMath::DegreesToRadians(10.0f)),
+		FVector(-20.0f, -12.0f, 18.0f));
+	const FTransform LeftProceduralTarget(
+		FQuat(FVector::UpVector, FMath::DegreesToRadians(35.0f)),
+		FVector(-5.0f, -12.0f, 8.0f));
+	const FTransform RightFKTransform(
+		FQuat(FVector::UpVector, FMath::DegreesToRadians(-15.0f)),
+		FVector(30.0f, 12.0f, 20.0f));
+	const FTransform RightProceduralTarget(
+		FQuat(FVector::UpVector, FMath::DegreesToRadians(-40.0f)),
+		FVector(45.0f, 12.0f, 10.0f));
+
+	const float NoGroundWeight = RpgFootPlacement::CalculateEffectivePlacementWeight(
+		false,
+		1.0f,
+		1.0f);
+	const float ZeroSnapshotWeight = RpgFootPlacement::CalculateEffectivePlacementWeight(
+		true,
+		0.0f,
+		1.0f);
+	const float ZeroGeometryWeight = RpgFootPlacement::CalculateEffectivePlacementWeight(
+		true,
+		1.0f,
+		0.0f);
+	TestEqual(TEXT("No ground disables only the procedural correction"), NoGroundWeight, 0.0f);
+	TestEqual(TEXT("A zero snapshot weight disables only the procedural correction"), ZeroSnapshotWeight, 0.0f);
+	TestEqual(TEXT("A zero raw-pose gate disables only the procedural correction"), ZeroGeometryWeight, 0.0f);
+	TestTrue(
+		TEXT("No ground writes the same-frame FK ankle instead of retaining raw IK"),
+		RpgFootPlacement::ResolveIKFootTarget(
+			LeftFKTransform,
+			LeftProceduralTarget,
+			NoGroundWeight).Equals(LeftFKTransform, 0.001f));
+	TestTrue(
+		TEXT("A zero snapshot weight writes the same-frame FK ankle"),
+		RpgFootPlacement::ResolveIKFootTarget(
+			LeftFKTransform,
+			LeftProceduralTarget,
+			ZeroSnapshotWeight).Equals(LeftFKTransform, 0.001f));
+	TestTrue(
+		TEXT("A zero geometry weight writes the same-frame FK ankle"),
+		RpgFootPlacement::ResolveIKFootTarget(
+			LeftFKTransform,
+			LeftProceduralTarget,
+			ZeroGeometryWeight).Equals(LeftFKTransform, 0.001f));
+
+	const float LeftWeight = RpgFootPlacement::CalculateEffectivePlacementWeight(true, 0.0f, 1.0f);
+	const float RightWeight = RpgFootPlacement::CalculateEffectivePlacementWeight(true, 1.0f, 1.0f);
+	const FTransform LeftResult = RpgFootPlacement::ResolveIKFootTarget(
+		LeftFKTransform,
+		LeftProceduralTarget,
+		LeftWeight);
+	const FTransform RightResult = RpgFootPlacement::ResolveIKFootTarget(
+		RightFKTransform,
+		RightProceduralTarget,
+		RightWeight);
+	TestTrue(
+		TEXT("The left swing leg independently follows its FK ankle"),
+		LeftResult.Equals(LeftFKTransform, 0.001f));
+	TestTrue(
+		TEXT("The right planted leg independently reaches its procedural target"),
+		RightResult.Equals(RightProceduralTarget, 0.001f));
+
+	const FTransform StaticInputIK(FQuat::Identity, FVector(0.0f, 0.0f, 10.0f));
+	const FTransform LiftedFKFoot(FQuat::Identity, FVector(40.0f, 0.0f, 25.0f));
+	const FTransform LiftedAuthoredBall(FQuat::Identity, FVector(50.0f, 0.0f, 15.0f));
+	const float LiftedBallGeometryWeight = RpgFootPlacement::CalculateGeometryWeight(
+		LiftedAuthoredBall.GetLocation().Z,
+		0.0f,
+		true,
+		10.0f,
+		20.0f);
+	const float LiftedBallEffectiveWeight = RpgFootPlacement::CalculateEffectivePlacementWeight(
+		true,
+		1.0f,
+		LiftedBallGeometryWeight);
+	const FTransform LiftedResult = RpgFootPlacement::ResolveIKFootTarget(
+		LiftedFKFoot,
+		StaticInputIK,
+		LiftedBallEffectiveWeight);
+	TestEqual(
+		TEXT("A lifted authored FK ball outside the ten-centimeter gate has zero procedural weight"),
+		LiftedBallGeometryWeight,
+		0.0f);
+	TestTrue(
+		TEXT("A static input IK track cannot pin an FK swing foot after the geometry gate releases"),
+		LiftedResult.Equals(LiftedFKFoot, 0.001f));
+	TestFalse(
+		TEXT("The released swing foot does not retain the unrelated static input IK target"),
+		LiftedResult.Equals(StaticInputIK, 0.001f));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 	FRpgFootPlacementPelvisAndSnapshotPodTest,
 	"SurvivalRpg.Animation.FootPlacement.Runtime.PelvisAndSnapshotPod",
 	EAutomationTestFlags::EditorContext |
@@ -258,6 +460,16 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 
 bool FRpgFootPlacementPelvisAndSnapshotPodTest::RunTest(const FString& Parameters)
 {
+	const FStructProperty* FKFootBoneProperty = FindFProperty<FStructProperty>(
+		FRpgFootPlacementNodeLegDefinition::StaticStruct(),
+		GET_MEMBER_NAME_CHECKED(FRpgFootPlacementNodeLegDefinition, FKFootBone));
+	if (TestNotNull(TEXT("The AnyThread leg definition exposes its authored FK foot"), FKFootBoneProperty))
+	{
+		TestTrue(
+			TEXT("The FK foot contract uses Unreal's bone-reference value type"),
+			FKFootBoneProperty->Struct == FBoneReference::StaticStruct());
+	}
+
 	TestTrue(
 		TEXT("The lower requested foot drives the pelvis downward"),
 		FMath::IsNearlyEqual(RpgFootPlacement::CalculatePelvisOffset(-12.0f, -4.0f, 50.0f), -12.0f));
@@ -270,6 +482,30 @@ bool FRpgFootPlacementPelvisAndSnapshotPodTest::RunTest(const FString& Parameter
 	TestTrue(
 		TEXT("A negative maximum is treated as zero correction"),
 		FMath::IsNearlyZero(RpgFootPlacement::CalculatePelvisOffset(-10.0f, -20.0f, -1.0f)));
+	TestTrue(
+		TEXT("Pelvis smoothing does not advance without elapsed update time"),
+		FMath::IsNearlyZero(RpgFootPlacement::SmoothPelvisOffset(0.0f, -50.0f, 0.0f, 0.08f, 120.0f)));
+	TestTrue(
+		TEXT("Pelvis smoothing obeys its hard speed bound on a large target step"),
+		FMath::IsNearlyEqual(
+			RpgFootPlacement::SmoothPelvisOffset(0.0f, -50.0f, 1.0f / 20.0f, 0.08f, 120.0f),
+			-6.0f,
+			0.001f));
+	TestTrue(
+		TEXT("Pelvis smoothing is monotonic toward a reachable target"),
+		RpgFootPlacement::SmoothPelvisOffset(-10.0f, -20.0f, 1.0f / 60.0f, 0.08f, 120.0f) < -10.0f);
+	const float RecoveredPelvisOffset = RpgFootPlacement::SmoothPelvisOffset(
+		-12.0f,
+		0.0f,
+		1.0f / 60.0f,
+		0.08f,
+		120.0f);
+	TestTrue(
+		TEXT("Pelvis recovery toward zero is gradual instead of an upward pop"),
+		RecoveredPelvisOffset > -12.0f && RecoveredPelvisOffset < 0.0f);
+	TestTrue(
+		TEXT("Pelvis recovery obeys the configured 120 cm/s speed bound"),
+		RecoveredPelvisOffset + 12.0f <= 120.0f / 60.0f + UE_SMALL_NUMBER);
 
 	auto ValidateValueOnlyStruct = [this](UScriptStruct* ScriptStruct, bool bAllowLegSnapshot)
 	{
@@ -345,6 +581,7 @@ bool FRpgFootPlacementAnyThreadSourceContractTest::RunTest(const FString& Parame
 		TEXT("GetSocketTransform"),
 		TEXT("GetBoneTransform"),
 		TEXT("GetBoneLocation"),
+		TEXT("GetComponentSpaceTransform(IKFootIndex)"),
 		TEXT("CurrentFloor"),
 		TEXT("SweepSingle"),
 		TEXT("LineTrace"),

--- a/Source/SurvivalRpgEditor/Private/Animation/RpgFootPlacementRuntimeTests.cpp
+++ b/Source/SurvivalRpgEditor/Private/Animation/RpgFootPlacementRuntimeTests.cpp
@@ -1,0 +1,385 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+#include "CoreMinimal.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Misc/AutomationTest.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "SurvivalRpg/Animation/RpgFootPlacementTypes.h"
+#include "UObject/UnrealType.h"
+
+namespace RpgFootPlacementRuntimeTests
+{
+	bool IsSnapshotValueProperty(const FProperty* Property, bool bAllowLegSnapshot)
+	{
+		if (CastField<FBoolProperty>(Property) || CastField<FNumericProperty>(Property))
+		{
+			return true;
+		}
+
+		const FStructProperty* StructProperty = CastField<FStructProperty>(Property);
+		if (!StructProperty)
+		{
+			return false;
+		}
+
+		const UScriptStruct* ValueStruct = StructProperty->Struct;
+		return ValueStruct == TBaseStructure<FVector>::Get() ||
+			ValueStruct == TBaseStructure<FQuat>::Get() ||
+			ValueStruct == TBaseStructure<FTransform>::Get() ||
+			(bAllowLegSnapshot && ValueStruct == FRpgFootPlacementLegSnapshot::StaticStruct());
+	}
+
+	float AngleBetweenDegrees(const FVector& First, const FVector& Second)
+	{
+		const float CosAngle = FMath::Clamp(
+			FVector::DotProduct(First.GetSafeNormal(), Second.GetSafeNormal()),
+			-1.0f,
+			1.0f);
+		return FMath::RadiansToDegrees(FMath::Acos(CosAngle));
+	}
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FRpgFootPlacementPlantPolicyTest,
+	"SurvivalRpg.Animation.FootPlacement.Runtime.PlantPolicy",
+	EAutomationTestFlags::EditorContext |
+		EAutomationTestFlags::EngineFilter)
+
+bool FRpgFootPlacementPlantPolicyTest::RunTest(const FString& Parameters)
+{
+	FRpgFootPlacementSettings Settings;
+	Settings.PlantSpeedThreshold = 60.0f;
+	Settings.PlantDistanceThreshold = 10.0f;
+	Settings.UnplantRadius = 35.0f;
+	Settings.ReplantRadiusRatio = 0.35f;
+	Settings.UnplantAngle = 45.0f;
+	Settings.ReplantAngleRatio = 0.5f;
+
+	TestEqual(
+		TEXT("Full GASP contact maps to zero pseudo-speed"),
+		RpgFootPlacement::ConvertContactCurveToSpeed(1.0f),
+		0.0f);
+	TestEqual(
+		TEXT("No GASP contact maps to 100 cm/s pseudo-speed"),
+		RpgFootPlacement::ConvertContactCurveToSpeed(0.0f),
+		100.0f);
+	TestEqual(
+		TEXT("Alignment is full at the plant-speed threshold"),
+		RpgFootPlacement::CalculateAlignmentAlpha(60.0f, Settings),
+		1.0f);
+	TestEqual(
+		TEXT("Alignment is released at the configured upper threshold"),
+		RpgFootPlacement::CalculateAlignmentAlpha(200.0f, Settings),
+		0.0f);
+	TestEqual(
+		TEXT("Alignment interpolates through the roll phase"),
+		RpgFootPlacement::CalculateAlignmentAlpha(130.0f, Settings),
+		0.5f);
+
+	TestFalse(
+		TEXT("A missing walkable surface cannot establish a plant lock"),
+		RpgFootPlacement::ShouldPlantFoot(false, 0.0f, 0.0f, Settings));
+	TestTrue(
+		TEXT("The exact speed and positive distance boundaries may establish a plant lock"),
+		RpgFootPlacement::ShouldPlantFoot(true, 60.0f, 10.0f, Settings));
+	TestTrue(
+		TEXT("The signed ground distance uses the same inclusive plant boundary"),
+		RpgFootPlacement::ShouldPlantFoot(true, 60.0f, -10.0f, Settings));
+	TestFalse(
+		TEXT("Speed above the plant threshold cannot establish a lock"),
+		RpgFootPlacement::ShouldPlantFoot(true, 60.01f, 0.0f, Settings));
+	TestFalse(
+		TEXT("A foot outside the plant distance cannot establish a lock"),
+		RpgFootPlacement::ShouldPlantFoot(true, 0.0f, 10.01f, Settings));
+
+	TestFalse(
+		TEXT("An existing lock remains planted at all three inclusive boundaries"),
+		RpgFootPlacement::ShouldUnplantFoot(60.0f, 35.0f, 45.0f, Settings));
+	TestTrue(
+		TEXT("Foot speed independently releases an existing lock"),
+		RpgFootPlacement::ShouldUnplantFoot(60.01f, 0.0f, 0.0f, Settings));
+	TestTrue(
+		TEXT("Anchor drift independently releases an existing lock"),
+		RpgFootPlacement::ShouldUnplantFoot(0.0f, 35.01f, 0.0f, Settings));
+	TestTrue(
+		TEXT("Ground-normal change independently releases an existing lock"),
+		RpgFootPlacement::ShouldUnplantFoot(0.0f, 0.0f, 45.01f, Settings));
+	TestTrue(
+		TEXT("A released lock replants inside the tighter radius and angle bounds"),
+		RpgFootPlacement::ShouldReplantFoot(12.25f, 22.5f, Settings));
+	TestFalse(
+		TEXT("A released lock remains unplanted outside the replant radius"),
+		RpgFootPlacement::ShouldReplantFoot(12.26f, 0.0f, Settings));
+	TestFalse(
+		TEXT("A released lock remains unplanted outside the replant angle"),
+		RpgFootPlacement::ShouldReplantFoot(0.0f, 22.51f, Settings));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FRpgFootPlacementHalfLifeTest,
+	"SurvivalRpg.Animation.FootPlacement.Runtime.HalfLife",
+	EAutomationTestFlags::EditorContext |
+		EAutomationTestFlags::EngineFilter)
+
+bool FRpgFootPlacementHalfLifeTest::RunTest(const FString& Parameters)
+{
+	TestTrue(
+		TEXT("A zero delta produces no interpolation"),
+		FMath::IsNearlyZero(RpgFootPlacement::CalculateHalfLifeAlpha(0.0f, 1.0f)));
+	TestTrue(
+		TEXT("A negative delta produces no interpolation"),
+		FMath::IsNearlyZero(RpgFootPlacement::CalculateHalfLifeAlpha(-0.1f, 1.0f)));
+	TestTrue(
+		TEXT("A non-positive half-life completes immediately for a positive delta"),
+		FMath::IsNearlyEqual(RpgFootPlacement::CalculateHalfLifeAlpha(0.1f, 0.0f), 1.0f));
+	TestTrue(
+		TEXT("One half-life covers exactly half the remaining distance"),
+		FMath::IsNearlyEqual(RpgFootPlacement::CalculateHalfLifeAlpha(1.0f, 1.0f), 0.5f));
+	TestTrue(
+		TEXT("Two half-lives cover three quarters of the remaining distance"),
+		FMath::IsNearlyEqual(RpgFootPlacement::CalculateHalfLifeAlpha(2.0f, 1.0f), 0.75f));
+
+	const float FrameRates[] = {20.0f, 60.0f, 120.0f};
+	for (const float FrameRate : FrameRates)
+	{
+		const float DeltaSeconds = 1.0f / FrameRate;
+		const float Alpha = RpgFootPlacement::CalculateHalfLifeAlpha(DeltaSeconds, 1.0f);
+		float Value = 0.0f;
+		for (int32 Frame = 0; Frame < FMath::RoundToInt(FrameRate); ++Frame)
+		{
+			Value = FMath::Lerp(Value, 1.0f, Alpha);
+		}
+
+		TestTrue(
+			FString::Printf(TEXT("One elapsed half-life reaches 0.5 at %.0f FPS"), FrameRate),
+			FMath::IsNearlyEqual(Value, 0.5f, 0.0001f));
+	}
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FRpgFootPlacementGroundAlignmentTest,
+	"SurvivalRpg.Animation.FootPlacement.Runtime.FlatAndSlopeAlignment",
+	EAutomationTestFlags::EditorContext |
+		EAutomationTestFlags::EngineFilter)
+
+bool FRpgFootPlacementGroundAlignmentTest::RunTest(const FString& Parameters)
+{
+	const FTransform FlatIKTransform(FQuat::Identity, FVector(0.0f, 0.0f, 20.0f));
+	const FTransform FlatBallTransform(FQuat::Identity, FVector(10.0f, 0.0f, 10.0f));
+	const FTransform FlatResult = RpgFootPlacement::AlignFootToGroundPlane(
+		FlatIKTransform,
+		FlatBallTransform,
+		FVector::ZeroVector,
+		FVector::UpVector,
+		FVector::UpVector,
+		50.0f,
+		45.0f);
+	TestTrue(
+		TEXT("A flat plane projects the ball down while preserving its IK-to-ball offset"),
+		FlatResult.GetLocation().Equals(FVector(0.0f, 0.0f, 10.0f), 0.001f));
+	TestTrue(
+		TEXT("A flat plane preserves the authored foot rotation"),
+		FlatResult.GetRotation().Equals(FQuat::Identity, 0.001f));
+
+	const FVector ThirtyDegreeNormal(0.0f, 0.5f, FMath::Sqrt(3.0f) * 0.5f);
+	const FTransform SlopeIKTransform(FQuat::Identity, FVector(0.0f, 0.0f, 10.0f));
+	const FTransform SlopeBallTransform = FTransform::Identity;
+	const FTransform SlopeResult = RpgFootPlacement::AlignFootToGroundPlane(
+		SlopeIKTransform,
+		SlopeBallTransform,
+		FVector::ZeroVector,
+		ThirtyDegreeNormal,
+		FVector::UpVector,
+		50.0f,
+		45.0f);
+	const FVector SlopeUp = SlopeResult.GetRotation().RotateVector(FVector::UpVector);
+	TestTrue(
+		TEXT("A slope inside the rotation limit aligns the foot up axis to the plane normal"),
+		SlopeUp.Equals(ThirtyDegreeNormal, 0.001f));
+	TestTrue(
+		TEXT("Slope alignment rotates the IK-to-ball offset around the projected ball"),
+		SlopeResult.GetLocation().Equals(ThirtyDegreeNormal * 10.0f, 0.001f));
+
+	const FTransform ClampedSlopeResult = RpgFootPlacement::AlignFootToGroundPlane(
+		SlopeIKTransform,
+		SlopeBallTransform,
+		FVector::ZeroVector,
+		ThirtyDegreeNormal,
+		FVector::UpVector,
+		2.0f,
+		15.0f);
+	const float ClampedRotationDegrees = RpgFootPlacementRuntimeTests::AngleBetweenDegrees(
+		FVector::UpVector,
+		ClampedSlopeResult.GetRotation().RotateVector(FVector::UpVector));
+	TestTrue(
+		TEXT("Slope rotation respects the configured angular bound"),
+		FMath::IsNearlyEqual(ClampedRotationDegrees, 15.0f, 0.01f));
+	TestTrue(
+		TEXT("Slope translation respects the configured distance bound"),
+		FMath::IsNearlyEqual(
+			FVector::Distance(ClampedSlopeResult.GetLocation(), SlopeIKTransform.GetLocation()),
+			2.0f,
+			0.001f));
+
+	const FTransform PreviousBase(
+		FQuat::Identity,
+		FVector(100.0f, 0.0f, 0.0f));
+	const FTransform CurrentBase(
+		FQuat(FVector::UpVector, FMath::DegreesToRadians(90.0f)),
+		FVector(120.0f, 10.0f, 0.0f));
+	const FVector SurfacePoint(110.0f, 0.0f, 5.0f);
+	const FVector RebasedPoint = RpgFootPlacement::RebasePointThroughSurface(
+		SurfacePoint,
+		PreviousBase,
+		CurrentBase);
+	TestTrue(
+		TEXT("A surface-local point follows both moving-base translation and rotation around its pivot"),
+		RebasedPoint.Equals(FVector(120.0f, 20.0f, 5.0f), 0.001f));
+	const FVector RebasedNormal = RpgFootPlacement::RebaseNormalThroughSurface(
+		FVector::ForwardVector,
+		PreviousBase,
+		CurrentBase);
+	TestTrue(
+		TEXT("A surface-local normal follows moving-base rotation without translation"),
+		RebasedNormal.Equals(FVector::RightVector, 0.001f));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FRpgFootPlacementPelvisAndSnapshotPodTest,
+	"SurvivalRpg.Animation.FootPlacement.Runtime.PelvisAndSnapshotPod",
+	EAutomationTestFlags::EditorContext |
+		EAutomationTestFlags::EngineFilter)
+
+bool FRpgFootPlacementPelvisAndSnapshotPodTest::RunTest(const FString& Parameters)
+{
+	TestTrue(
+		TEXT("The lower requested foot drives the pelvis downward"),
+		FMath::IsNearlyEqual(RpgFootPlacement::CalculatePelvisOffset(-12.0f, -4.0f, 50.0f), -12.0f));
+	TestTrue(
+		TEXT("The pelvis offset is bounded by the maximum downward correction"),
+		FMath::IsNearlyEqual(RpgFootPlacement::CalculatePelvisOffset(-80.0f, -20.0f, 50.0f), -50.0f));
+	TestTrue(
+		TEXT("Positive foot offsets never pull the pelvis upward"),
+		FMath::IsNearlyZero(RpgFootPlacement::CalculatePelvisOffset(5.0f, 12.0f, 50.0f)));
+	TestTrue(
+		TEXT("A negative maximum is treated as zero correction"),
+		FMath::IsNearlyZero(RpgFootPlacement::CalculatePelvisOffset(-10.0f, -20.0f, -1.0f)));
+
+	auto ValidateValueOnlyStruct = [this](UScriptStruct* ScriptStruct, bool bAllowLegSnapshot)
+	{
+		int32 ReflectedPropertyCount = 0;
+		for (TFieldIterator<FProperty> PropertyIt(ScriptStruct); PropertyIt; ++PropertyIt)
+		{
+			++ReflectedPropertyCount;
+			const FProperty* Property = *PropertyIt;
+			TestTrue(
+				FString::Printf(
+					TEXT("%s.%s is a pointer-free scalar or approved math/value struct"),
+					*ScriptStruct->GetName(),
+					*Property->GetName()),
+				RpgFootPlacementRuntimeTests::IsSnapshotValueProperty(Property, bAllowLegSnapshot));
+		}
+		TestTrue(
+			FString::Printf(TEXT("%s exposes reflected snapshot fields"), *ScriptStruct->GetName()),
+			ReflectedPropertyCount > 0);
+	};
+
+	ValidateValueOnlyStruct(FRpgFootPlacementLegSnapshot::StaticStruct(), false);
+	ValidateValueOnlyStruct(FRpgFootPlacementSnapshot::StaticStruct(), true);
+
+	FRpgFootPlacementSnapshot Snapshot;
+	TestTrue(TEXT("A fresh snapshot requests a reset before its first valid sample"), Snapshot.bReset);
+	TestFalse(TEXT("A fresh snapshot is not consumable by AnyThread evaluation"), Snapshot.bValid);
+	TestTrue(
+		TEXT("A fresh snapshot carries safe normalized fallback normals"),
+		Snapshot.FloorNormalWorld.Equals(FVector::UpVector) &&
+			Snapshot.LeftFoot.GroundNormalWorld.Equals(FVector::UpVector) &&
+			Snapshot.RightFoot.GroundNormalWorld.Equals(FVector::UpVector));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FRpgFootPlacementAnyThreadSourceContractTest,
+	"SurvivalRpg.Animation.FootPlacement.Runtime.AnyThreadSourceContract",
+	EAutomationTestFlags::EditorContext |
+		EAutomationTestFlags::EngineFilter)
+
+bool FRpgFootPlacementAnyThreadSourceContractTest::RunTest(const FString& Parameters)
+{
+	const TCHAR* SourceFiles[] = {
+		TEXT("SurvivalRpg/Animation/AnimNode_RpgFootPlacement.h"),
+		TEXT("SurvivalRpg/Animation/AnimNode_RpgFootPlacement.cpp"),
+		TEXT("SurvivalRpg/Animation/RpgFootPlacementTypes.cpp"),
+	};
+	const TCHAR* BannedTokens[] = {
+		TEXT("Engine/World.h"),
+		TEXT("GameFramework/Character.h"),
+		TEXT("GameFramework/CharacterMovementComponent.h"),
+		TEXT("Components/SkeletalMeshComponent.h"),
+		TEXT("UWorld"),
+		TEXT("AActor"),
+		TEXT("UCharacterMovementComponent"),
+		TEXT("USkeletalMeshComponent"),
+		TEXT("UObject*"),
+		TEXT("TObjectPtr"),
+		TEXT("TWeakObjectPtr"),
+		TEXT("FHitResult"),
+		TEXT("FCollisionQueryParams"),
+		TEXT("FCollisionShape"),
+		TEXT("GetWorld"),
+		TEXT("GetOwner"),
+		TEXT("GetOwningActor"),
+		TEXT("GetCharacterMovement"),
+		TEXT("GetMovementBase"),
+		TEXT("GetSkelMeshComponent"),
+		TEXT("GetAnimInstanceObject"),
+		TEXT("GetProxyOnAnyThread"),
+		TEXT("GetProxyOnGameThread"),
+		TEXT("GetComponentTransform"),
+		TEXT("GetSocketTransform"),
+		TEXT("GetBoneTransform"),
+		TEXT("GetBoneLocation"),
+		TEXT("CurrentFloor"),
+		TEXT("SweepSingle"),
+		TEXT("LineTrace"),
+		TEXT("Output.AnimInstanceProxy"),
+	};
+
+	for (const TCHAR* RelativeSourceFile : SourceFiles)
+	{
+		const FString SourcePath = FPaths::Combine(FPaths::ProjectDir(), TEXT("Source"), RelativeSourceFile);
+		FString Source;
+		if (!TestTrue(
+			FString::Printf(TEXT("The AnyThread contract source exists: %s"), RelativeSourceFile),
+			FFileHelper::LoadFileToString(Source, *SourcePath)))
+		{
+			continue;
+		}
+
+		for (const TCHAR* BannedToken : BannedTokens)
+		{
+			TestFalse(
+				FString::Printf(
+					TEXT("%s does not use banned AnyThread token '%s'"),
+					RelativeSourceFile,
+					BannedToken),
+				Source.Contains(BannedToken, ESearchCase::CaseSensitive));
+		}
+
+		if (FCString::Strstr(RelativeSourceFile, TEXT("AnimNode_RpgFootPlacement.cpp")))
+		{
+			TestTrue(
+				TEXT("The audited implementation contains the worker-thread skeletal-control entry point"),
+				Source.Contains(TEXT("EvaluateSkeletalControl_AnyThread"), ESearchCase::CaseSensitive));
+		}
+	}
+	return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/Source/SurvivalRpgEditor/Private/Animation/RpgGaspLocomotionAssetTests.cpp
+++ b/Source/SurvivalRpgEditor/Private/Animation/RpgGaspLocomotionAssetTests.cpp
@@ -196,6 +196,12 @@ bool FRpgGaspLocomotionContentContractTest::RunTest(const FString& Parameters)
 		TestTrue(
 			*FString::Printf(TEXT("%s keeps normalized root-motion scale"), *Animation->GetName()),
 			Animation->bUseNormalizedRootMotionScale);
+		TestTrue(
+			*FString::Printf(TEXT("%s supplies the left Foot Placement contact curve"), *Animation->GetName()),
+			Animation->HasCurveData(TEXT("contact_l"), false));
+		TestTrue(
+			*FString::Printf(TEXT("%s supplies the right Foot Placement contact curve"), *Animation->GetName()),
+			Animation->HasCurveData(TEXT("contact_r"), false));
 
 		const TArray<UAssetUserData*>* AssetUserData = Animation->GetAssetUserDataArray();
 		TestTrue(

--- a/Source/SurvivalRpgEditor/Private/Animation/RpgGaspPilotAssetTests.cpp
+++ b/Source/SurvivalRpgEditor/Private/Animation/RpgGaspPilotAssetTests.cpp
@@ -1144,10 +1144,10 @@ bool FRpgGaspPilotAssetContractTest::RunTest(const FString& Parameters)
 			TestEqual(TEXT("Foot Placement plants below 60 cm/s"), FootPlacementSettings->PlantSpeedThreshold, 60.0f);
 			TestEqual(TEXT("Foot Placement bounds the contact-weighted roll phase at 200 cm/s"), FootPlacementSettings->UnalignmentSpeedThreshold, 200.0f);
 			TestEqual(TEXT("Foot Placement plants within ten centimeters"), FootPlacementSettings->PlantDistanceThreshold, 10.0f);
-			TestEqual(TEXT("Foot Placement releases outside GASP's 35-centimeter radius"), FootPlacementSettings->UnplantRadius, 35.0f);
-			TestEqual(TEXT("Foot Placement replants inside 35 percent of the release radius"), FootPlacementSettings->ReplantRadiusRatio, 0.35f);
-			TestEqual(TEXT("Foot Placement releases after GASP's 45-degree normal change"), FootPlacementSettings->UnplantAngle, 45.0f);
-			TestEqual(TEXT("Foot Placement replants inside half the release angle"), FootPlacementSettings->ReplantAngleRatio, 0.5f);
+			TestEqual(TEXT("Foot Placement releases outside GASP's 20-centimeter radius"), FootPlacementSettings->UnplantRadius, 20.0f);
+			TestEqual(TEXT("Foot Placement replants inside 20 percent of the release radius"), FootPlacementSettings->ReplantRadiusRatio, 0.2f);
+			TestEqual(TEXT("Foot Placement releases after GASP's 60-degree normal change"), FootPlacementSettings->UnplantAngle, 60.0f);
+			TestEqual(TEXT("Foot Placement replants inside 20 percent of the release angle"), FootPlacementSettings->ReplantAngleRatio, 0.2f);
 			TestEqual(TEXT("Foot Placement bounds locked-foot slope alignment to 60 degrees"), FootPlacementSettings->MaxFootAlignmentAngle, 60.0f);
 			TestEqual(TEXT("Foot Placement bounds locked-foot translation to 50 centimeters"), FootPlacementSettings->MaxFootTranslation, 50.0f);
 			TestEqual(TEXT("Foot Placement keeps a 0.1-second trace-miss grace period"), FootPlacementSettings->TraceMissGracePeriod, 0.10f);
@@ -1544,6 +1544,10 @@ bool FRpgGaspPilotAssetContractTest::RunTest(const FString& Parameters)
 			if (RpgFootPlacement->LegsDefinition.Num() == 2)
 			{
 				TestEqual(
+					TEXT("Foot Placement reads the authored left FK ankle first"),
+					RpgFootPlacement->LegsDefinition[0].FKFootBone.BoneName,
+					FName(TEXT("foot_l")));
+				TestEqual(
 					TEXT("Foot Placement drives the left IK foot first"),
 					RpgFootPlacement->LegsDefinition[0].IKFootBone.BoneName,
 					FName(TEXT("ik_foot_l")));
@@ -1551,6 +1555,10 @@ bool FRpgGaspPilotAssetContractTest::RunTest(const FString& Parameters)
 					TEXT("Foot Placement pivots the left target around ball_l"),
 					RpgFootPlacement->LegsDefinition[0].BallBone.BoneName,
 					FName(TEXT("ball_l")));
+				TestEqual(
+					TEXT("Foot Placement reads the authored right FK ankle second"),
+					RpgFootPlacement->LegsDefinition[1].FKFootBone.BoneName,
+					FName(TEXT("foot_r")));
 				TestEqual(
 					TEXT("Foot Placement drives the right IK foot second"),
 					RpgFootPlacement->LegsDefinition[1].IKFootBone.BoneName,
@@ -1563,6 +1571,10 @@ bool FRpgGaspPilotAssetContractTest::RunTest(const FString& Parameters)
 			TestEqual(TEXT("Foot Placement clamps translation to 50 cm"), RpgFootPlacement->MaxFootTranslation, 50.0f);
 			TestEqual(TEXT("Foot Placement clamps alignment to 60 degrees"), RpgFootPlacement->MaxFootRotation, 60.0f);
 			TestEqual(TEXT("Foot Placement clamps pelvis lowering to 50 cm"), RpgFootPlacement->MaxPelvisOffset, 50.0f);
+			TestEqual(TEXT("Foot Placement raw-gates plants within 10 cm"), RpgFootPlacement->PlantDistanceThreshold, 10.0f);
+			TestEqual(TEXT("Foot Placement raw-gates locks outside a 20 cm radius"), RpgFootPlacement->UnplantRadius, 20.0f);
+			TestEqual(TEXT("Foot Placement smooths pelvis correction with a 0.08-second half-life"), RpgFootPlacement->PelvisBlendHalfLife, 0.08f);
+			TestEqual(TEXT("Foot Placement limits pelvis correction to 120 cm/s"), RpgFootPlacement->MaxPelvisSpeed, 120.0f);
 			TestEqual(TEXT("Foot Placement uses a float graph alpha"), RpgFootPlacement->AlphaInputType, EAnimAlphaInputType::Float);
 			TestEqual(TEXT("Foot Placement keeps its graph-driven alpha default at one"), RpgFootPlacement->Alpha, 1.0f);
 			TestEqual(TEXT("Foot Placement has no hidden LOD cutoff"), RpgFootPlacement->LODThreshold, INDEX_NONE);

--- a/Source/SurvivalRpgEditor/Private/Animation/RpgGaspPilotAssetTests.cpp
+++ b/Source/SurvivalRpgEditor/Private/Animation/RpgGaspPilotAssetTests.cpp
@@ -4,11 +4,13 @@
 
 #include "AlphaBlend.h"
 #include "Abilities/GameplayAbility.h"
+#include "Animation/AnimGraphNode_RpgFootPlacement.h"
 #include "AnimGraph/AnimGraphNode_OrientationWarping.h"
 #include "AnimGraph/AnimGraphNode_Steering.h"
 #include "AnimGraphNode_BlendStackInput.h"
 #include "AnimGraphNode_BlendStackResult.h"
 #include "AnimGraphNode_ComponentToLocalSpace.h"
+#include "AnimGraphNode_LegIK.h"
 #include "AnimGraphNode_LocalToComponentSpace.h"
 #include "Animation/AnimBlueprint.h"
 #include "Animation/AnimSequence.h"
@@ -310,6 +312,19 @@ namespace RpgGaspPilotAssetTests
 		}
 
 		return NodeProperty->ContainerPtrToValuePtr<TRuntimeNode>(EditorNode);
+	}
+
+	template <typename TStruct>
+	const TStruct* ReadStructPropertyValue(const UObject* Object, FName PropertyName)
+	{
+		const FStructProperty* Property =
+			Object ? FindFProperty<FStructProperty>(Object->GetClass(), PropertyName) : nullptr;
+		if (!Property || Property->Struct != TStruct::StaticStruct())
+		{
+			return nullptr;
+		}
+
+		return Property->ContainerPtrToValuePtr<TStruct>(Object);
 	}
 
 	bool ReadBoolProperty(const UObject* Object, FName PropertyName, bool& OutValue)
@@ -1109,6 +1124,45 @@ bool FRpgGaspPilotAssetContractTest::RunTest(const FString& Parameters)
 			TestTrue(TEXT("The GASP AnimBlueprint generates its thread-safe trajectory snapshot"), bGeneratesTrajectory);
 		}
 
+		const FRpgFootPlacementSettings* FootPlacementSettings =
+			ReadStructPropertyValue<FRpgFootPlacementSettings>(
+				PilotAnimDefaults,
+				TEXT("FootPlacementSettings"));
+		if (TestNotNull(
+				TEXT("The GASP AnimBlueprint exposes project-local Foot Placement settings"),
+				FootPlacementSettings))
+		{
+			TestTrue(
+				TEXT("The GASP AnimBlueprint enables game-thread Foot Placement sampling"),
+				FootPlacementSettings->bEnabled);
+			TestFalse(
+				TEXT("The bounded #60 solver preserves the already-validated authored crouch pose"),
+				FootPlacementSettings->bApplyWhileCrouching);
+			TestEqual(TEXT("Foot Placement traces start 75 cm above each ball"), FootPlacementSettings->TraceStartHeight, 75.0f);
+			TestEqual(TEXT("Foot Placement traces end 100 cm below each ball"), FootPlacementSettings->TraceEndDepth, 100.0f);
+			TestEqual(TEXT("Foot Placement uses a five-centimeter sphere sweep"), FootPlacementSettings->SweepRadius, 5.0f);
+			TestEqual(TEXT("Foot Placement plants below 60 cm/s"), FootPlacementSettings->PlantSpeedThreshold, 60.0f);
+			TestEqual(TEXT("Foot Placement bounds the contact-weighted roll phase at 200 cm/s"), FootPlacementSettings->UnalignmentSpeedThreshold, 200.0f);
+			TestEqual(TEXT("Foot Placement plants within ten centimeters"), FootPlacementSettings->PlantDistanceThreshold, 10.0f);
+			TestEqual(TEXT("Foot Placement releases outside GASP's 35-centimeter radius"), FootPlacementSettings->UnplantRadius, 35.0f);
+			TestEqual(TEXT("Foot Placement replants inside 35 percent of the release radius"), FootPlacementSettings->ReplantRadiusRatio, 0.35f);
+			TestEqual(TEXT("Foot Placement releases after GASP's 45-degree normal change"), FootPlacementSettings->UnplantAngle, 45.0f);
+			TestEqual(TEXT("Foot Placement replants inside half the release angle"), FootPlacementSettings->ReplantAngleRatio, 0.5f);
+			TestEqual(TEXT("Foot Placement bounds locked-foot slope alignment to 60 degrees"), FootPlacementSettings->MaxFootAlignmentAngle, 60.0f);
+			TestEqual(TEXT("Foot Placement bounds locked-foot translation to 50 centimeters"), FootPlacementSettings->MaxFootTranslation, 50.0f);
+			TestEqual(TEXT("Foot Placement keeps a 0.1-second trace-miss grace period"), FootPlacementSettings->TraceMissGracePeriod, 0.10f);
+			TestEqual(TEXT("Foot Placement blends weights with a 0.08-second half-life"), FootPlacementSettings->WeightBlendHalfLife, 0.08f);
+
+			TestEqual(TEXT("Foot Placement samples the left FK ankle"), FootPlacementSettings->LeftLeg.FKFootBone, FName(TEXT("foot_l")));
+			TestEqual(TEXT("Foot Placement drives the left IK target"), FootPlacementSettings->LeftLeg.IKFootBone, FName(TEXT("ik_foot_l")));
+			TestEqual(TEXT("Foot Placement traces from the left ball"), FootPlacementSettings->LeftLeg.BallBone, FName(TEXT("ball_l")));
+			TestEqual(TEXT("Foot Placement reads the left contact curve"), FootPlacementSettings->LeftLeg.SpeedCurveName, FName(TEXT("contact_l")));
+			TestEqual(TEXT("Foot Placement samples the right FK ankle"), FootPlacementSettings->RightLeg.FKFootBone, FName(TEXT("foot_r")));
+			TestEqual(TEXT("Foot Placement drives the right IK target"), FootPlacementSettings->RightLeg.IKFootBone, FName(TEXT("ik_foot_r")));
+			TestEqual(TEXT("Foot Placement traces from the right ball"), FootPlacementSettings->RightLeg.BallBone, FName(TEXT("ball_r")));
+			TestEqual(TEXT("Foot Placement reads the right contact curve"), FootPlacementSettings->RightLeg.SpeedCurveName, FName(TEXT("contact_r")));
+		}
+
 		FString OffsetRootRotationMode;
 		if (TestTrue(
 			TEXT("The runtime Offset Root rotation mode is readable"),
@@ -1246,6 +1300,23 @@ bool FRpgGaspPilotAssetContractTest::RunTest(const FString& Parameters)
 			TEXT("Offset Root Bone"));
 		UAnimGraphNode_Slot* SlotNode =
 			FindUniqueNode<UAnimGraphNode_Slot>(*this, AnimGraph, TEXT("Montage Slot"));
+		UAnimGraphNode_LocalToComponentSpace* FootPlacementLocalToComponentNode =
+			FindUniqueNode<UAnimGraphNode_LocalToComponentSpace>(
+				*this,
+				AnimGraph,
+				TEXT("Foot Placement Local To Component"));
+		UAnimGraphNode_RpgFootPlacement* RpgFootPlacementNode =
+			FindUniqueNode<UAnimGraphNode_RpgFootPlacement>(
+				*this,
+				AnimGraph,
+				TEXT("Project-local Foot Placement"));
+		UAnimGraphNode_LegIK* LegIkNode =
+			FindUniqueNode<UAnimGraphNode_LegIK>(*this, AnimGraph, TEXT("Leg IK"));
+		UAnimGraphNode_ComponentToLocalSpace* FootPlacementComponentToLocalNode =
+			FindUniqueNode<UAnimGraphNode_ComponentToLocalSpace>(
+				*this,
+				AnimGraph,
+				TEXT("Foot Placement Component To Local"));
 		UAnimGraphNode_PoseSearchHistoryCollector* PoseHistoryNode =
 			FindUniqueNode<UAnimGraphNode_PoseSearchHistoryCollector>(*this, AnimGraph, TEXT("Pose History"));
 		UAnimGraphNode_Root* RootNode =
@@ -1256,11 +1327,16 @@ bool FRpgGaspPilotAssetContractTest::RunTest(const FString& Parameters)
 			FindUniqueVariableGetter(*this, AnimGraph, TEXT("OffsetRootRotationMode"));
 		UK2Node_VariableGet* ResetOffsetRootGetter =
 			FindUniqueVariableGetter(*this, AnimGraph, TEXT("bResetOffsetRootEveryFrame"));
+		UK2Node_VariableGet* FootPlacementSnapshotGetter =
+			FindUniqueVariableGetter(*this, AnimGraph, TEXT("FootPlacementSnapshot"));
+		UK2Node_VariableGet* FootPlacementAlphaGetter =
+			FindUniqueVariableGetter(*this, AnimGraph, TEXT("FootPlacementAlpha"));
 		TestEqual(
-			TEXT("The top-level pilot graph contains only the five pose nodes and three property getters"),
+			TEXT("The top-level pilot graph contains exactly nine pose nodes and five property getters"),
 			AnimGraph->Nodes.Num(),
-			8);
-		int32 FootPlacementNodeCount = 0;
+			14);
+		int32 StockFootPlacementNodeCount = 0;
+		int32 RpgFootPlacementNodeCount = 0;
 		int32 LegIkNodeCount = 0;
 		int32 OrientationWarpingNodeCount = 0;
 		for (const UEdGraphNode* GraphNode : AnimGraph->Nodes)
@@ -1270,22 +1346,55 @@ bool FRpgGaspPilotAssetContractTest::RunTest(const FString& Parameters)
 				continue;
 			}
 
-			FootPlacementNodeCount += GraphNode->GetClass()->GetFName() == TEXT("AnimGraphNode_FootPlacement");
-			LegIkNodeCount += GraphNode->GetClass()->GetFName() == TEXT("AnimGraphNode_LegIK");
+			StockFootPlacementNodeCount += GraphNode->GetClass()->GetFName() == TEXT("AnimGraphNode_FootPlacement");
+			RpgFootPlacementNodeCount += GraphNode->GetClass() == UAnimGraphNode_RpgFootPlacement::StaticClass();
+			LegIkNodeCount += GraphNode->GetClass() == UAnimGraphNode_LegIK::StaticClass();
 			OrientationWarpingNodeCount += GraphNode->GetClass()->GetFName() == TEXT("AnimGraphNode_OrientationWarping");
 		}
 		TestEqual(
 			TEXT("The pilot does not silently use Epic's worker-thread-unsafe Foot Placement node"),
-			FootPlacementNodeCount,
+			StockFootPlacementNodeCount,
 			0);
 		TestEqual(
-			TEXT("Leg IK remains part of the thread-safe Foot Placement follow-up"),
+			TEXT("The pilot uses exactly one project-local thread-safe Foot Placement node"),
+			RpgFootPlacementNodeCount,
+			1);
+		TestEqual(
+			TEXT("The project-local Foot Placement target is resolved by exactly one stock Leg IK node"),
 			LegIkNodeCount,
-			0);
+			1);
 		TestEqual(
 			TEXT("The pilot does not apply incomplete top-level Orientation Warping"),
 			OrientationWarpingNodeCount,
 			0);
+		if (FootPlacementLocalToComponentNode)
+		{
+			TestEqual(
+				TEXT("Foot Placement uses the exact Local To Component conversion class"),
+				FootPlacementLocalToComponentNode->GetClass(),
+				UAnimGraphNode_LocalToComponentSpace::StaticClass());
+		}
+		if (RpgFootPlacementNode)
+		{
+			TestEqual(
+				TEXT("Foot Placement uses the exact project-local editor node class"),
+				RpgFootPlacementNode->GetClass(),
+				UAnimGraphNode_RpgFootPlacement::StaticClass());
+		}
+		if (LegIkNode)
+		{
+			TestEqual(
+				TEXT("Leg IK uses Epic's exact stock editor node class"),
+				LegIkNode->GetClass(),
+				UAnimGraphNode_LegIK::StaticClass());
+		}
+		if (FootPlacementComponentToLocalNode)
+		{
+			TestEqual(
+				TEXT("Foot Placement uses the exact Component To Local conversion class"),
+				FootPlacementComponentToLocalNode->GetClass(),
+				UAnimGraphNode_ComponentToLocalSpace::StaticClass());
+		}
 
 		if (MotionMatchingNode)
 		{
@@ -1418,6 +1527,99 @@ bool FRpgGaspPilotAssetContractTest::RunTest(const FString& Parameters)
 			}
 		}
 
+		const FAnimNode_RpgFootPlacement* RpgFootPlacement =
+			ReadRuntimeNode<FAnimNode_RpgFootPlacement>(RpgFootPlacementNode);
+		if (TestNotNull(
+				TEXT("The project-local Foot Placement runtime node is readable"),
+				RpgFootPlacement))
+		{
+			TestEqual(
+				TEXT("Foot Placement lowers the mannequin pelvis"),
+				RpgFootPlacement->PelvisBone.BoneName,
+				FName(TEXT("pelvis")));
+			TestEqual(
+				TEXT("Foot Placement has exactly two leg definitions"),
+				RpgFootPlacement->LegsDefinition.Num(),
+				2);
+			if (RpgFootPlacement->LegsDefinition.Num() == 2)
+			{
+				TestEqual(
+					TEXT("Foot Placement drives the left IK foot first"),
+					RpgFootPlacement->LegsDefinition[0].IKFootBone.BoneName,
+					FName(TEXT("ik_foot_l")));
+				TestEqual(
+					TEXT("Foot Placement pivots the left target around ball_l"),
+					RpgFootPlacement->LegsDefinition[0].BallBone.BoneName,
+					FName(TEXT("ball_l")));
+				TestEqual(
+					TEXT("Foot Placement drives the right IK foot second"),
+					RpgFootPlacement->LegsDefinition[1].IKFootBone.BoneName,
+					FName(TEXT("ik_foot_r")));
+				TestEqual(
+					TEXT("Foot Placement pivots the right target around ball_r"),
+					RpgFootPlacement->LegsDefinition[1].BallBone.BoneName,
+					FName(TEXT("ball_r")));
+			}
+			TestEqual(TEXT("Foot Placement clamps translation to 50 cm"), RpgFootPlacement->MaxFootTranslation, 50.0f);
+			TestEqual(TEXT("Foot Placement clamps alignment to 60 degrees"), RpgFootPlacement->MaxFootRotation, 60.0f);
+			TestEqual(TEXT("Foot Placement clamps pelvis lowering to 50 cm"), RpgFootPlacement->MaxPelvisOffset, 50.0f);
+			TestEqual(TEXT("Foot Placement uses a float graph alpha"), RpgFootPlacement->AlphaInputType, EAnimAlphaInputType::Float);
+			TestEqual(TEXT("Foot Placement keeps its graph-driven alpha default at one"), RpgFootPlacement->Alpha, 1.0f);
+			TestEqual(TEXT("Foot Placement has no hidden LOD cutoff"), RpgFootPlacement->LODThreshold, INDEX_NONE);
+		}
+
+		const FAnimNode_LegIK* LegIk = ReadRuntimeNode<FAnimNode_LegIK>(LegIkNode);
+		if (TestNotNull(TEXT("The stock Leg IK runtime node is readable"), LegIk))
+		{
+			TestEqual(TEXT("Leg IK reaches within 0.01 cm"), LegIk->ReachPrecision, 0.01f);
+			TestEqual(TEXT("Leg IK uses twelve solver iterations"), LegIk->MaxIterations, 12);
+			TestEqual(TEXT("Leg IK softens at 99 percent extension"), LegIk->SoftPercentLength, 0.99f);
+			TestEqual(TEXT("Leg IK applies full soft-extension correction"), LegIk->SoftAlpha, 1.0f);
+			TestEqual(TEXT("Leg IK has exactly two leg definitions"), LegIk->LegsDefinition.Num(), 2);
+			static const FName ExpectedIkFeet[] = {TEXT("ik_foot_l"), TEXT("ik_foot_r")};
+			static const FName ExpectedFkFeet[] = {TEXT("foot_l"), TEXT("foot_r")};
+			for (int32 Index = 0; Index < UE_ARRAY_COUNT(ExpectedIkFeet) && Index < LegIk->LegsDefinition.Num(); ++Index)
+			{
+				const FAnimLegIKDefinition& LegDefinition = LegIk->LegsDefinition[Index];
+				TestEqual(
+					*FString::Printf(TEXT("Leg IK target %d is stable"), Index),
+					LegDefinition.IKFootBone.BoneName,
+					ExpectedIkFeet[Index]);
+				TestEqual(
+					*FString::Printf(TEXT("Leg IK FK ankle %d is stable"), Index),
+					LegDefinition.FKFootBone.BoneName,
+					ExpectedFkFeet[Index]);
+				TestEqual(
+					*FString::Printf(TEXT("Leg IK limb %d resolves two bones"), Index),
+					LegDefinition.NumBonesInLimb,
+					2);
+				TestEqual(
+					*FString::Printf(TEXT("Leg IK limb %d keeps a 15-degree compression limit"), Index),
+					LegDefinition.MinRotationAngle,
+					15.0f);
+				TestEqual(
+					*FString::Printf(TEXT("Leg IK foot %d faces along Y"), Index),
+					LegDefinition.FootBoneForwardAxis.GetValue(),
+					EAxis::Y);
+				TestEqual(
+					*FString::Printf(TEXT("Leg IK knee %d hinges around Z"), Index),
+					LegDefinition.HingeRotationAxis.GetValue(),
+					EAxis::Z);
+				TestTrue(
+					*FString::Printf(TEXT("Leg IK limb %d prevents backward folding"), Index),
+					LegDefinition.bEnableRotationLimit);
+				TestTrue(
+					*FString::Printf(TEXT("Leg IK limb %d keeps knee twist correction"), Index),
+					LegDefinition.bEnableKneeTwistCorrection);
+				TestTrue(
+					*FString::Printf(TEXT("Leg IK limb %d has no authored twist override curve"), Index),
+					LegDefinition.TwistOffsetCurveName.IsNone());
+			}
+			TestEqual(TEXT("Leg IK uses the shared float graph alpha"), LegIk->AlphaInputType, EAnimAlphaInputType::Float);
+			TestEqual(TEXT("Leg IK keeps its graph-driven alpha default at one"), LegIk->Alpha, 1.0f);
+			TestEqual(TEXT("Leg IK has no hidden LOD cutoff"), LegIk->LODThreshold, INDEX_NONE);
+		}
+
 		if (SlotNode)
 		{
 			TestEqual(
@@ -1455,6 +1657,89 @@ bool FRpgGaspPilotAssetContractTest::RunTest(const FString& Parameters)
 			}
 		}
 
+		if (RpgFootPlacementNode)
+		{
+			const UEdGraphPin* SnapshotInput =
+				RpgFootPlacementNode->FindPin(TEXT("Snapshot"), EGPD_Input);
+			if (TestNotNull(TEXT("Foot Placement exposes its immutable snapshot input"), SnapshotInput))
+			{
+				TestFalse(TEXT("The Foot Placement snapshot input is visible"), SnapshotInput->bHidden);
+				TestEqual(
+					TEXT("The Foot Placement snapshot uses a struct pin"),
+					SnapshotInput->PinType.PinCategory,
+					UEdGraphSchema_K2::PC_Struct);
+				TestEqual(
+					TEXT("The Foot Placement snapshot pin uses FRpgFootPlacementSnapshot"),
+					SnapshotInput->PinType.PinSubCategoryObject.Get(),
+					static_cast<UObject*>(FRpgFootPlacementSnapshot::StaticStruct()));
+			}
+
+			const UEdGraphPin* AlphaInput = RpgFootPlacementNode->FindPin(TEXT("Alpha"), EGPD_Input);
+			if (TestNotNull(TEXT("Foot Placement exposes its shared alpha input"), AlphaInput))
+			{
+				TestFalse(TEXT("The Foot Placement alpha input is visible"), AlphaInput->bHidden);
+				TestEqual(
+					TEXT("The Foot Placement alpha uses a real-number pin"),
+					AlphaInput->PinType.PinCategory,
+					UEdGraphSchema_K2::PC_Real);
+				TestEqual(
+					TEXT("The Foot Placement alpha is single precision"),
+					AlphaInput->PinType.PinSubCategory,
+					UEdGraphSchema_K2::PC_Float);
+			}
+		}
+
+		if (LegIkNode)
+		{
+			const UEdGraphPin* AlphaInput = LegIkNode->FindPin(TEXT("Alpha"), EGPD_Input);
+			if (TestNotNull(TEXT("Leg IK exposes its shared alpha input"), AlphaInput))
+			{
+				TestFalse(TEXT("The Leg IK alpha input is visible"), AlphaInput->bHidden);
+				TestEqual(
+					TEXT("The Leg IK alpha uses a real-number pin"),
+					AlphaInput->PinType.PinCategory,
+					UEdGraphSchema_K2::PC_Real);
+				TestEqual(
+					TEXT("The Leg IK alpha is single precision"),
+					AlphaInput->PinType.PinSubCategory,
+					UEdGraphSchema_K2::PC_Float);
+			}
+		}
+
+		if (FootPlacementSnapshotGetter)
+		{
+			const UEdGraphPin* SnapshotOutput =
+				FootPlacementSnapshotGetter->FindPin(TEXT("FootPlacementSnapshot"), EGPD_Output);
+			if (TestNotNull(TEXT("FootPlacementSnapshot getter exposes its value"), SnapshotOutput))
+			{
+				TestEqual(
+					TEXT("The snapshot getter uses a struct pin"),
+					SnapshotOutput->PinType.PinCategory,
+					UEdGraphSchema_K2::PC_Struct);
+				TestEqual(
+					TEXT("The snapshot getter exposes FRpgFootPlacementSnapshot"),
+					SnapshotOutput->PinType.PinSubCategoryObject.Get(),
+					static_cast<UObject*>(FRpgFootPlacementSnapshot::StaticStruct()));
+			}
+		}
+
+		if (FootPlacementAlphaGetter)
+		{
+			const UEdGraphPin* AlphaOutput =
+				FootPlacementAlphaGetter->FindPin(TEXT("FootPlacementAlpha"), EGPD_Output);
+			if (TestNotNull(TEXT("FootPlacementAlpha getter exposes its value"), AlphaOutput))
+			{
+				TestEqual(
+					TEXT("The Foot Placement alpha getter uses a real-number pin"),
+					AlphaOutput->PinType.PinCategory,
+					UEdGraphSchema_K2::PC_Real);
+				TestEqual(
+					TEXT("The Foot Placement alpha getter is single precision"),
+					AlphaOutput->PinType.PinSubCategory,
+					UEdGraphSchema_K2::PC_Float);
+			}
+		}
+
 		TestExclusiveLink(
 			*this,
 			TEXT("Motion Matching feeds Offset Root Bone"),
@@ -1471,8 +1756,36 @@ bool FRpgGaspPilotAssetContractTest::RunTest(const FString& Parameters)
 			TEXT("Source"));
 		TestExclusiveLink(
 			*this,
-			TEXT("DefaultSlot feeds Pose History"),
+			TEXT("DefaultSlot feeds the Foot Placement component-space conversion"),
 			SlotNode,
+			TEXT("Pose"),
+			FootPlacementLocalToComponentNode,
+			TEXT("LocalPose"));
+		TestExclusiveLink(
+			*this,
+			TEXT("The component-space conversion feeds project-local Foot Placement"),
+			FootPlacementLocalToComponentNode,
+			TEXT("ComponentPose"),
+			RpgFootPlacementNode,
+			TEXT("ComponentPose"));
+		TestExclusiveLink(
+			*this,
+			TEXT("Project-local Foot Placement feeds stock Leg IK"),
+			RpgFootPlacementNode,
+			TEXT("Pose"),
+			LegIkNode,
+			TEXT("ComponentPose"));
+		TestExclusiveLink(
+			*this,
+			TEXT("Stock Leg IK feeds the local-space conversion"),
+			LegIkNode,
+			TEXT("Pose"),
+			FootPlacementComponentToLocalNode,
+			TEXT("ComponentPose"));
+		TestExclusiveLink(
+			*this,
+			TEXT("The Foot Placement local-space result feeds Pose History"),
+			FootPlacementComponentToLocalNode,
 			TEXT("Pose"),
 			PoseHistoryNode,
 			TEXT("Source"));
@@ -1504,6 +1817,18 @@ bool FRpgGaspPilotAssetContractTest::RunTest(const FString& Parameters)
 			TEXT("bResetOffsetRootEveryFrame"),
 			OffsetRootBoneNode,
 			TEXT("bResetEveryFrame"));
+		TestExactOutputLinks(
+			*this,
+			TEXT("The immutable game-thread snapshot drives only project-local Foot Placement"),
+			FootPlacementSnapshotGetter,
+			TEXT("FootPlacementSnapshot"),
+			{{RpgFootPlacementNode, TEXT("Snapshot")}});
+		TestExactOutputLinks(
+			*this,
+			TEXT("The montage-safe Foot Placement alpha gates both skeletal controls"),
+			FootPlacementAlphaGetter,
+			TEXT("FootPlacementAlpha"),
+			{{RpgFootPlacementNode, TEXT("Alpha")}, {LegIkNode, TEXT("Alpha")}});
 	}
 
 	TestEqual(

--- a/Source/SurvivalRpgEditor/Public/Animation/AnimGraphNode_RpgFootPlacement.h
+++ b/Source/SurvivalRpgEditor/Public/Animation/AnimGraphNode_RpgFootPlacement.h
@@ -1,0 +1,28 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "AnimGraphNode_SkeletalControlBase.h"
+#include "SurvivalRpg/Animation/AnimNode_RpgFootPlacement.h"
+#include "AnimGraphNode_RpgFootPlacement.generated.h"
+
+/** Editor representation of the project-local, snapshot-only RPG Foot Placement node. */
+UCLASS(meta = (Keywords = "RPG Foot Placement IK Thread Safe"))
+class SURVIVALRPGEDITOR_API UAnimGraphNode_RpgFootPlacement : public UAnimGraphNode_SkeletalControlBase
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(EditAnywhere, Category = "Settings")
+	FAnimNode_RpgFootPlacement Node;
+
+	virtual FText GetNodeTitle(ENodeTitleType::Type TitleType) const override;
+	virtual FText GetTooltipText() const override;
+	virtual void ValidateAnimNodeDuringCompilation(
+		USkeleton* ForSkeleton,
+		FCompilerResultsLog& MessageLog) override;
+
+protected:
+	virtual FText GetControllerDescription() const override;
+	virtual const FAnimNode_SkeletalControlBase* GetNode() const override { return &Node; }
+};


### PR DESCRIPTION
Closes #60

Follow-up für Directional Jump/Landing: #66

## Zusammenfassung

Ergänzt den isolierten GASP-Locomotion-Pilot um projektlokales, thread-sicheres Foot Placement und nachgeschaltetes Leg IK.

Alle World-, CharacterMovement-, Floor-, Trace-, MovementBase- und Component-Zugriffe bleiben in `FRpgAnimInstanceProxy::PreUpdate` auf dem Game Thread. Die parallele AnimGraph-Auswertung erhält ausschließlich einen unveränderlichen, pointerfreien Snapshot.

## Änderungen

- zwei begrenzte Sphere Sweeps pro aktivem Character auf dem Game Thread
- Contact-Curve-basierte Plant-/Release-/Replant-Policy mit Hysterese
- Trace-Miss-Grace und Rebase auf bewegten Hit Components beziehungsweise Movement Bases
- Reset bei Montage, Crouch, Airborne, blockierenden Gameplay-Tags, Teleport, Owner-/Role-/Base-Wechsel und großen Transform-Sprüngen
- projektlokaler `FAnimNode_RpgFootPlacement` ohne Actor-, World-, CMC- oder Trace-Zugriff im AnyThread-Pfad
- Stock-`FAnimNode_LegIK` als reiner Pose-/Curve-Solver hinter dem projektlokalen Target-Node
- aktueller FK-Knöchel ist immer das neutrale IK-Ziel; ungeeignete/statische retargetete IK-Tracks können Schwungbeine nicht festhalten
- Same-Frame-Geometriegates, Ball-Pivot-Locking und begrenzte Zielkorrekturen
- geglättete und geschwindigkeitsbegrenzte Beckenverschiebung
- gemeinsamer montage-sicherer Alpha-Bypass für Foot Placement und Leg IK
- bestehender Hauptgraph bleibt erhalten und wird nur erweitert:

  `Motion Matching → Offset Root → DefaultSlot → L2C → RPG Foot Placement → Leg IK → C2L → Pose History → Output`

- Crouch und Airborne bleiben bewusst auf ihren authored Posen
- keine Abhängigkeit auf GASP Sample Character, Mover, Traversal, Foley oder SmartObjects

## Threading-Vertrag

- Actor, World, CharacterMovement, CurrentFloor und Collision Sweeps: ausschließlich Game Thread
- projektlokaler AnyThread-Node: ausschließlich Pose und `FRpgFootPlacementSnapshot`
- Snapshot enthält keine UObject-, Actor-, World-, MovementComponent- oder `FHitResult`-Referenzen
- Gameplay Movement und Collision bleiben unverändert; die Lösung ist rein kosmetisch

## Automatisch verifiziert

- [x] UE 5.8 `SurvivalRpgEditor Win64 Development` Build
- [x] komplette `SurvivalRpg.Animation`-Suite: **14/14 erfolgreich**
- [x] Foot-Placement-Runtime-Verträge: **6/6 erfolgreich**
- [x] alle 95 kuratierten AnimSequences besitzen `contact_l` und `contact_r`
- [x] Threading-/POD-/Math-/Hysterese-/Moving-Surface-Verträge geschützt
- [x] Neutral-IK-Vertrag verhindert festgehaltene Schwungbeine
- [x] Assetvertrag verhindert Epics Stock-Foot-Placement-Node
- [x] Graph-Wiring, Node-Settings, Leg-IK-Konfiguration und gemeinsamer Alpha geprüft
- [x] `DefaultSlot`, `RootMotionFromMontagesOnly`, TIR und Rotation-Mode-Verträge bleiben grün
- [x] Git-LFS-AnimBlueprint-Objekt vollständig gepusht

## Manuelle Abnahme

- [x] Ebene: Idle, Start, Stop und Richtungswechsel funktional; kein Ski-/Stuck-State nach dem Neutral-IK-Fix
- [x] Crouch bleibt auf der abgenommenen authored Pose
- [x] Airborne-Bypass bestätigt: Foot Placement und Leg IK sind im Sprung aus
- [x] Listen-Server-Authority-Smoketest
- [ ] Schräge: hoch, runter und quer
- [ ] Treppe und Kante mit einzeln unbelastetem Fuß
- [ ] bewegte/rotierende Plattform, falls in der Testmap verfügbar
- [ ] Attack, Block, Dodge, Hit, Death und Harvesting behalten Montage, Root Motion und Notify-Timing
- [ ] Listen Server + Client: Autonomous Proxy und Simulated Proxy

Der beobachtete seitliche/rechte Hüft-Twist ist kein akkumulativer Foot-Placement-State und bleibt Locomotion-/OW-Polish. Der seitliche/rückwärtige Jump-Pose-Snap ist als eigenständiger Jump-/Landing-Vertrag in #66 erfasst.

## Bewusste Grenzen

- Die Plant-Locks sind in diesem bounded Slice primär durch die kuratierten Contact Curves gesteuert; Same-Frame-Geometriegrenzen sichern falsche oder veraltete Locks zusätzlich ab.
- Zwei komplexe Visibility Sweeps pro aktivem Character-Tick sollten bei größerer AI-/Multiplayer-Last später profiliert werden.
- Vollständige Lag/Loss-, Dedicated-Server- und Late-Join-Cutover-Abnahme bleibt #55.
