### PR TITLE
Add Unreal GASP expert skill

### DIFF
--- a/.agents/skills/survival-rpg-combat-foundation/SKILL.md
+++ b/.agents/skills/survival-rpg-combat-foundation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: survival-rpg-combat-foundation
-description: Use for SurvivalRpg combat, equipment, inventory-facing item instances, loadouts, GAS ability grants, mastery/progression, runes, portal combat, Dungeonbreak, and modular GameFeature combat content. Prefer current repo truth, preserve Lyra-rooted RPG equipment/inventory architecture, and pair with $unreal-lyra-expert for engine-facing implementation.
+description: Use for SurvivalRpg combat, equipment, inventory-facing item instances, loadouts, GAS ability grants, mastery/progression, runes, portal combat, Dungeonbreak, and modular GameFeature combat content. Prefer current repo truth, preserve Lyra-rooted RPG equipment/inventory architecture, pair with $unreal-lyra-expert for engine-facing implementation, and add $unreal-gasp-expert for combat animation, montage/locomotion overlap, dodge, block, hit reactions, or GASP-driven presentation.
 ---
 
 # SurvivalRpg Combat Foundation
@@ -10,6 +10,8 @@ description: Use for SurvivalRpg combat, equipment, inventory-facing item instan
 This skill owns SurvivalRpg combat, equipment, inventory-facing item instances, weapon action routing, runes, mastery/progression, portal combat, Dungeonbreak combat escalation, and combat GameFeature guidance.
 
 Use it together with `$unreal-lyra-expert` when implementation details touch Unreal Engine, GAS internals, replication, Experiences, Game Features, Lyra Interaction, or Lyra-rooted inventory/equipment.
+
+Use it together with `$unreal-gasp-expert` when combat work changes the GASP AnimBP, Motion Matching layers, montage slots, root-motion interaction, dodge or block presentation, hit reactions, equipment sockets, death, ragdoll, or locomotion-driven combat tags. Keep combat outcomes authoritative in GAS and equipment while animation remains presentation.
 
 Use it together with `$survival-rpg-project` when a combat, equipment, rune, portal, or progression decision changes product scope, progression identity, survival friction, first-playable priorities, or long-term resource relevance.
 
@@ -311,6 +313,8 @@ Check these when montage abilities fail:
 - ability is actually granted to the ASC
 - activation tags are not blocked
 
+When the active character uses the GASP AnimBP, also check the `$unreal-gasp-expert` contract for `DefaultSlot`, root-motion extraction, `GetMesh()`, worker-thread tag snapshots, locomotion interruption, and simulated-proxy presentation.
+
 Core should not reference feature-only montages. A feature can reference core/shared character assets.
 
 ---
@@ -431,3 +435,5 @@ Flag proposals that:
 - implement skill trees that make weapon switching feel like starting from zero
 - put special fire/rift/rune logic into generic core assets
 - require main maps to hard-reference feature-only actors without clear reason
+- make authoritative combat results depend on GASP pose selection or AnimBP-local state
+- remove montage slots, notifies, root-motion behavior, equipment sockets, death, or ragdoll seams while simplifying the GASP locomotion graph

--- a/.agents/skills/survival-rpg-combat-foundation/agents/openai.yaml
+++ b/.agents/skills/survival-rpg-combat-foundation/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "SurvivalRpg Combat Foundation"
   short_description: "Combat, equipment, GAS and RPG item seams"
-  default_prompt: "Use $survival-rpg-combat-foundation for SurvivalRpg combat, equipment, loadout, item-instance, progression, runes, portal-combat, Dungeonbreak, and combat GameFeature work. Pair with $unreal-lyra-expert for Unreal/GAS/replication details. Preserve Lyra-rooted RPG equipment/inventory architecture and add concise documentation comments for designer-facing combat, item, equipment, rune, portal, DataAsset, and Blueprint-configurable fields by default."
+  default_prompt: "Use $survival-rpg-combat-foundation for SurvivalRpg combat, equipment, GAS, and progression work while preserving Lyra-rooted RPG architecture and designer-facing documentation; pair with $unreal-lyra-expert for engine implementation and add $unreal-gasp-expert when combat overlaps GASP animation, montages, locomotion, hit reactions, death, or ragdoll."
 
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/survival-rpg-orchestrator/SKILL.md
+++ b/.agents/skills/survival-rpg-orchestrator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: survival-rpg-orchestrator
-description: Use for large or ambiguous SurvivalRpg requests that need routing across project vision, Unreal/Lyra architecture, combat/equipment, planning, review, or implementation. Select only the needed specialist skills and break work into the smallest useful slice.
+description: Use for large or ambiguous SurvivalRpg requests that need routing across project vision, Unreal/Lyra architecture, GASP animation/locomotion, combat/equipment, planning, review, or implementation. Select only the needed specialist skills and break work into the smallest useful slice.
 ---
 
 # SurvivalRpg Orchestrator
@@ -20,7 +20,8 @@ Route to the minimum skill set that covers the task.
 - Use `$survival-rpg-project` for any decision that affects game identity, feature scope, progression priorities, portal fantasy, survival friction, or long-term resource relevance.
 - Use `$survival-rpg-combat-foundation` for combat foundation, weapon equip/unequip, loadout, hotbar or hotwheel, weapon action routing, or early GAS weapon architecture in this repository.
 - Use `$unreal-lyra-expert` for Unreal Engine, GAS, Lyra-style architecture, modular gameplay, replication, C++ versus Blueprint boundaries, or engine-facing reviews.
-- Use both skills together when implementing gameplay systems in this repository.
+- Use `$unreal-gasp-expert` for GASP CMC locomotion, Motion Matching, Pose Search, trajectory, procedural animation nodes, retargeting, animation threading, or multiplayer locomotion parity.
+- Combine only the specialists whose ownership boundaries the request crosses.
 - Do not duplicate specialist guidance inside this skill. Delegate to the specialist skill instead.
 
 Preserve repository-wide documentation defaults.
@@ -34,6 +35,10 @@ Apply these default routing rules.
 - New gameplay feature: use `$survival-rpg-project`, then add `$unreal-lyra-expert` if the feature touches runtime implementation.
 - Combat foundation, weapon equip/unequip, hotbar or hotwheel loadout, or early weapon GAS work: use `$survival-rpg-combat-foundation` first, then add `$unreal-lyra-expert` for engine-facing work and `$survival-rpg-project` when feature scope or progression tradeoffs matter.
 - Combat, progression, gathering, crafting, portals, bosses, runes, or world events: use both core skills unless the user is only discussing design direction; keep `$survival-rpg-combat-foundation` active whenever the task touches the Phase 1 weapon backbone.
+- GASP source audits, curated asset work, Pose Search tuning, or purely cosmetic AnimGraph work: use `$unreal-gasp-expert` alone unless the task crosses a gameplay boundary.
+- GASP work that touches PawnData, Experiences, Game Features, character lifecycle, movement replication, GAS montages, equipment, death, or ragdoll: use `$unreal-gasp-expert` together with `$unreal-lyra-expert`.
+- GASP work that touches attacks, dodge, block, hit reactions, combat montage notifies, combat tags, or equipment-granted abilities: also use `$survival-rpg-combat-foundation`.
+- Requests to adopt GASP Mover, Traversal, Locomotor, camera, Foley, or experimental systems: route through `$unreal-gasp-expert` for an isolated dependency evaluation and add `$survival-rpg-project` when the change affects gameplay scope or movement fantasy.
 - Refactor, bug fix, review, replication, GAS ability work, or subsystem placement: use `$unreal-lyra-expert` and keep `$survival-rpg-project` active if the change could shift the game's identity or scope.
 - Documentation, prioritization, feature triage, or MVP planning: use `$survival-rpg-project` first and only add `$unreal-lyra-expert` when technical constraints matter.
 

--- a/.agents/skills/survival-rpg-orchestrator/agents/openai.yaml
+++ b/.agents/skills/survival-rpg-orchestrator/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "SurvivalRpg Orchestrator"
   short_description: "Routes broad SurvivalRpg tasks"
-  default_prompt: "Use $survival-rpg-orchestrator for broad, ambiguous, or multi-system SurvivalRpg tasks. Select the minimum specialist skills, inspect repo truth, choose the smallest useful slice, then implement or plan. Preserve the repository default that designer-facing DataAsset, Blueprint, config, replicated, saved, and gameplay-facing fields should receive concise documentation comments."
+  default_prompt: "Use $survival-rpg-orchestrator to route broad SurvivalRpg tasks to the minimum project, Lyra, GASP, and combat specialists, inspect repository truth, choose the smallest verifiable slice, and preserve repository designer-facing documentation defaults."
 
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/unreal-gasp-expert/SKILL.md
+++ b/.agents/skills/unreal-gasp-expert/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: unreal-gasp-expert
+description: Use for Unreal Engine 5 Game Animation Sample Project (GASP) CMC locomotion, RPG movement, equipment-load-aware gait and sprint profiles, curated mantle/vault/climb/traversal, Motion Matching, Pose Search schemas/databases, trajectory generation, Blend Stack, Steering, Offset Root Bone, Foot Placement/IK, retargeting, animation-thread safety, multiplayer locomotion parity, and integration with SurvivalRpg's Lyra-derived PawnData, Experiences, GAS montages, equipment, death, or ragdoll. Inspect the project and local GASP reference first; preserve project-owned curated content and pair with $unreal-lyra-expert at gameplay, composition, or character-lifecycle boundaries.
+---
+
+# Unreal GASP Expert
+
+Treat GASP as a technical reference for a project-owned animation system. Preserve SurvivalRpg's curated CMC path and integrate it through the Lyra-derived gameplay architecture instead of importing the sample wholesale.
+
+## Start from current repository truth
+
+Inspect the affected project and reference assets before proposing or making changes.
+
+1. Read `SurvivalRpg.uproject` to confirm the engine version and enabled animation plugins.
+2. Read `docs/gasp-cmc-migration-plan.md` and `Plugins/RpgGaspLocomotion/Docs/README.md`.
+3. Read `Plugins/RpgGaspLocomotion/RpgGaspLocomotion.uplugin` and, for content changes, `Plugins/RpgGaspLocomotion/Docs/CuratedAssetManifest.csv`.
+4. Inspect `Source/SurvivalRpg/Animation`, the affected character/movement code, the active GASP AnimBP/PawnData/Experience, and the focused tests under `Source/SurvivalRpgEditor/Private/Animation`.
+5. Compare with `D:\Repos\GameAnimationSample` when available. Treat it as a version-matched comparison source, never as a required runtime dependency.
+6. Compare with `D:\Repos\LyraStarterGame` when a change crosses into PawnData, Experience, GAS, character lifecycle, equipment, death, or ragdoll.
+
+If either reference project is unavailable, continue from repository truth and state that the comparison could not be performed.
+
+Read [references/gasp-lyra-integration.md](references/gasp-lyra-integration.md) whenever a task crosses animation, gameplay, composition, combat, equipment, or networking ownership.
+
+## Classify the work before changing it
+
+Place the request in one or more concrete categories:
+
+- source-parity audit against GASP
+- curated animation import or retargeting
+- Pose Search schema, database, normalization, or chooser work
+- AnimGraph, trajectory, Motion Matching, Blend Stack, Steering, Offset Root Bone, or Foot Placement work
+- starts, stops, pivots, turn-in-place, gait, crouch, jump, or landing debugging
+- equipment-load-aware locomotion, heavy running, sprint, mantle, vault, hurdle, climb, or ledge movement
+- animation threading, replication, simulated-proxy, or late-join debugging
+- Lyra, GAS montage, combat, equipment, death, or ragdoll integration
+
+Choose the smallest slice that proves the intended behavior. Separate observed GASP behavior, current SurvivalRpg behavior, and the proposed adaptation.
+
+## Preserve the project-owned CMC architecture
+
+- Treat the current CMC/Pose Search path as the production default unless the user explicitly requests a replacement evaluation.
+- Keep the stock GASP character, AnimBP, databases, and supporting systems as reference material rather than runtime dependencies.
+- Do not introduce GASP's full Mover/Traversal stack, Locomotor, NetworkPrediction, sample camera, Foley, audio, experimental state machines, generic retarget collections, or dense sample content merely because the sample contains them.
+- Require an isolated dependency and lifecycle evaluation before adopting any excluded sample subsystem.
+- Preserve the authoritative project skeleton, `URpgAnimInstance`, project-local schemas/databases, and the `RpgGaspLocomotion` content boundary.
+- Inspect current runtime selection before assuming the sample's Chooser or State Controller should own selection. Preserve project-native selection where it is intentional.
+- Record intentional source deviations in the plugin contract, manifest, or focused tests rather than relying on memory or issue-specific scripts.
+
+## Shape RPG locomotion and curated traversal
+
+- Build grounded dark-fantasy movement that can communicate equipment load, stamina, combat state, terrain, and learned traversal without becoming constant survival friction or superhero parkour.
+- Treat the existing `Equipment.Load.Light`, `Equipment.Load.Medium`, and `Equipment.Load.Heavy` state as gameplay input. Keep equipment/GAS and CharacterMovement authoritative; let GASP presentation consume a thread-safe snapshot.
+- Define load-aware movement as a data-driven profile. Consider maximum speed, acceleration, braking, rotation response, jump, dodge, stamina, gait, and Pose Search selection, but apply only the differences that improve feel and readability.
+- Do not implement heavy running only by slowing animation playback. Keep movement physics, gameplay costs, gait selection, and visual weight aligned to the same authoritative profile.
+- Replicate or reconstruct the animation-relevant movement profile for simulated proxies. Do not assume owner-only equipment load state is sufficient for remote locomotion or late join.
+- Inspect the current gait resolver before adding sprint. Add an explicit gameplay-owned sprint/gait state when the project needs true sprint instead of inferring it from a locally selected pose or speed alone.
+- Treat mantle, vault, hurdle, and short climb as curated RPG traversal actions. Prefer server-validated GAS abilities using the existing CMC path, project-owned montages, and Motion Warping where appropriate.
+- Treat sustained climbing, ledge hanging, ladders, or wall movement as explicit CharacterMovement custom modes or equally authoritative movement state. Do not implement sustained traversal only inside the AnimBP.
+- Retarget only the GASP sequences and metadata required by the approved action. Replace sample Blueprint helpers, BranchIn dependencies, camera logic, and traversal state machines with project-owned seams.
+- Start with one isolated traversal action, such as a forward standing mantle, in separate PawnData/Experience or a disposable development GameFeature. Prove collision validation, cancellation, multiplayer correction, and rollback before widening the move set.
+- Preserve combat, equipment, montage-slot, root-motion, hit-reaction, death, and ragdoll behavior while traversal is active or interrupted.
+- Evaluate Mover only as a separate movement-stack replacement study when CMC demonstrably cannot provide a required capability. Do not make Mover a prerequisite for curated traversal.
+
+## Keep animation updates thread-safe
+
+- Gather character, movement, ASC, component, and world state on the game thread.
+- Transfer only immutable or snapshot-safe values through the AnimInstance proxy.
+- Consume snapshot values during worker-thread animation update; do not query actors, components, the ASC, or the world there, and do not perform dynamic asset loading or mutable UObject work.
+- Snapshot gameplay tags or gameplay-derived gates on the game thread before animation consumes them.
+- Keep Motion Matching selection and procedural animation cosmetic. Never make authoritative gameplay outcomes depend on the locally selected pose.
+- Preserve parallel animation update for non-GASP AnimBPs and avoid adding game-thread work when the feature is disabled.
+
+## Preserve source fidelity without importing source coupling
+
+For asset or Pose Search changes:
+
+- Audit the recursive dependency closure before migration.
+- Import only the animations and metadata required by the approved slice.
+- Retarget to the project skeleton and keep assets project-owned.
+- Preserve root-motion enablement, normalization, force-lock, and reference-pose locking where required by the current import contract.
+- Preserve curve spelling and case, including source variants, unless a documented project normalization replaces them.
+- Preserve required sampling ranges, exclusion/transition/cost notifies, mirroring, database membership, schema channels, normalization, tags, and cost biases.
+- Remove Foley, EarlyTransition, BranchIn, state-machine, or other excluded references only with an explicit local replacement policy.
+- Update the curated manifest and plugin contract when asset membership or source parity changes.
+- Review binary/LFS scope and hard/soft/management references before accepting an asset diff.
+
+Do not treat on-disk compression size as the content contract when Unreal can recompress assets with project or engine defaults.
+
+## Preserve multiplayer and gameplay seams
+
+- Verify autonomous proxy, authority, and simulated proxy inputs separately.
+- Preserve the replicated movement inputs needed for remote starts, stops, pivots, gait, rotation modes, turn-in-place, jump, and landing selection.
+- Verify reconstruction after late join and after movement correction; do not rely only on steady-state local play.
+- Keep gameplay authority in movement, GAS, equipment, and character systems. Keep pose selection, foot placement, and presentation state cosmetic.
+- Preserve `GetMesh()` as the mesh used by GAS montages, notifies, equipment sockets, corpse physics, and ragdoll unless the project establishes a different authoritative seam.
+- Preserve the `DefaultSlot` montage path and root motion from montages only unless a reviewed gameplay requirement changes that contract.
+- Recheck attack combos, block, dodge, hit reactions, harvesting rewards, death, equipment attachment, and ragdoll after AnimGraph or skeleton changes.
+
+## Route across specialist skills
+
+- Use `$unreal-lyra-expert` together with this skill for PawnData, Experiences, Game Features, character classes, movement replication, GAS integration, montage lifecycle, equipment, death, or ragdoll.
+- Add `$survival-rpg-combat-foundation` when the task changes attacks, block, dodge, hit reactions, combat montages, equipment-granted abilities, or combat animation tags.
+- Add `$survival-rpg-project` only when an animation decision changes product scope, combat feel, traversal scope, progression identity, or first-playable priorities.
+- Keep isolated source audits, retargeting checks, Pose Search tuning, and purely cosmetic AnimGraph work within this skill when no gameplay boundary is affected.
+
+Do not duplicate Lyra, combat, or product authority inside this skill. Use the integration contract to decide which specialist owns each decision.
+
+## Verify proportionally
+
+Use the narrowest verification that proves the change, then widen when the boundary demands it.
+
+- Run the relevant editor build after C++ or module dependency changes; never claim compilation without running it.
+- Run focused automation filters such as `SurvivalRpg.Animation.Gasp`, `SurvivalRpg.Animation.MotionMatching`, `SurvivalRpg.Animation.FootPlacement`, `SurvivalRpg.Animation.TurnInPlace`, `SurvivalRpg.Animation.Jump`, `SurvivalRpg.Animation.Network`, or `SurvivalRpg.Animation.Threading` as applicable.
+- Validate affected assets, AnimBP compilation, parent class, skeleton, exposed defaults, graph nodes, reference closure, and cook/load assumptions.
+- Test locomotion in editor for starts, stops, pivots, gait boundaries, crouch, turns, jump/landing, uneven ground, LOD changes, and rapid input reversals.
+- For replicated changes, test a listen server with at least two clients, simulated proxies, correction scenarios, and late join.
+- For load-aware movement, test equipment changes while idle and moving, all load thresholds, sprint/gait transitions, prediction correction, simulated proxies, and late join.
+- For traversal, test authoritative obstacle validation, activation cost, montage/root-motion handoff, cancellation, collision failure, correction, combat interruption, death/ragdoll, and rollback of the isolated feature.
+- For gameplay integration, run montage, notify, root-motion, equipment socket, hit reaction, death, corpse, and ragdoll regressions.
+- Inspect Pose Search cost/debug output and profile animation-thread/game-thread cost before tuning by feel alone.
+
+Report which project files and reference assets were inspected, which behavior intentionally follows GASP, which behavior intentionally differs, and which verification actually ran.

--- a/.agents/skills/unreal-gasp-expert/agents/openai.yaml
+++ b/.agents/skills/unreal-gasp-expert/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Unreal GASP Expert"
+  short_description: "GASP CMC, RPG movement, and Lyra integration"
+  default_prompt: "Use $unreal-gasp-expert to inspect and solve SurvivalRpg GASP CMC, load-aware RPG locomotion, curated traversal, Motion Matching, Pose Search, or Lyra/GAS animation integration while preserving project-owned content and multiplayer/thread-safety contracts."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/unreal-gasp-expert/references/gasp-lyra-integration.md
+++ b/.agents/skills/unreal-gasp-expert/references/gasp-lyra-integration.md
@@ -1,0 +1,78 @@
+# GASP-Lyra Integration Contract
+
+Use this contract when a task crosses SurvivalRpg animation, Lyra composition, GAS combat, equipment, character lifecycle, or networking.
+
+## Canonical sources
+
+Use sources in this order:
+
+1. Current SurvivalRpg runtime code, assets, tests, and plugin contracts.
+2. `docs/gasp-cmc-migration-plan.md` for the adopted migration boundary.
+3. `D:\Repos\GameAnimationSample` for version-matched GASP comparison when present.
+4. `D:\Repos\LyraStarterGame` for Lyra lifecycle and composition comparison when present.
+
+Never let either sample project override a deliberate SurvivalRpg adaptation without evidence and explicit scope.
+
+## Ownership matrix
+
+| Concern | Primary owner | Required collaborator | Contract |
+| --- | --- | --- | --- |
+| Locomotion pose selection and presentation | GASP adaptation | Lyra for lifecycle/network inputs | Keep cosmetic state outside gameplay authority. |
+| AnimGraph, Pose Search, trajectory, procedural nodes | GASP adaptation | Combat when montage layers overlap | Preserve thread-safe snapshots and montage slots. |
+| Pawn class and pawn configuration | Lyra/PawnData | GASP for AnimBP requirements | Compose through PawnData and Experience rather than a sample-owned character path. |
+| Mode and feature composition | Lyra Experiences/Game Features | GASP for required assets/plugins | Keep activation data-driven and dependencies narrow. |
+| Abilities, costs, cooldowns, blockers, combat tags | GAS/Combat | GASP for read-only animation gates | Snapshot tags for animation; never infer authoritative gameplay from a selected pose. |
+| Combat montages and attack windows | GAS/Combat | GASP and Lyra | Preserve slot, root-motion, notify, prediction, and cancellation semantics. |
+| Equipment and attachment | RPG equipment architecture | GASP for skeleton/socket compatibility | Equipment owns truth; animation only presents it. |
+| Load-aware gait, sprint, and heavy movement | Equipment/GAS and CharacterMovement | GASP for animation selection | Drive gameplay and visuals from one authoritative movement profile and reconstruct it for simulated proxies. |
+| Movement and network truth | Character movement/Lyra gameplay path | GASP for selection inputs | Replicate or reconstruct inputs needed by simulated proxies and late joiners. |
+| Mantle, vault, hurdle, and short climb | GAS and CharacterMovement | GASP for curated montages; Lyra for composition | Validate traversal on the server and keep the action project-owned. |
+| Sustained climb, ledge hang, and ladders | CharacterMovement custom mode | GAS/Lyra for activation; GASP for presentation | Keep continuous movement authority outside the AnimBP. |
+| Death, corpse, and ragdoll | Character/combat lifecycle | GASP for AnimGraph and mesh handoff | Keep `GetMesh()` and physics transitions compatible. |
+| Curated animation content | `RpgGaspLocomotion` | Lyra only when composition changes | Keep assets project-owned and sample dependencies absent. |
+
+## Stable seams
+
+Preserve these seams unless an inspected project change proves that they moved:
+
+- `URpgAnimInstance` is the native base for the GASP player AnimBP.
+- The AnimInstance proxy captures gameplay and movement inputs on the game thread.
+- The active GASP character is selected through PawnData and an Experience.
+- `GetMesh()` remains the montage, notify, equipment socket, corpse, and ragdoll mesh.
+- `DefaultSlot` remains available to GAS combat montages.
+- Curated sequences preserve their authored root-motion import settings while the AnimInstance extraction policy remains root motion from montages only.
+- Runtime database selection remains project-native even when its logic mirrors selected GASP chooser domains.
+- The content-only plugin owns curated locomotion assets but does not choose PawnData, Experience, or AnimBP.
+- Equipment/GAS and CharacterMovement own load and traversal state; the AnimInstance receives only animation-safe snapshots.
+
+## Cross-system decision rules
+
+- If a change affects only source parity, retargeted content, Pose Search metadata, or cosmetic graph tuning, let `$unreal-gasp-expert` lead.
+- If it affects PawnData, Experience activation, character class, movement replication, ASC access, montage lifecycle, death, or ragdoll, use `$unreal-gasp-expert` with `$unreal-lyra-expert`.
+- If it affects attacks, dodge, block, hit reactions, combat tags, montage notifies, equipment grants, or damage windows, add `$survival-rpg-combat-foundation`.
+- If it affects load-aware movement, sprint, stamina, traversal abilities, or equipment-driven gait, use `$unreal-gasp-expert` with `$unreal-lyra-expert` and `$survival-rpg-combat-foundation`.
+- If it proposes Mover, Traversal, camera, Foley, or a wider movement fantasy, require an isolated product and dependency evaluation before implementation.
+
+## Integration invariants
+
+- Do not query UObject gameplay state from worker-thread animation update.
+- Do not make combat success, hit detection, stamina use, or movement authority depend on cosmetic pose selection.
+- Do not replace Experience/PawnData composition with the GASP sample character hierarchy.
+- Do not replace RPG equipment truth with AnimBP variables or socket state.
+- Do not remove montage slots, gameplay notifies, or root-motion behavior while simplifying locomotion graphs.
+- Do not hard-reference the sample project or import its broad dependency closure.
+- Do not add Mover, Traversal, Locomotor, NetworkPrediction, sample camera, or Foley as incidental dependencies.
+
+## Verification matrix
+
+| Change | Minimum checks |
+| --- | --- |
+| Asset membership or metadata | Manifest/README update, content contract test, reference-closure audit, LFS diff review |
+| Pose Search or AnimGraph | Asset contract tests, AnimBP compile, database/schema validation, locomotion play test |
+| Threading or procedural animation | Threading and focused runtime tests, no worker-thread gameplay queries, LOD/performance check |
+| Movement input or rotation mode | Authority/autonomous/simulated-proxy test, correction behavior, late join |
+| Equipment load or sprint profile | Threshold and gear-change tests, movement/animation agreement, simulated proxies, correction, late join |
+| Curated mantle/vault/climb | Server obstacle validation, GAS cost/cancel, CMC/montage handoff, collision failure, correction, combat/death interruption, removable isolated pilot |
+| GAS montage or combat layer | Slot/root-motion/notifies, cancel/block behavior, attack windows, hit reactions |
+| Equipment, death, or ragdoll | Socket attachment, mesh ownership, death transition, corpse physics, late join where relevant |
+| New sample subsystem | Dependency closure, ownership/lifecycle design, isolated pilot, rollback path, multiplayer acceptance |

--- a/.agents/skills/unreal-lyra-expert/SKILL.md
+++ b/.agents/skills/unreal-lyra-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: unreal-lyra-expert
-description: Use for Unreal Engine 5 C++/Blueprint review, design, debugging, refactoring, networking, GAS, Enhanced Input, CommonUI, CommonGame, ModularGameplay, Game Features, Lyra Experiences, Lyra Interaction, and Lyra-rooted RPG inventory/equipment architecture. Inspect the project first; treat Lyra systems that exist in the project as canonical, but adapt inventory/equipment to the project's RPG model.
+description: Use for Unreal Engine 5 C++/Blueprint review, design, debugging, refactoring, networking, GAS, Enhanced Input, CommonUI, CommonGame, ModularGameplay, Game Features, Lyra Experiences, Lyra Interaction, and Lyra-rooted RPG inventory/equipment architecture. Inspect the project first; treat Lyra systems that exist in the project as canonical, adapt inventory/equipment to the project's RPG model, and pair with $unreal-gasp-expert when GASP locomotion or animation crosses PawnData, Experiences, GAS montages, movement replication, equipment, death, or ragdoll.
 ---
 
 # Unreal Lyra Expert
@@ -41,6 +41,15 @@ For this project, treat the following as established architecture, not optional 
 - Game Feature plugins are an intended feature and content activation boundary.
 - Lyra-style Interaction is intentionally adopted approximately 1:1 and should be reused instead of rebuilding one-off interaction traces or widget-driven interaction logic.
 - Equipment and Inventory use Lyra as the root architecture, but the implementation is adapted for this project's RPG systems.
+- Project-owned GASP CMC locomotion is composed through Lyra PawnData and Experiences; the Epic sample character is not the gameplay composition root.
+
+Coordinate with `$unreal-gasp-expert` instead of duplicating GASP guidance here.
+
+- Let `$unreal-gasp-expert` lead Motion Matching, Pose Search, trajectory, Blend Stack, Steering, Offset Root Bone, Foot Placement/IK, retargeting, animation threading, and locomotion parity work.
+- Use both skills when animation changes affect PawnData, Experiences, Game Features, character class or lifecycle, movement replication, GAS montage execution, equipment sockets, death, or ragdoll.
+- Keep Lyra-derived gameplay and composition systems authoritative while GASP owns locomotion presentation and animation-specific selection.
+- Preserve the project-owned curated CMC path; do not replace it with GASP's sample character, Mover, Traversal, camera, Foley, or experimental state-machine stack without explicit evaluation.
+- Let the GASP skill load its [GASP-Lyra integration contract](../unreal-gasp-expert/references/gasp-lyra-integration.md) when both domains are active.
 
 Inventory/equipment guidance:
 
@@ -165,6 +174,7 @@ Use stronger decision heuristics when choosing a pattern.
 - If a feature needs contextual world use, pickups, containers, crafting stations, harvest nodes, doors, NPC vendors, loot objects, or RPG interaction gating, check the adopted Lyra Interaction path first.
 - If a feature needs cooldowns, costs, state gating, combat-state ownership, or gameplay-triggered status handling, bias toward GAS when GAS already owns that domain.
 - If a feature modifies equipment, item ownership, item stats, ability grants from equipment, or replicated item state, extend the Lyra-rooted RPG inventory/equipment architecture.
+- If a feature modifies GASP locomotion or animation presentation and also touches Lyra composition, movement replication, GAS montages, equipment, death, or ragdoll, use `$unreal-gasp-expert` with this skill.
 - If behavior repeats across many actors, prefer a component, subsystem-appropriate abstraction, or reusable gameplay pattern over copy-paste logic.
 - If content is optional, delayed, or large, prefer soft references and scalable asset-loading patterns over hard reference chains.
 - If a problem is only a local bug, solve it locally before proposing architectural expansion.

--- a/.agents/skills/unreal-lyra-expert/agents/openai.yaml
+++ b/.agents/skills/unreal-lyra-expert/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Unreal Lyra Expert"
   short_description: "UE5 Lyra-derived RPG architecture expert"
-  default_prompt: "Inspect the project first. Treat Experiences, Game Features, Lyra Interaction, and Lyra-rooted RPG inventory/equipment as established project architecture when present. Preserve project-specific RPG adaptations instead of reverting to plain Lyra sample behavior. Prefer project-compatible Unreal practices, verify engine version before using version-specific APIs, and add concise documentation comments for designer-facing DataAsset, Blueprint, config, replicated, saved, and gameplay-facing fields by default."
+  default_prompt: "Use $unreal-lyra-expert to inspect the project first, preserve adopted Lyra/RPG architecture and project-compatible Unreal practices, verify engine version, and document designer-facing APIs; pair with $unreal-gasp-expert when GASP animation crosses PawnData, Experiences, GAS montages, movement replication, equipment, death, or ragdoll."
 
 policy:
   allow_implicit_invocation: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,11 +10,13 @@ Established architecture:
 - Lyra Interaction is adopted approximately 1:1.
 - Inventory and Equipment use Lyra as the root architecture.
 - Inventory and Equipment are adapted for RPG systems.
+- GASP CMC locomotion is a project-owned, curated animation path integrated through Lyra PawnData and Experiences.
 
 Use the closest matching skill:
 - Use `$survival-rpg-project` for game identity, feature scope, first-playable priorities, survival/crafting/progression tradeoffs, portal fantasy, and long-term resource relevance.
 - Use `$survival-rpg-combat-foundation` for combat, equipment, loadouts, item instances, ability grants, mastery/progression, runes, portal combat, Dungeonbreak, and combat GameFeature content.
 - Use `$unreal-lyra-expert` for Unreal Engine, Lyra-derived architecture, GAS, replication, CommonUI/CommonGame, Enhanced Input, Experiences, Game Features, Lyra Interaction, and Lyra-rooted RPG inventory/equipment implementation.
+- Use `$unreal-gasp-expert` for Game Animation Sample Project (GASP), CMC locomotion, load-aware RPG movement, sprint/gait profiles, curated mantle/vault/climb traversal, Motion Matching, Pose Search, trajectory, procedural animation, retargeting, animation threading, and multiplayer locomotion parity.
 - Use `$survival-rpg-orchestrator` for broad or ambiguous multi-system tasks that need routing before implementation.
 
 Architecture guardrails:
@@ -23,6 +25,10 @@ Architecture guardrails:
 - Preserve RPG inventory/equipment adaptations.
 - Do not revert RPG systems to plain Lyra sample behavior unless explicitly requested.
 - Do not introduce unrelated Lyra subsystems only because Lyra has them.
+- Treat Epic's GASP project as a comparison source, not a runtime dependency; preserve the project-owned CMC/Pose Search implementation.
+- Reuse GASP traversal assets only through project-owned CMC/GAS/Motion-Warping seams; do not import the full GASP Mover/Traversal stack, Locomotor, sample camera, Foley, or experimental state-machine content without an explicit isolated evaluation.
+- Pair `$unreal-gasp-expert` with `$unreal-lyra-expert` when animation work touches PawnData, Experiences, character lifecycle, movement replication, GAS montages, equipment, death, or ragdoll.
+- Add `$survival-rpg-combat-foundation` when GASP work touches attacks, dodge, block, hit reactions, combat tags, montage notifies, or equipment-granted combat behavior.
 
 ## Documentation defaults
 
@@ -60,3 +66,4 @@ Do not add comments for obvious local variables or trivial private helpers unles
 Verification:
 - Do not claim the project compiles unless the relevant Unreal build was actually run.
 - For replicated gameplay, check server authority, replicated state, late join behavior, and OnRep / FastArray behavior.
+- For GASP animation changes, check worker-thread safety, simulated-proxy inputs, late join, montage/root-motion compatibility, and project-local asset dependencies.


### PR DESCRIPTION
## What changed

- add the repo-local `$unreal-gasp-expert` skill with implicit activation metadata
- document the GASP/Lyra/GAS ownership and integration contract
- route GASP animation work through `AGENTS.md`, the Lyra expert, the project orchestrator, and the combat foundation skill
- define project-owned CMC/Pose Search as the production path
- cover load-aware RPG locomotion, heavy running, curated mantle/vault/climb traversal, animation-thread safety, simulated proxies, and late join
- keep Epic's GASP and Lyra projects as optional comparison sources rather than runtime dependencies

## Why

SurvivalRpg already has a curated GASP CMC locomotion path, but Codex lacked a dedicated specialist contract for Motion Matching, Pose Search, multiplayer animation parity, combat montage seams, and Lyra composition. The new skill makes those boundaries explicit and keeps future work aligned with the existing architecture.

## Impact

This changes Codex guidance and routing only. It does not modify Unreal gameplay code, assets, or the current runtime integration.

## Validation

- `quick_validate.py` passed for all four affected skill folders
- `git diff --check` passed
- no Unreal build was required because the PR contains only Markdown and YAML skill files
