### PR TITLE
chore: configure Unreal MCP for Codex

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+[mcp_servers.unreal-mcp]
+url = "http://127.0.0.1:8000/mcp"

--- a/Config/DefaultEditorPerProjectUserSettings.ini
+++ b/Config/DefaultEditorPerProjectUserSettings.ini
@@ -1,2 +1,8 @@
 [ContentBrowser]
 ContentBrowserTab1.SelectedPaths=/Game/ThirdPersonBP
+
+[/Script/ModelContextProtocolEngine.ModelContextProtocolSettings]
+ServerUrlPath=/mcp
+ServerPortNumber=8000
+bAutoStartServer=True
+bEnableToolSearch=True

--- a/SurvivalRpg.uproject
+++ b/SurvivalRpg.uproject
@@ -95,6 +95,14 @@
 			"Enabled": true
 		},
 		{
+			"Name": "ModelContextProtocol",
+			"Enabled": true
+		},
+		{
+			"Name": "AllToolsets",
+			"Enabled": true
+		},
+		{
 			"Name": "AsyncMessageSystem",
 			"Enabled": true
 		},


### PR DESCRIPTION
## Summary

- Enable Unreal Engine 5.8's experimental Unreal MCP and All Toolsets plugins.
- Add a project-scoped Codex MCP endpoint at `http://127.0.0.1:8000/mcp`.
- Auto-start the local MCP server with tool search enabled when the editor opens.

## Why

This connects Codex to Epic's official in-editor MCP server so editor state, assets, toolsets, and automation can be inspected through structured Unreal tools while the project is open.

## Impact

The Unreal Editor starts a loopback-only MCP server for this project. Regular source editing and builds remain unchanged; live MCP tools are available only while the editor process is running.

## Validation

- Parsed `SurvivalRpg.uproject` successfully and verified both plugin entries.
- Verified the project-scoped Codex configuration with `codex mcp list`.
- Confirmed Unreal listens on port 8000 and negotiates an MCP session.
- Listed 53 Unreal toolsets through MCP.
- Successfully ran read-only `GetSelectedActors` and `IsPIERunning` calls.
- Ran `git diff --check origin/master...HEAD`.
