### PR TITLE
Clarify GASP C++ and Blueprint boundaries

### DIFF
--- a/.agents/skills/unreal-gasp-expert/SKILL.md
+++ b/.agents/skills/unreal-gasp-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: unreal-gasp-expert
-description: Use for Unreal Engine 5 Game Animation Sample Project (GASP) CMC locomotion, RPG movement, equipment-load-aware gait and sprint profiles, curated mantle/vault/climb/traversal, Motion Matching, Pose Search schemas/databases, trajectory generation, Blend Stack, Steering, Offset Root Bone, Foot Placement/IK, retargeting, animation-thread safety, multiplayer locomotion parity, and integration with SurvivalRpg's Lyra-derived PawnData, Experiences, GAS montages, equipment, death, or ragdoll. Inspect the project and local GASP reference first; preserve project-owned curated content and pair with $unreal-lyra-expert at gameplay, composition, or character-lifecycle boundaries.
+description: Use for Unreal Engine 5 Game Animation Sample Project (GASP) CMC locomotion, RPG movement, equipment-load-aware gait and sprint profiles, curated mantle/vault/climb/traversal, Motion Matching, Pose Search schemas/databases, trajectory generation, Blend Stack, Steering, Offset Root Bone, Foot Placement/IK, retargeting, animation-thread safety, multiplayer locomotion parity, GASP C++/Blueprint/DataAsset ownership, URpgAnimInstance refactoring, and integration with SurvivalRpg's Lyra-derived PawnData, Experiences, GAS montages, equipment, death, or ragdoll. Inspect the project and local GASP reference first; preserve project-owned curated content and pair with $unreal-lyra-expert at gameplay, composition, or character-lifecycle boundaries.
 ---
 
 # Unreal GASP Expert
@@ -37,14 +37,33 @@ Place the request in one or more concrete categories:
 
 Choose the smallest slice that proves the intended behavior. Separate observed GASP behavior, current SurvivalRpg behavior, and the proposed adaptation.
 
+## Choose the implementation boundary explicitly
+
+Treat the Epic GASP project as Blueprint-authored project glue built on native Engine animation systems. Its lack of project C++ proves neither that a production Lyra integration should stay Blueprint-only nor that all adaptation logic belongs in native code.
+
+Before implementing a slice, state which responsibility belongs in C++, Blueprint, or data assets and why.
+
+- Keep authority, replication, CharacterMovement truth, server-validated traversal, game-thread-to-worker snapshots, world queries, engine-facing custom AnimNodes, and narrowly scoped durable pure resolvers in C++.
+- Keep AnimGraph composition, layer/mask wiring, blend and warping feel, database membership, animation references, character/profile tuning, and presentation-only configuration in AnimBPs, Choosers, or DataAssets by default.
+- Keep gameplay state in GAS, equipment, CharacterMovement, and Lyra lifecycle systems. Let animation consume only read-only presentation inputs.
+- Require a concrete threading, networking, engine-integration, performance, or deterministic-testability reason before moving cosmetic selection or tuning into C++.
+- Do not translate a complex native state machine one-to-one into Blueprint. Reduce and separate responsibilities first, then place each remaining part at its natural boundary.
+
+Treat `URpgAnimInstance` as a narrow integration coordinator, not the default owner of every GASP rule.
+
+- Before adding another enum, state machine, watchdog, database switch, or asset classifier, inspect whether an existing responsibility should be split into a focused value-only runtime/helper or moved into a profile, Chooser, AnimBP, or DataAsset.
+- Prefer configured roles, tags, or explicit profile membership over hard-coded asset package-path classification.
+- Avoid duplicating the same database contract across enums, fixed arrays, switch statements, validation, and tests when one data-driven contract can own it.
+- Preserve a concise mapping from relevant source GASP Blueprint/Chooser behavior to the SurvivalRpg C++/Blueprint/DataAsset seam so the adaptation remains learnable.
+
 ## Preserve the project-owned CMC architecture
 
 - Treat the current CMC/Pose Search path as the production default unless the user explicitly requests a replacement evaluation.
 - Keep the stock GASP character, AnimBP, databases, and supporting systems as reference material rather than runtime dependencies.
 - Do not introduce GASP's full Mover/Traversal stack, Locomotor, NetworkPrediction, sample camera, Foley, audio, experimental state machines, generic retarget collections, or dense sample content merely because the sample contains them.
 - Require an isolated dependency and lifecycle evaluation before adopting any excluded sample subsystem.
-- Preserve the authoritative project skeleton, `URpgAnimInstance`, project-local schemas/databases, and the `RpgGaspLocomotion` content boundary.
-- Inspect current runtime selection before assuming the sample's Chooser or State Controller should own selection. Preserve project-native selection where it is intentional.
+- Preserve the authoritative project skeleton, the native `URpgAnimInstance`/proxy integration seam, project-local schemas/databases, and the `RpgGaspLocomotion` content boundary.
+- Inspect current runtime selection before assuming the sample's Chooser or State Controller should own selection. Preserve project-native selection where it is intentional without treating that choice as permission to hard-code presentation tuning or grow a monolithic AnimInstance.
 - Record intentional source deviations in the plugin contract, manifest, or focused tests rather than relying on memory or issue-specific scripts.
 
 ## Shape RPG locomotion and curated traversal
@@ -70,6 +89,7 @@ Choose the smallest slice that proves the intended behavior. Separate observed G
 - Snapshot gameplay tags or gameplay-derived gates on the game thread before animation consumes them.
 - Keep Motion Matching selection and procedural animation cosmetic. Never make authoritative gameplay outcomes depend on the locally selected pose.
 - Preserve parallel animation update for non-GASP AnimBPs and avoid adding game-thread work when the feature is disabled.
+- Keep game-thread snapshots focused. Do not move presentation-only state into the proxy merely to avoid a clean AnimBP, Chooser, or DataAsset boundary.
 
 ## Preserve source fidelity without importing source coupling
 
@@ -115,9 +135,10 @@ Use the narrowest verification that proves the change, then widen when the bound
 - Validate affected assets, AnimBP compilation, parent class, skeleton, exposed defaults, graph nodes, reference closure, and cook/load assumptions.
 - Test locomotion in editor for starts, stops, pivots, gait boundaries, crouch, turns, jump/landing, uneven ground, LOD changes, and rapid input reversals.
 - For replicated changes, test a listen server with at least two clients, simulated proxies, correction scenarios, and late join.
+- Treat value-only/unit simulations as regression coverage, not as proof of real replication, correction, notify delivery, or late-join behavior.
 - For load-aware movement, test equipment changes while idle and moving, all load thresholds, sprint/gait transitions, prediction correction, simulated proxies, and late join.
 - For traversal, test authoritative obstacle validation, activation cost, montage/root-motion handoff, cancellation, collision failure, correction, combat interruption, death/ragdoll, and rollback of the isolated feature.
 - For gameplay integration, run montage, notify, root-motion, equipment socket, hit reaction, death, corpse, and ragdoll regressions.
 - Inspect Pose Search cost/debug output and profile animation-thread/game-thread cost before tuning by feel alone.
 
-Report which project files and reference assets were inspected, which behavior intentionally follows GASP, which behavior intentionally differs, and which verification actually ran.
+Report which project files and reference assets were inspected, which behavior intentionally follows GASP, which behavior intentionally differs, why each changed responsibility lives in C++/Blueprint/DataAssets, and which verification actually ran.

--- a/.agents/skills/unreal-gasp-expert/references/gasp-lyra-integration.md
+++ b/.agents/skills/unreal-gasp-expert/references/gasp-lyra-integration.md
@@ -19,6 +19,8 @@ Never let either sample project override a deliberate SurvivalRpg adaptation wit
 | --- | --- | --- | --- |
 | Locomotion pose selection and presentation | GASP adaptation | Lyra for lifecycle/network inputs | Keep cosmetic state outside gameplay authority. |
 | AnimGraph, Pose Search, trajectory, procedural nodes | GASP adaptation | Combat when montage layers overlap | Preserve thread-safe snapshots and montage slots. |
+| Native animation integration | `URpgAnimInstance`/proxy and focused native helpers | AnimBP/DataAssets for presentation | Keep C++ narrow: snapshots, engine-facing hooks, world-query handoff, and justified pure resolvers rather than one growing state owner. |
+| Presentation composition and tuning | AnimBP, Choosers, profiles, and DataAssets | Native integration for safe inputs | Keep blend feel, database membership/references, masks, and cosmetic thresholds visible and data-driven by default. |
 | Pawn class and pawn configuration | Lyra/PawnData | GASP for AnimBP requirements | Compose through PawnData and Experience rather than a sample-owned character path. |
 | Mode and feature composition | Lyra Experiences/Game Features | GASP for required assets/plugins | Keep activation data-driven and dependencies narrow. |
 | Abilities, costs, cooldowns, blockers, combat tags | GAS/Combat | GASP for read-only animation gates | Snapshot tags for animation; never infer authoritative gameplay from a selected pose. |
@@ -35,19 +37,20 @@ Never let either sample project override a deliberate SurvivalRpg adaptation wit
 
 Preserve these seams unless an inspected project change proves that they moved:
 
-- `URpgAnimInstance` is the native base for the GASP player AnimBP.
+- `URpgAnimInstance` is the native base and integration coordinator for the GASP player AnimBP; it is not automatically the owner of every presentation rule.
 - The AnimInstance proxy captures gameplay and movement inputs on the game thread.
 - The active GASP character is selected through PawnData and an Experience.
 - `GetMesh()` remains the montage, notify, equipment socket, corpse, and ragdoll mesh.
 - `DefaultSlot` remains available to GAS combat montages.
 - Curated sequences preserve their authored root-motion import settings while the AnimInstance extraction policy remains root motion from montages only.
-- Runtime database selection remains project-native even when its logic mirrors selected GASP chooser domains.
+- Runtime database selection remains project-owned even when its logic mirrors selected GASP chooser domains. Project-owned may combine focused native resolvers with asset-driven configuration; it does not require monolithic native ownership.
 - The content-only plugin owns curated locomotion assets but does not choose PawnData, Experience, or AnimBP.
 - Equipment/GAS and CharacterMovement own load and traversal state; the AnimInstance receives only animation-safe snapshots.
 
 ## Cross-system decision rules
 
 - If a change affects only source parity, retargeted content, Pose Search metadata, or cosmetic graph tuning, let `$unreal-gasp-expert` lead.
+- If a change is presentation-only, prefer AnimBP, Chooser, profile, or DataAsset ownership unless measured performance, engine integration, thread safety, or durable deterministic testing justifies a focused native resolver.
 - If it affects PawnData, Experience activation, character class, movement replication, ASC access, montage lifecycle, death, or ragdoll, use `$unreal-gasp-expert` with `$unreal-lyra-expert`.
 - If it affects attacks, dodge, block, hit reactions, combat tags, montage notifies, equipment grants, or damage windows, add `$survival-rpg-combat-foundation`.
 - If it affects load-aware movement, sprint, stamina, traversal abilities, or equipment-driven gait, use `$unreal-gasp-expert` with `$unreal-lyra-expert` and `$survival-rpg-combat-foundation`.
@@ -62,6 +65,9 @@ Preserve these seams unless an inspected project change proves that they moved:
 - Do not remove montage slots, gameplay notifies, or root-motion behavior while simplifying locomotion graphs.
 - Do not hard-reference the sample project or import its broad dependency closure.
 - Do not add Mover, Traversal, Locomotor, NetworkPrediction, sample camera, or Foley as incidental dependencies.
+- Do not add another presentation state machine, watchdog, database switch, or package-path classifier to `URpgAnimInstance` before evaluating a focused helper/runtime split and an AnimBP/Chooser/DataAsset alternative.
+- Do not move complex native behavior one-to-one into Blueprint; simplify and separate the responsibility first.
+- Do not claim multiplayer completion from value-only unit tests. Verify authority, autonomous proxy, simulated proxy, correction, notify delivery, and late join in an actual network session when the change crosses those seams.
 
 ## Verification matrix
 
@@ -76,3 +82,4 @@ Preserve these seams unless an inspected project change proves that they moved:
 | GAS montage or combat layer | Slot/root-motion/notifies, cancel/block behavior, attack windows, hit reactions |
 | Equipment, death, or ragdoll | Socket attachment, mesh ownership, death transition, corpse physics, late join where relevant |
 | New sample subsystem | Dependency closure, ownership/lifecycle design, isolated pilot, rollback path, multiplayer acceptance |
+| C++/Blueprint/DataAsset boundary or native refactor | Responsibility map, behavior-preserving focused tests, AnimBP/data validation, build after native changes, and real network checks when replicated seams are touched |


### PR DESCRIPTION
## Summary

- define an explicit C++ / AnimBP / DataAsset / Chooser ownership boundary for GASP work
- keep URpgAnimInstance as a narrow native integration coordinator instead of a default feature owner
- prefer data-driven presentation tuning and database mapping
- require real multiplayer sessions for replication, correction, notify, and late-join claims
- extend the GASP/Lyra integration reference with the same ownership and verification contract

## Why

The local Epic GASP project is Blueprint-authored project glue on top of native Engine animation systems. SurvivalRpg still needs native Lyra, networking, threading, and AnimNode seams, but recent work concentrated too many unrelated presentation responsibilities in URpgAnimInstance. The skill now requires every slice to justify and document its implementation boundary.

Related architecture follow-up: #81.

The GASP backlog was rebaselined in #46, #55, #57, #62, #70, #74, and #75.

## Validation

- skill-creator quick_validate.py: passed
- fresh crouch-family forward test: ownership and real-network requirements applied correctly
- git diff --check: passed
- no Unreal build run; this PR changes skill documentation only