### PR TITLE
Extract GASP trajectory runtime seam for #81

### DIFF
--- a/Plugins/RpgGaspLocomotion/Docs/README.md
+++ b/Plugins/RpgGaspLocomotion/Docs/README.md
@@ -2,6 +2,9 @@
 
 This content-only plugin owns the curated Game Animation Sample Project (GASP) locomotion substrate for SurvivalRpg. It does not select a PawnData, Experience, or Animation Blueprint; the isolated runtime pilot was delivered by issue #54.
 
+The behavior-preserving source-to-project responsibility map and the staged issue #81 extraction
+order are recorded in [RuntimeOwnershipMap.md](RuntimeOwnershipMap.md).
+
 ## Curated slice
 
 - 190 retargeted `UAnimSequence` assets using `/Game/SurvivalRpg/Characters/Mannequins/Meshes/SK_Mannequin`

--- a/Plugins/RpgGaspLocomotion/Docs/RuntimeOwnershipMap.md
+++ b/Plugins/RpgGaspLocomotion/Docs/RuntimeOwnershipMap.md
@@ -1,0 +1,75 @@
+# GASP runtime ownership map
+
+This map records how the relevant UE 5.8 GASP CMC Blueprint responsibilities are adapted by
+SurvivalRpg. It is the behavior-preserving architecture baseline for issue #81; it does not make
+the sample project a runtime dependency.
+
+## Ownership rules
+
+- CharacterMovement, GAS, equipment, and the Lyra-derived character lifecycle own gameplay truth.
+- `URpgAnimInstance::InitializeWithAbilitySystem` owns the game-thread ASC/tag-map lifecycle.
+  `FRpgAnimInstanceProxy::PreUpdate` collects actor, movement-component, and world data and copies
+  the already mirrored gameplay-tag booleans into the immutable proxy snapshot.
+- Worker-thread animation consumes only immutable values and already loaded animation assets.
+- AnimBP, Choosers, Pose Search databases, and future presentation profiles own concrete asset
+  membership, graph composition, blending, warping, IK feel, and presentation tuning.
+- Focused C++ helpers are retained only for engine callbacks, game-thread world queries, immutable
+  snapshots, custom AnimNodes, and small deterministic resolvers.
+
+## Source-to-project mapping
+
+| GASP CMC source responsibility | Current SurvivalRpg owner | Target owner | Intentional adaptation |
+| --- | --- | --- | --- |
+| `Update_PropertiesFromCharacter`, `Update_EssentialValues` | `InitializeWithAbilitySystem` for the ASC/tag map; `FRpgAnimInstanceProxy::PreUpdate` for the value snapshot | Existing ASC lifecycle plus proxy snapshot boundary | ASC delegates are initialized on the game thread. `PreUpdate` copies mirrored tag booleans and reads CharacterMovement/world state; no sample character hierarchy is imported. |
+| `Update_Trajectory` | Proxy `PreUpdate` orchestrates `PoseSearchGenerateTransformTrajectory`; `RpgPoseSearchTrajectory` owns its sampling constants and validation/correction helpers | Same split: proxy owns generation and snapshot lifetime; focused native helper owns the sampling/correction mechanism | Controller-yaw extrapolation is disabled for the controller-facing project character; raw history stays separate from worker-facing corrected output. |
+| `HandleTransformTrajectoryWorldCollisions` | `RpgPoseSearchTrajectory::ResolveWorldCollision` | Focused game-thread trajectory helper | Uses bounded sphere sweeps, CharacterMovement walkability, explicit validity, floor projection, and a pointer-free landing prediction. It never changes movement or touchdown authority. |
+| `Update_MotionMatching` | `URpgAnimInstance::UpdateGaspMotionMatching`, native role resolver, AnimBP database defaults | Thin native node callback plus designer-owned database/profile configuration | The project keeps a curated role contract and excludes GASP BranchIn, experimental state-machine, Foley, and broad Chooser dependencies. Database externalization remains a later #81 slice. |
+| `IsMoving`, `IsStarting`, `IsPivoting` | `IsGroundMotionMatchingChooserMoving` and `ResolveMotionMatchingDatabaseRoles`; the latter consumes the GASP-authored future-velocity window and project gait/stance snapshot | Focused value-only Motion Matching selection runtime plus validated designer-owned database/profile membership | Project gameplay gait and rotation mode constrain the authored source predicates. Selection remains cosmetic and reads only the proxy snapshot. |
+| `Get_MMInterruptMode` | `ShouldInterruptGroundMotionMatching` plus explicit turn/landing request and playback latches in `UpdateGaspMotionMatching` | Focused value-only Motion Matching runtime coordinated by the native AnimNode callback | Interrupts also protect physical movement-domain changes and one-shot project turn/landing requests; they never become replicated gameplay state. |
+| `Update_MotionMatching_PostSelection` | `URpgAnimInstance::UpdateGaspMotionMatchingPostSelection` and request latches | Thin engine callback bridge plus focused value-only runtimes | Completed-search metadata is cosmetic only. Unlike source GASP, the project does not apply `Override Motion Matching Blend Settings`; the authored node retains uniform `0.2 s` blending after the FastFeet turn regression. |
+| `Update_States`, `Update_Logic` | Proxy movement snapshot plus native turn/jump/landing presentation lifecycles | Gameplay state in CharacterMovement/GAS; focused presentation runtimes and AnimBP/profile tuning | The sample's broad and experimental state controller is not copied. Physical airborne/grounded state always comes from CharacterMovement. |
+| `ShouldTurnInPlace`, `Get_TrajectoryTurnAngle` | `URpgAnimInstance` turn-in-place resolver, synthetic trajectory, latch, and watchdog | Focused turn-in-place runtime; feel thresholds in designer configuration | Turns remain controller-facing and cosmetic; they never rotate the authoritative actor. Extraction is pending in #81. |
+| `JustLanded_Light`, `JustLanded_Heavy`, `Get_LandVelocity`, `PlayLand`, `PlayMovingLand` | Proxy pre-touchdown snapshot plus `URpgAnimInstance` landing resolver/latch/watchdog | Focused landing runtime; database membership and feel in assets | Landing begins only on the physical CMC touchdown edge. Idle/Walk/Run Light/Heavy are curated; Sprint landing remains deferred until authoritative Sprint issue #62. |
+| `AllowFootPinning`, foot-placement settings helpers | Proxy game-thread traces, `RpgFootPlacement` value helpers, `FAnimNode_RpgFootPlacement` | Existing focused native types/node plus AnimBP tuning | Project-local snapshots make the node worker-safe and preserve moving-base handling; crouch stays opted out by default. |
+| `Get_DesiredFacing`, `EnableSteering`, Orientation Warping gates | `URpgAnimInstance::GetGaspBlendStackInputs` and authored curves | AnimBP/presentation profile, with only value inputs supplied natively | Current behavior is preserved, but package-path asset classification must be replaced by explicit validated profile membership in a later #81 slice. |
+| Sparse database and state selection | Fixed native role enum/mapping plus project-local Pose Search assets | Validated designer-owned profile/Chooser with stable native schema only where required | Curated databases remain project-owned; fixed mappings are compatibility state during #81, not the intended final presentation owner. |
+| Slide and other optional locomotion families | Not adopted; no runtime owner | No #81 owner; Adopt/Defer/Reject decision belongs to audit issue #74 | #81 does not pre-approve content families or grow the AnimInstance role architecture. |
+| `Debug_ExperimentalStateMachine`, full GASP Mover/Traversal stack, sample camera, Foley | Not adopted; no runtime owner | No runtime owner without a dedicated isolated feature evaluation | These sample subsystems are outside the CMC pilot contract and are never incidental dependencies. Curated traversal assets may only enter later through project-owned CMC/GAS/Motion-Warping seams. |
+| Sample character/mode composition | Existing `BP_Rpg_Character_GASP`, `DA_PawnData_GASP`, and pilot Experience | Existing Lyra-derived pilot composition remains unchanged | Only the GASP sample character hierarchy is not adopted. #81 does not change PawnData, Experience selection, or the default pawn cutover. |
+
+## Slice 1 boundary and verification contract
+
+- **Authority and lifecycle:** CharacterMovement remains authoritative. On each eligible game-thread
+  `PreUpdate`, the proxy generates the raw trajectory and, when enabled, invokes the bounded
+  world-collision helper. It then publishes only corrected trajectory and pointer-free prediction
+  values to animation consumers. Worker updates perform no world query.
+- **Native type count:** zero new `UObject` classes. The existing reflected settings and prediction
+  structs keep their names and defaults but move to a focused header; one non-reflected value result
+  and namespace functions isolate the engine-facing world-query mechanism for deterministic tests.
+- **Replication and persistence:** none added or changed. Trajectory correction and landing
+  prediction are locally derived cosmetic presentation state; they neither replicate nor save and
+  never start a physical landing.
+- **Designer/editor work:** no Blueprint, DataAsset, Pose Search database, manifest, or content asset
+  changes. Collision settings stay on the existing AnimBP-facing properties. No MCP/editor authoring
+  is required for this slice.
+- **Stable tests:** `SurvivalRpg.Animation.Trajectory.CollisionAndTimeToLand` owns sampling,
+  collision, walkability, bounded-query, and landing-prediction semantics;
+  `SurvivalRpg.Animation.MotionMatching.GroundDatabaseResolver` protects the shared sampling
+  contract; `SurvivalRpg.Animation.Gasp.PilotAssetContract` protects reflected defaults and the
+  existing AnimBP bindings.
+
+## Issue #81 extraction order
+
+1. Extract GASP sampling constants plus collision, prediction, and value helpers from
+   `URpgAnimInstance` while preserving reflected settings, proxy values, semantics, and tests.
+   `PoseSearchGenerateTransformTrajectory` orchestration and snapshot lifetime remain in proxy
+   `PreUpdate`.
+2. Replace package-name presentation classification with explicit, validated designer-owned
+   membership that is safe to consume during worker updates.
+3. Split Motion Matching role resolution, turn-in-place, and jump/landing into focused value-only
+   runtimes without changing serialized AnimBP names or behavior.
+4. Externalize database-to-role mapping and feel tuning into an asset/profile seam; keep the
+   AnimInstance as the stable AnimBP facade and engine callback coordinator.
+
+Each step must build independently and keep the pilot Experience reversible. New locomotion
+families, Sprint authority, combat polish, and default PawnData cutover are separate issues.

--- a/Source/SurvivalRpg/Animation/RpgAnimInstance.cpp
+++ b/Source/SurvivalRpg/Animation/RpgAnimInstance.cpp
@@ -50,357 +50,12 @@ constexpr float LightLandingIdleSpeedThreshold = 3.0f;
 constexpr float LandingMovementHandoffWindow = 0.3f;
 constexpr float BackwardJumpStartHoldTimeout = 1.25f;
 constexpr float BackwardJumpStartReleaseLeadTime = 0.2f;
-constexpr float TrajectoryFloorOffsetMin = 0.001f;
-constexpr float TrajectoryFloorOffsetMax = 10.0f;
-constexpr float TrajectoryObstacleHeightMin = 1.0f;
-constexpr float TrajectoryObstacleHeightMax = 1000.0f;
-constexpr float TrajectorySweepRadiusMin = 0.1f;
-constexpr float TrajectorySweepRadiusMax = 20.0f;
-constexpr int32 TrajectoryCollisionMaxPredictionSamples = 15;
-
-struct FRpgTrajectoryCollisionResolution
-{
-	FVector LandingLocation = FVector::ZeroVector;
-	FVector LandingNormal = FVector::UpVector;
-	float TimeToLand = -1.0f;
-	float PredictionHorizon = 0.0f;
-	int32 WorldQueryCount = 0;
-	bool bHasWalkableLanding = false;
-};
-
-using FRpgTrajectorySweepQuery = TFunctionRef<bool(
-	FHitResult& OutHit,
-	const FVector& TraceStart,
-	const FVector& TraceEnd,
-	ECollisionChannel TraceChannel,
-	const FCollisionShape& CollisionShape)>;
-using FRpgTrajectoryWalkabilityQuery = TFunctionRef<bool(const FHitResult& HitResult)>;
-
-bool IsTransformTrajectoryFiniteInternal(const FTransformTrajectory& Trajectory)
-{
-	if (Trajectory.Samples.IsEmpty())
-	{
-		return false;
-	}
-
-	float PreviousTime = -MAX_flt;
-	for (const FTransformTrajectorySample& Sample : Trajectory.Samples)
-	{
-		if (!FMath::IsFinite(Sample.TimeInSeconds) ||
-			Sample.TimeInSeconds + UE_SMALL_NUMBER < PreviousTime ||
-			Sample.Position.ContainsNaN() || Sample.Facing.ContainsNaN())
-		{
-			return false;
-		}
-		PreviousTime = Sample.TimeInSeconds;
-	}
-	return true;
-}
-
-bool IsTrajectoryCollisionSettingsRuntimeValid(
-	const FRpgTrajectoryCollisionSettings& Settings,
-	int32 GeneratedPredictionSampleCount)
-{
-	const int32 TraceChannel = static_cast<int32>(Settings.TraceChannel.GetValue());
-	return Settings.bEnabled &&
-		FMath::IsFinite(Settings.FloorOffset) &&
-		Settings.FloorOffset >= TrajectoryFloorOffsetMin &&
-		Settings.FloorOffset <= TrajectoryFloorOffsetMax &&
-		FMath::IsFinite(Settings.MaxObstacleHeight) &&
-		Settings.MaxObstacleHeight >= TrajectoryObstacleHeightMin &&
-		Settings.MaxObstacleHeight <= TrajectoryObstacleHeightMax &&
-		FMath::IsFinite(Settings.SweepRadius) &&
-		Settings.SweepRadius >= TrajectorySweepRadiusMin &&
-		Settings.SweepRadius <= TrajectorySweepRadiusMax &&
-		GeneratedPredictionSampleCount > 0 &&
-		Settings.MaxPredictionSamples >= 1 &&
-		Settings.MaxPredictionSamples <= GeneratedPredictionSampleCount &&
-		Settings.MaxPredictionSamples <= TrajectoryCollisionMaxPredictionSamples &&
-		TraceChannel >= static_cast<int32>(ECC_WorldStatic) &&
-		TraceChannel < static_cast<int32>(ECC_OverlapAll_Deprecated);
-}
-
-bool ProjectTrajectoryPointOntoHitPlane(
-	const FVector& Point,
-	const FVector& GravityDirection,
-	const FVector& PlanePoint,
-	const FVector& PlaneNormal,
-	FVector& OutProjectedPoint)
-{
-	if (Point.ContainsNaN() || GravityDirection.ContainsNaN() ||
-		PlanePoint.ContainsNaN() || PlaneNormal.ContainsNaN() ||
-		GravityDirection.IsNearlyZero() || PlaneNormal.IsNearlyZero())
-	{
-		return false;
-	}
-
-	const FVector SafeGravityDirection = GravityDirection.GetSafeNormal();
-	const FVector SafePlaneNormal = PlaneNormal.GetSafeNormal();
-	const double PlaneDenominator = FVector::DotProduct(
-		SafeGravityDirection,
-		SafePlaneNormal);
-	if (!FMath::IsFinite(PlaneDenominator) ||
-		FMath::Abs(PlaneDenominator) <= UE_SMALL_NUMBER)
-	{
-		return false;
-	}
-
-	const double DistanceAlongGravity = FVector::DotProduct(
-		PlanePoint - Point,
-		SafePlaneNormal) / PlaneDenominator;
-	if (!FMath::IsFinite(DistanceAlongGravity))
-	{
-		return false;
-	}
-
-	OutProjectedPoint = Point + SafeGravityDirection * DistanceAlongGravity;
-	return !OutProjectedPoint.ContainsNaN();
-}
-
-float CalculateTrajectoryLandingTimeInternal(
-	float PreviousTime,
-	float CurrentTime,
-	const FVector& PreviousPosition,
-	const FVector& CurrentPosition,
-	const FVector& LandingLocation,
-	const FVector& UpDirection)
-{
-	if (!FMath::IsFinite(PreviousTime) || !FMath::IsFinite(CurrentTime) ||
-		CurrentTime < PreviousTime || PreviousPosition.ContainsNaN() ||
-		CurrentPosition.ContainsNaN() || LandingLocation.ContainsNaN() ||
-		UpDirection.ContainsNaN() || UpDirection.IsNearlyZero())
-	{
-		return -1.0f;
-	}
-
-	const FVector SafeUpDirection = UpDirection.GetSafeNormal();
-	const float PreviousHeight = FVector::DotProduct(
-		PreviousPosition - LandingLocation,
-		SafeUpDirection);
-	const float CurrentHeight = FVector::DotProduct(
-		CurrentPosition - LandingLocation,
-		SafeUpDirection);
-	const float HeightDelta = PreviousHeight - CurrentHeight;
-	const float Alpha = HeightDelta > UE_SMALL_NUMBER
-		? FMath::Clamp(PreviousHeight / HeightDelta, 0.0f, 1.0f)
-		: 1.0f;
-	return FMath::Lerp(PreviousTime, CurrentTime, Alpha);
-}
-
 void ResetPoseSearchTrajectoryState(FRpgAnimInstanceProxy& Proxy)
 {
 	Proxy.RawTransformTrajectory.Samples.Reset();
 	Proxy.TransformTrajectory.Samples.Reset();
 	Proxy.TrajectoryLandingPrediction = FRpgTrajectoryLandingPrediction();
 	Proxy.DesiredControllerYawLastUpdate = 0.0f;
-}
-
-FRpgTrajectoryCollisionResolution ResolvePoseSearchTrajectoryCollision(
-	const FRpgTrajectoryCollisionSettings& Settings,
-	const FVector& GravityAcceleration,
-	bool bIsFalling,
-	const FTransformTrajectory& RawTrajectory,
-	FTransformTrajectory& OutTrajectory,
-	int32 GeneratedPredictionSampleCount,
-	FRpgTrajectorySweepQuery SweepQuery,
-	FRpgTrajectoryWalkabilityQuery WalkabilityQuery)
-{
-	FRpgTrajectoryCollisionResolution Result;
-	OutTrajectory = RawTrajectory;
-
-	FVector GravityDirection = FVector::ZeroVector;
-	float GravityMagnitude = 0.0f;
-	GravityAcceleration.ToDirectionAndLength(GravityDirection, GravityMagnitude);
-	if (!IsTrajectoryCollisionSettingsRuntimeValid(Settings, GeneratedPredictionSampleCount) ||
-		!IsTransformTrajectoryFiniteInternal(RawTrajectory) ||
-		GravityAcceleration.ContainsNaN() || GravityDirection.ContainsNaN() ||
-		!FMath::IsFinite(GravityMagnitude) || GravityMagnitude <= UE_SMALL_NUMBER)
-	{
-		return Result;
-	}
-
-	int32 CurrentSampleIndex = INDEX_NONE;
-	for (int32 SampleIndex = 0; SampleIndex < RawTrajectory.Samples.Num(); ++SampleIndex)
-	{
-		if (RawTrajectory.Samples[SampleIndex].TimeInSeconds > 0.0f)
-		{
-			CurrentSampleIndex = SampleIndex;
-			break;
-		}
-	}
-	if (CurrentSampleIndex == INDEX_NONE ||
-		CurrentSampleIndex + 1 >= RawTrajectory.Samples.Num())
-	{
-		return Result;
-	}
-
-	const FVector UpDirection = -GravityDirection;
-	const float CurrentSampleTime = RawTrajectory.Samples[CurrentSampleIndex].TimeInSeconds;
-	float PreviousRelativeTime = 0.0f;
-	FVector PreviousPosition = RawTrajectory.Samples[CurrentSampleIndex].Position;
-	float PostContactHeightAlongUp = 0.0f;
-	float FreeFallAccumulatedSeconds = 0.0f;
-	bool bHasPostContactHeight = false;
-	bool bHasLastWalkablePosition = false;
-	int32 ProcessedPredictionSamples = 0;
-	const int32 MaxPredictionSamples = FMath::Min(
-		Settings.MaxPredictionSamples,
-		GeneratedPredictionSampleCount);
-
-	for (int32 SampleIndex = CurrentSampleIndex + 1;
-		 SampleIndex < RawTrajectory.Samples.Num() &&
-		 ProcessedPredictionSamples < MaxPredictionSamples;
-		 ++SampleIndex)
-	{
-		const FTransformTrajectorySample& RawSample = RawTrajectory.Samples[SampleIndex];
-		FTransformTrajectorySample& CorrectedSample = OutTrajectory.Samples[SampleIndex];
-		const float RelativeTime = RawSample.TimeInSeconds - CurrentSampleTime;
-		if (!FMath::IsFinite(RelativeTime) ||
-			RelativeTime <= PreviousRelativeTime + UE_SMALL_NUMBER)
-		{
-			break;
-		}
-
-		const float StepSeconds = RelativeTime - PreviousRelativeTime;
-		FreeFallAccumulatedSeconds += StepSeconds;
-		FVector BallisticPosition = RawSample.Position;
-		if (bHasPostContactHeight)
-		{
-			const float RawHeightAlongUp = FVector::DotProduct(
-				BallisticPosition,
-				UpDirection);
-			BallisticPosition +=
-				UpDirection * (PostContactHeightAlongUp - RawHeightAlongUp);
-		}
-		BallisticPosition +=
-			GravityAcceleration * (0.5f * FMath::Square(FreeFallAccumulatedSeconds));
-		CorrectedSample.Position = BallisticPosition;
-		Result.PredictionHorizon = RelativeTime;
-		++ProcessedPredictionSamples;
-
-		FHitResult HitResult;
-		const bool bTraceBallisticSegment =
-			bIsFalling && !bHasLastWalkablePosition;
-		const FVector TraceStart = bTraceBallisticSegment
-			? PreviousPosition
-			: BallisticPosition + UpDirection * Settings.MaxObstacleHeight;
-		++Result.WorldQueryCount;
-		const bool bHit = SweepQuery(
-			HitResult,
-			TraceStart,
-			BallisticPosition,
-			Settings.TraceChannel.GetValue(),
-			FCollisionShape::MakeSphere(Settings.SweepRadius));
-		const bool bWalkableHit =
-			bHit && HitResult.bBlockingHit && WalkabilityQuery(HitResult);
-		if (bWalkableHit && !HitResult.ImpactPoint.ContainsNaN() &&
-			!HitResult.ImpactNormal.ContainsNaN() &&
-			!HitResult.ImpactNormal.IsNearlyZero())
-		{
-			FVector SurfacePositionAtSample = FVector::ZeroVector;
-			if (ProjectTrajectoryPointOntoHitPlane(
-					BallisticPosition,
-					GravityDirection,
-					HitResult.ImpactPoint,
-					HitResult.ImpactNormal,
-					SurfacePositionAtSample))
-			{
-				const FVector CorrectedPosition =
-					SurfacePositionAtSample + UpDirection * Settings.FloorOffset;
-				CorrectedSample.Position = CorrectedPosition;
-				PostContactHeightAlongUp = FVector::DotProduct(
-					CorrectedPosition,
-					UpDirection);
-				bHasPostContactHeight = true;
-				bHasLastWalkablePosition = true;
-				FreeFallAccumulatedSeconds = 0.0f;
-
-				if (!Result.bHasWalkableLanding && bIsFalling)
-				{
-					Result.TimeToLand = bTraceBallisticSegment && FMath::IsFinite(HitResult.Time)
-						? FMath::Lerp(
-							PreviousRelativeTime,
-							RelativeTime,
-							FMath::Clamp(HitResult.Time, 0.0f, 1.0f))
-						: CalculateTrajectoryLandingTimeInternal(
-							PreviousRelativeTime,
-							RelativeTime,
-							PreviousPosition,
-							BallisticPosition,
-							HitResult.ImpactPoint,
-							UpDirection);
-					Result.LandingLocation = HitResult.ImpactPoint;
-					Result.LandingNormal = HitResult.ImpactNormal;
-					Result.bHasWalkableLanding = true;
-				}
-			}
-			else
-			{
-				bHasLastWalkablePosition = false;
-			}
-		}
-		else
-		{
-			bHasLastWalkablePosition = false;
-		}
-
-		PreviousRelativeTime = RelativeTime;
-		PreviousPosition = CorrectedSample.Position;
-	}
-
-	return Result;
-}
-
-FRpgTrajectoryCollisionResolution ResolvePoseSearchTrajectoryWorldCollision(
-	const ARpgCharacter& Character,
-	const URpgCharacterMovementComponent& MovementComponent,
-	const FRpgTrajectoryCollisionSettings& Settings,
-	const FTransformTrajectory& RawTrajectory,
-	FTransformTrajectory& OutTrajectory,
-	int32 GeneratedPredictionSampleCount)
-{
-	check(IsInGameThread());
-	OutTrajectory = RawTrajectory;
-	UWorld* World = Character.GetWorld();
-	if (!World)
-	{
-		return FRpgTrajectoryCollisionResolution();
-	}
-
-	FCollisionQueryParams QueryParams(
-		SCENE_QUERY_STAT(RpgPoseSearchTrajectory),
-		Settings.bTraceComplex,
-		&Character);
-	QueryParams.AddIgnoredActor(&Character);
-	const FVector GravityAcceleration =
-		MovementComponent.GetGravityDirection() * -MovementComponent.GetGravityZ();
-	return ResolvePoseSearchTrajectoryCollision(
-		Settings,
-		GravityAcceleration,
-		MovementComponent.IsFalling(),
-		RawTrajectory,
-		OutTrajectory,
-		GeneratedPredictionSampleCount,
-		[World, &QueryParams](
-			FHitResult& OutHit,
-			const FVector& TraceStart,
-			const FVector& TraceEnd,
-			ECollisionChannel TraceChannel,
-			const FCollisionShape& CollisionShape)
-		{
-			return World->SweepSingleByChannel(
-				OutHit,
-				TraceStart,
-				TraceEnd,
-				FQuat::Identity,
-				TraceChannel,
-				CollisionShape,
-				QueryParams);
-		},
-		[&MovementComponent](const FHitResult& HitResult)
-		{
-			return MovementComponent.IsWalkable(HitResult);
-		});
 }
 
 enum class ETurnInPlaceHardResetReason : uint8
@@ -916,120 +571,6 @@ URpgAnimInstance::URpgAnimInstance(const FObjectInitializer& ObjectInitializer)
 {
 }
 
-bool URpgAnimInstance::IsTransformTrajectoryFinite(const FTransformTrajectory& Trajectory)
-{
-	return IsTransformTrajectoryFiniteInternal(Trajectory);
-}
-
-float URpgAnimInstance::CalculateTrajectoryLandingTime(
-	float PreviousTime,
-	float CurrentTime,
-	const FVector& PreviousPosition,
-	const FVector& CurrentPosition,
-	const FVector& LandingLocation,
-	const FVector& UpDirection)
-{
-	return CalculateTrajectoryLandingTimeInternal(
-		PreviousTime,
-		CurrentTime,
-		PreviousPosition,
-		CurrentPosition,
-		LandingLocation,
-		UpDirection);
-}
-
-FRpgTrajectoryLandingPrediction URpgAnimInstance::MakeTrajectoryLandingPrediction(
-	bool bCanPublishPrediction,
-	bool bHasWalkableHit,
-	bool bHardReset,
-	float TimeToLand,
-	float PredictionHorizon,
-	const FVector& LandingLocation,
-	const FVector& LandingNormal)
-{
-	FRpgTrajectoryLandingPrediction Result;
-	if (!bCanPublishPrediction || !bHasWalkableHit || bHardReset ||
-		!FMath::IsFinite(TimeToLand) || !FMath::IsFinite(PredictionHorizon) ||
-		TimeToLand < 0.0f || PredictionHorizon <= 0.0f ||
-		TimeToLand > PredictionHorizon + UE_KINDA_SMALL_NUMBER ||
-		LandingLocation.ContainsNaN() || LandingNormal.ContainsNaN() ||
-		LandingNormal.IsNearlyZero())
-	{
-		return Result;
-	}
-
-	Result.LandingLocation = LandingLocation;
-	Result.LandingNormal = LandingNormal.GetSafeNormal(UE_SMALL_NUMBER, FVector::UpVector);
-	Result.TimeToLand = FMath::Clamp(TimeToLand, 0.0f, PredictionHorizon);
-	Result.bIsValid = true;
-	return Result;
-}
-
-#if WITH_DEV_AUTOMATION_TESTS
-FRpgTrajectoryLandingPrediction URpgAnimInstance::ResolveTrajectoryCollisionForTest(
-	const FRpgTrajectoryCollisionSettings& Settings,
-	const FVector& GravityAcceleration,
-	bool bIsFalling,
-	const FTransformTrajectory& RawTrajectory,
-	const TArray<FHitResult>& QueryHits,
-	const TArray<bool>& QueryWalkability,
-	FTransformTrajectory& OutTrajectory,
-	int32& OutWorldQueryCount,
-	TArray<FVector>* OutTraceStarts,
-	TArray<FVector>* OutTraceEnds)
-{
-	int32 QueryIndex = 0;
-	int32 LastQueryIndex = INDEX_NONE;
-	const FRpgTrajectoryCollisionResolution Resolution =
-		ResolvePoseSearchTrajectoryCollision(
-			Settings,
-			GravityAcceleration,
-			bIsFalling,
-			RawTrajectory,
-			OutTrajectory,
-			TrajectoryPredictionSampleCount,
-			[&QueryHits, &QueryIndex, &LastQueryIndex, OutTraceStarts, OutTraceEnds](
-				FHitResult& OutHit,
-				const FVector& TraceStart,
-				const FVector& TraceEnd,
-				ECollisionChannel,
-				const FCollisionShape&)
-			{
-				if (OutTraceStarts)
-				{
-					OutTraceStarts->Add(TraceStart);
-				}
-				if (OutTraceEnds)
-				{
-					OutTraceEnds->Add(TraceEnd);
-				}
-				LastQueryIndex = QueryIndex++;
-				if (!QueryHits.IsValidIndex(LastQueryIndex))
-				{
-					OutHit = FHitResult();
-					return false;
-				}
-
-				OutHit = QueryHits[LastQueryIndex];
-				return OutHit.bBlockingHit != 0;
-			},
-			[&QueryWalkability, &LastQueryIndex](const FHitResult&)
-			{
-				return QueryWalkability.IsValidIndex(LastQueryIndex) &&
-					QueryWalkability[LastQueryIndex];
-			});
-	OutWorldQueryCount = Resolution.WorldQueryCount;
-	return MakeTrajectoryLandingPrediction(
-		bIsFalling,
-		Resolution.bHasWalkableLanding,
-		false,
-		Resolution.TimeToLand,
-		Resolution.PredictionHorizon,
-		Resolution.LandingLocation,
-		Resolution.LandingNormal);
-}
-#endif
-
 float URpgAnimInstance::QuantizeTurnInPlaceAngle(float SignedAngle)
 {
 	const float AbsoluteAngle = FMath::Min(FMath::Abs(SignedAngle), 180.0f);
@@ -1375,38 +916,30 @@ void FRpgAnimInstanceProxy::PreUpdate(UAnimInstance* InAnimInstance, float Delta
 			RawTransformTrajectory,
 			DesiredControllerYawLastUpdate,
 			GeneratedRawTrajectory,
-			URpgAnimInstance::TrajectoryHistorySamplingInterval,
-			URpgAnimInstance::TrajectoryHistorySampleCount,
-			URpgAnimInstance::TrajectoryPredictionSamplingInterval,
-			URpgAnimInstance::TrajectoryPredictionSampleCount);
+			RpgPoseSearchTrajectory::HistorySamplingInterval,
+			RpgPoseSearchTrajectory::HistorySampleCount,
+			RpgPoseSearchTrajectory::PredictionSamplingInterval,
+			RpgPoseSearchTrajectory::PredictionSampleCount);
 		RawTransformTrajectory = MoveTemp(GeneratedRawTrajectory);
-		if (URpgAnimInstance::IsTransformTrajectoryFinite(RawTransformTrajectory))
+		if (RpgPoseSearchTrajectory::IsTransformTrajectoryFinite(RawTransformTrajectory))
 		{
 			TransformTrajectory = RawTransformTrajectory;
 			if (RpgAnimInstance->GetTrajectoryCollisionSettings().bEnabled)
 			{
-				FTransformTrajectory CorrectedTrajectory;
-				const FRpgTrajectoryCollisionResolution CollisionResolution =
-					ResolvePoseSearchTrajectoryWorldCollision(
+				RpgPoseSearchTrajectory::FCollisionResult CollisionResult =
+					RpgPoseSearchTrajectory::ResolveWorldCollision(
 						*Character,
 						*MovementComponent,
 						RpgAnimInstance->GetTrajectoryCollisionSettings(),
 						RawTransformTrajectory,
-						CorrectedTrajectory,
-						URpgAnimInstance::TrajectoryPredictionSampleCount);
-				if (URpgAnimInstance::IsTransformTrajectoryFinite(CorrectedTrajectory))
-				{
-					TransformTrajectory = MoveTemp(CorrectedTrajectory);
-				}
-				TrajectoryLandingPrediction =
-					URpgAnimInstance::MakeTrajectoryLandingPrediction(
 						bIsFalling && MovementState == ERpgLocomotionMovementState::Airborne,
-						CollisionResolution.bHasWalkableLanding,
-						bTurnInPlaceHardReset,
-						CollisionResolution.TimeToLand,
-						CollisionResolution.PredictionHorizon,
-						CollisionResolution.LandingLocation,
-						CollisionResolution.LandingNormal);
+						bTurnInPlaceHardReset);
+				if (RpgPoseSearchTrajectory::IsTransformTrajectoryFinite(
+					CollisionResult.CorrectedTrajectory))
+				{
+					TransformTrajectory = MoveTemp(CollisionResult.CorrectedTrajectory);
+				}
+				TrajectoryLandingPrediction = CollisionResult.LandingPrediction;
 			}
 		}
 		else
@@ -2321,9 +1854,8 @@ EDataValidationResult URpgAnimInstance::IsDataValid(FDataValidationContext& Cont
 	if (bGeneratePoseSearchTrajectory)
 	{
 		if (TrajectoryCollisionSettings.bEnabled &&
-			!IsTrajectoryCollisionSettingsRuntimeValid(
-				TrajectoryCollisionSettings,
-				TrajectoryPredictionSampleCount))
+			!RpgPoseSearchTrajectory::IsCollisionSettingsRuntimeValid(
+				TrajectoryCollisionSettings))
 		{
 			Context.AddError(FText::FromString(
 				TEXT("Trajectory collision requires FloorOffset 0.001-10 cm, MaxObstacleHeight 1-1000 cm, SweepRadius 0.1-20 cm, 1-15 samples, and a serialized collision channel below ECC_OverlapAll_Deprecated.")));

--- a/Source/SurvivalRpg/Animation/RpgAnimInstance.h
+++ b/Source/SurvivalRpg/Animation/RpgAnimInstance.h
@@ -13,6 +13,7 @@
 #include "PoseSearch/PoseSearchLibrary.h"
 #include "PoseSearch/PoseSearchTrajectoryLibrary.h"
 #include "RpgFootPlacementTypes.h"
+#include "RpgPoseSearchTrajectory.h"
 #include "SurvivalRpg/Core/Character/RpgCharacterRotationMode.h"
 #include "RpgAnimInstance.generated.h"
 
@@ -142,69 +143,6 @@ enum class ERpgTurnInPlaceState : uint8
 	Collecting,
 	Active,
 	Recovering,
-};
-
-/**
- * Game-thread collision policy for the cosmetic Pose Search trajectory.
- *
- * The project resolves at most the configured number of future samples per update. None of
- * these bounded sweeps changes CharacterMovement, collision, replication, or touchdown state.
- */
-USTRUCT(BlueprintType)
-struct SURVIVALRPG_API FRpgTrajectoryCollisionSettings
-{
-	GENERATED_BODY()
-
-	/** Enables game-thread gravity and world-collision correction for generated Pose Search trajectories. */
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Trajectory Collision")
-	bool bEnabled = true;
-
-	/** Height in centimeters retained between a corrected trajectory sample and the hit floor. */
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Trajectory Collision", meta = (ClampMin = "0.001", ClampMax = "10.0", UIMin = "0.001", UIMax = "2.0", Units = "cm"))
-	float FloorOffset = 0.01f;
-
-	/** Maximum vertical obstacle/floor search range per future sample, in centimeters. */
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Trajectory Collision", meta = (ClampMin = "1.0", ClampMax = "1000.0", UIMin = "50.0", UIMax = "300.0", Units = "cm"))
-	float MaxObstacleHeight = 150.0f;
-
-	/** Radius of each bounded walkability sweep, in centimeters. */
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Trajectory Collision", meta = (ClampMin = "0.1", ClampMax = "20.0", UIMin = "0.5", UIMax = "10.0", Units = "cm"))
-	float SweepRadius = 2.0f;
-
-	/** Maximum future samples swept per update; clamped to the generated 15-sample GASP horizon. */
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Trajectory Collision", meta = (ClampMin = "1", ClampMax = "15", UIMin = "1", UIMax = "15"))
-	int32 MaxPredictionSamples = 15;
-
-	/** Collision channel used by cosmetic prediction sweeps; defaults to Visibility like GASP. */
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Trajectory Collision")
-	TEnumAsByte<ECollisionChannel> TraceChannel = ECC_Visibility;
-
-	/** Uses complex geometry for cosmetic prediction traces; disabled by default to keep the hot path bounded. */
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Trajectory Collision")
-	bool bTraceComplex = false;
-};
-
-/** Pointer-free, cosmetic prediction of the next walkable landing within the trajectory horizon. */
-USTRUCT(BlueprintType)
-struct SURVIVALRPG_API FRpgTrajectoryLandingPrediction
-{
-	GENERATED_BODY()
-
-	/** Predicted world-space contact point from the first validated walkable trajectory collision. */
-	UPROPERTY(BlueprintReadOnly, Category = "Rpg|Animation|Trajectory Collision")
-	FVector LandingLocation = FVector::ZeroVector;
-
-	/** Unit world-space normal at the predicted walkable contact. */
-	UPROPERTY(BlueprintReadOnly, Category = "Rpg|Animation|Trajectory Collision")
-	FVector LandingNormal = FVector::UpVector;
-
-	/** Seconds until predicted contact; -1 means there is no valid airborne prediction. */
-	UPROPERTY(BlueprintReadOnly, Category = "Rpg|Animation|Trajectory Collision", meta = (Units = "s"))
-	float TimeToLand = -1.0f;
-
-	/** True only for a finite, walkable airborne hit inside the current prediction horizon. */
-	UPROPERTY(BlueprintReadOnly, Category = "Rpg|Animation|Trajectory Collision")
-	bool bIsValid = false;
 };
 
 /**
@@ -880,46 +818,6 @@ private:
 	static constexpr float RunStartMinimumFutureSpeedGain = 100.0f;
 	static constexpr float RunStartFutureVelocityBeginTime = 0.4f;
 	static constexpr float RunStartFutureVelocityEndTime = 0.5f;
-	// Exact sampling arguments authored by GASP's Update_Trajectory function.
-	static constexpr float TrajectoryHistorySamplingInterval = -1.0f;
-	static constexpr int32 TrajectoryHistorySampleCount = 30;
-	static constexpr float TrajectoryPredictionSamplingInterval = 0.1f;
-	static constexpr int32 TrajectoryPredictionSampleCount = 15;
-
-	/** Returns false for an empty trajectory or any non-finite time, position, or facing sample. */
-	static bool IsTransformTrajectoryFinite(const FTransformTrajectory& Trajectory);
-	/** Interpolates a bounded first-contact time between two ballistic samples and a floor plane. */
-	static float CalculateTrajectoryLandingTime(
-		float PreviousTime,
-		float CurrentTime,
-		const FVector& PreviousPosition,
-		const FVector& CurrentPosition,
-		const FVector& LandingLocation,
-		const FVector& UpDirection);
-	/** Sanitizes a walkable game-thread hit into the pointer-free airborne prediction contract. */
-	static FRpgTrajectoryLandingPrediction MakeTrajectoryLandingPrediction(
-		bool bCanPublishPrediction,
-		bool bHasWalkableHit,
-		bool bHardReset,
-		float TimeToLand,
-		float PredictionHorizon,
-		const FVector& LandingLocation,
-		const FVector& LandingNormal);
-#if WITH_DEV_AUTOMATION_TESTS
-	/** Runs the production collision resolver against deterministic query results for bounded automation coverage. */
-	static FRpgTrajectoryLandingPrediction ResolveTrajectoryCollisionForTest(
-		const FRpgTrajectoryCollisionSettings& Settings,
-		const FVector& GravityAcceleration,
-		bool bIsFalling,
-		const FTransformTrajectory& RawTrajectory,
-		const TArray<FHitResult>& QueryHits,
-		const TArray<bool>& QueryWalkability,
-		FTransformTrajectory& OutTrajectory,
-		int32& OutWorldQueryCount,
-		TArray<FVector>* OutTraceStarts = nullptr,
-		TArray<FVector>* OutTraceEnds = nullptr);
-#endif
-
 	/** Mirrors GASP's logical Moving state from finite horizontal velocity and acceleration. */
 	static bool IsGroundMotionMatchingChooserMoving(
 		const FGroundMotionMatchingSelectionSnapshot& Snapshot);

--- a/Source/SurvivalRpg/Animation/RpgPoseSearchTrajectory.cpp
+++ b/Source/SurvivalRpg/Animation/RpgPoseSearchTrajectory.cpp
@@ -1,0 +1,459 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+#include "RpgPoseSearchTrajectory.h"
+
+#include "Engine/HitResult.h"
+#include "Engine/World.h"
+#include "SurvivalRpg/Core/Character/RpgCharacter.h"
+#include "SurvivalRpg/Core/Character/RpgCharacterMovementComponent.h"
+
+#include UE_INLINE_GENERATED_CPP_BY_NAME(RpgPoseSearchTrajectory)
+
+namespace
+{
+constexpr float TrajectoryFloorOffsetMin = 0.001f;
+constexpr float TrajectoryFloorOffsetMax = 10.0f;
+constexpr float TrajectoryObstacleHeightMin = 1.0f;
+constexpr float TrajectoryObstacleHeightMax = 1000.0f;
+constexpr float TrajectorySweepRadiusMin = 0.1f;
+constexpr float TrajectorySweepRadiusMax = 20.0f;
+
+struct FTrajectoryCollisionResolution
+{
+	FVector LandingLocation = FVector::ZeroVector;
+	FVector LandingNormal = FVector::UpVector;
+	float TimeToLand = -1.0f;
+	float PredictionHorizon = 0.0f;
+	int32 WorldQueryCount = 0;
+	bool bHasWalkableLanding = false;
+};
+
+using FTrajectorySweepQuery = TFunctionRef<bool(
+	FHitResult& OutHit,
+	const FVector& TraceStart,
+	const FVector& TraceEnd,
+	ECollisionChannel TraceChannel,
+	const FCollisionShape& CollisionShape)>;
+using FTrajectoryWalkabilityQuery = TFunctionRef<bool(const FHitResult& HitResult)>;
+
+bool ProjectTrajectoryPointOntoHitPlane(
+	const FVector& Point,
+	const FVector& GravityDirection,
+	const FVector& PlanePoint,
+	const FVector& PlaneNormal,
+	FVector& OutProjectedPoint)
+{
+	if (Point.ContainsNaN() || GravityDirection.ContainsNaN() ||
+		PlanePoint.ContainsNaN() || PlaneNormal.ContainsNaN() ||
+		GravityDirection.IsNearlyZero() || PlaneNormal.IsNearlyZero())
+	{
+		return false;
+	}
+
+	const FVector SafeGravityDirection = GravityDirection.GetSafeNormal();
+	const FVector SafePlaneNormal = PlaneNormal.GetSafeNormal();
+	const double PlaneDenominator = FVector::DotProduct(
+		SafeGravityDirection,
+		SafePlaneNormal);
+	if (!FMath::IsFinite(PlaneDenominator) ||
+		FMath::Abs(PlaneDenominator) <= UE_SMALL_NUMBER)
+	{
+		return false;
+	}
+
+	const double DistanceAlongGravity = FVector::DotProduct(
+		PlanePoint - Point,
+		SafePlaneNormal) / PlaneDenominator;
+	if (!FMath::IsFinite(DistanceAlongGravity))
+	{
+		return false;
+	}
+
+	OutProjectedPoint = Point + SafeGravityDirection * DistanceAlongGravity;
+	return !OutProjectedPoint.ContainsNaN();
+}
+
+FTrajectoryCollisionResolution ResolveCollision(
+	const FRpgTrajectoryCollisionSettings& Settings,
+	const FVector& GravityAcceleration,
+	bool bIsFalling,
+	const FTransformTrajectory& RawTrajectory,
+	FTransformTrajectory& OutTrajectory,
+	FTrajectorySweepQuery SweepQuery,
+	FTrajectoryWalkabilityQuery WalkabilityQuery)
+{
+	FTrajectoryCollisionResolution Result;
+	OutTrajectory = RawTrajectory;
+
+	FVector GravityDirection = FVector::ZeroVector;
+	float GravityMagnitude = 0.0f;
+	GravityAcceleration.ToDirectionAndLength(GravityDirection, GravityMagnitude);
+	if (!RpgPoseSearchTrajectory::IsCollisionSettingsRuntimeValid(Settings) ||
+		!RpgPoseSearchTrajectory::IsTransformTrajectoryFinite(RawTrajectory) ||
+		GravityAcceleration.ContainsNaN() || GravityDirection.ContainsNaN() ||
+		!FMath::IsFinite(GravityMagnitude) || GravityMagnitude <= UE_SMALL_NUMBER)
+	{
+		return Result;
+	}
+
+	int32 CurrentSampleIndex = INDEX_NONE;
+	for (int32 SampleIndex = 0; SampleIndex < RawTrajectory.Samples.Num(); ++SampleIndex)
+	{
+		if (RawTrajectory.Samples[SampleIndex].TimeInSeconds > 0.0f)
+		{
+			CurrentSampleIndex = SampleIndex;
+			break;
+		}
+	}
+	if (CurrentSampleIndex == INDEX_NONE ||
+		CurrentSampleIndex + 1 >= RawTrajectory.Samples.Num())
+	{
+		return Result;
+	}
+
+	const FVector UpDirection = -GravityDirection;
+	const float CurrentSampleTime = RawTrajectory.Samples[CurrentSampleIndex].TimeInSeconds;
+	float PreviousRelativeTime = 0.0f;
+	FVector PreviousPosition = RawTrajectory.Samples[CurrentSampleIndex].Position;
+	float PostContactHeightAlongUp = 0.0f;
+	float FreeFallAccumulatedSeconds = 0.0f;
+	bool bHasPostContactHeight = false;
+	bool bHasLastWalkablePosition = false;
+	int32 ProcessedPredictionSamples = 0;
+	const int32 MaxPredictionSamples = FMath::Min(
+		Settings.MaxPredictionSamples,
+		RpgPoseSearchTrajectory::PredictionSampleCount);
+
+	for (int32 SampleIndex = CurrentSampleIndex + 1;
+		 SampleIndex < RawTrajectory.Samples.Num() &&
+		 ProcessedPredictionSamples < MaxPredictionSamples;
+		 ++SampleIndex)
+	{
+		const FTransformTrajectorySample& RawSample = RawTrajectory.Samples[SampleIndex];
+		FTransformTrajectorySample& CorrectedSample = OutTrajectory.Samples[SampleIndex];
+		const float RelativeTime = RawSample.TimeInSeconds - CurrentSampleTime;
+		if (!FMath::IsFinite(RelativeTime) ||
+			RelativeTime <= PreviousRelativeTime + UE_SMALL_NUMBER)
+		{
+			break;
+		}
+
+		const float StepSeconds = RelativeTime - PreviousRelativeTime;
+		FreeFallAccumulatedSeconds += StepSeconds;
+		FVector BallisticPosition = RawSample.Position;
+		if (bHasPostContactHeight)
+		{
+			const float RawHeightAlongUp = FVector::DotProduct(
+				BallisticPosition,
+				UpDirection);
+			BallisticPosition +=
+				UpDirection * (PostContactHeightAlongUp - RawHeightAlongUp);
+		}
+		BallisticPosition +=
+			GravityAcceleration * (0.5f * FMath::Square(FreeFallAccumulatedSeconds));
+		CorrectedSample.Position = BallisticPosition;
+		Result.PredictionHorizon = RelativeTime;
+		++ProcessedPredictionSamples;
+
+		FHitResult HitResult;
+		const bool bTraceBallisticSegment =
+			bIsFalling && !bHasLastWalkablePosition;
+		const FVector TraceStart = bTraceBallisticSegment
+			? PreviousPosition
+			: BallisticPosition + UpDirection * Settings.MaxObstacleHeight;
+		++Result.WorldQueryCount;
+		const bool bHit = SweepQuery(
+			HitResult,
+			TraceStart,
+			BallisticPosition,
+			Settings.TraceChannel.GetValue(),
+			FCollisionShape::MakeSphere(Settings.SweepRadius));
+		const bool bWalkableHit =
+			bHit && HitResult.bBlockingHit && WalkabilityQuery(HitResult);
+		if (bWalkableHit && !HitResult.ImpactPoint.ContainsNaN() &&
+			!HitResult.ImpactNormal.ContainsNaN() &&
+			!HitResult.ImpactNormal.IsNearlyZero())
+		{
+			FVector SurfacePositionAtSample = FVector::ZeroVector;
+			if (ProjectTrajectoryPointOntoHitPlane(
+					BallisticPosition,
+					GravityDirection,
+					HitResult.ImpactPoint,
+					HitResult.ImpactNormal,
+					SurfacePositionAtSample))
+			{
+				const FVector CorrectedPosition =
+					SurfacePositionAtSample + UpDirection * Settings.FloorOffset;
+				CorrectedSample.Position = CorrectedPosition;
+				PostContactHeightAlongUp = FVector::DotProduct(
+					CorrectedPosition,
+					UpDirection);
+				bHasPostContactHeight = true;
+				bHasLastWalkablePosition = true;
+				FreeFallAccumulatedSeconds = 0.0f;
+
+				if (!Result.bHasWalkableLanding && bIsFalling)
+				{
+					Result.TimeToLand =
+						bTraceBallisticSegment && FMath::IsFinite(HitResult.Time)
+							? FMath::Lerp(
+								PreviousRelativeTime,
+								RelativeTime,
+								FMath::Clamp(HitResult.Time, 0.0f, 1.0f))
+							: RpgPoseSearchTrajectory::CalculateLandingTime(
+								PreviousRelativeTime,
+								RelativeTime,
+								PreviousPosition,
+								BallisticPosition,
+								HitResult.ImpactPoint,
+								UpDirection);
+					Result.LandingLocation = HitResult.ImpactPoint;
+					Result.LandingNormal = HitResult.ImpactNormal;
+					Result.bHasWalkableLanding = true;
+				}
+			}
+			else
+			{
+				bHasLastWalkablePosition = false;
+			}
+		}
+		else
+		{
+			bHasLastWalkablePosition = false;
+		}
+
+		PreviousRelativeTime = RelativeTime;
+		PreviousPosition = CorrectedSample.Position;
+	}
+
+	return Result;
+}
+}
+
+namespace RpgPoseSearchTrajectory
+{
+bool IsTransformTrajectoryFinite(const FTransformTrajectory& Trajectory)
+{
+	if (Trajectory.Samples.IsEmpty())
+	{
+		return false;
+	}
+
+	float PreviousTime = -MAX_flt;
+	for (const FTransformTrajectorySample& Sample : Trajectory.Samples)
+	{
+		if (!FMath::IsFinite(Sample.TimeInSeconds) ||
+			Sample.TimeInSeconds + UE_SMALL_NUMBER < PreviousTime ||
+			Sample.Position.ContainsNaN() || Sample.Facing.ContainsNaN())
+		{
+			return false;
+		}
+		PreviousTime = Sample.TimeInSeconds;
+	}
+	return true;
+}
+
+bool IsCollisionSettingsRuntimeValid(
+	const FRpgTrajectoryCollisionSettings& Settings)
+{
+	const int32 TraceChannel = static_cast<int32>(Settings.TraceChannel.GetValue());
+	return Settings.bEnabled &&
+		FMath::IsFinite(Settings.FloorOffset) &&
+		Settings.FloorOffset >= TrajectoryFloorOffsetMin &&
+		Settings.FloorOffset <= TrajectoryFloorOffsetMax &&
+		FMath::IsFinite(Settings.MaxObstacleHeight) &&
+		Settings.MaxObstacleHeight >= TrajectoryObstacleHeightMin &&
+		Settings.MaxObstacleHeight <= TrajectoryObstacleHeightMax &&
+		FMath::IsFinite(Settings.SweepRadius) &&
+		Settings.SweepRadius >= TrajectorySweepRadiusMin &&
+		Settings.SweepRadius <= TrajectorySweepRadiusMax &&
+		Settings.MaxPredictionSamples >= 1 &&
+		Settings.MaxPredictionSamples <= PredictionSampleCount &&
+		TraceChannel >= static_cast<int32>(ECC_WorldStatic) &&
+		TraceChannel < static_cast<int32>(ECC_OverlapAll_Deprecated);
+}
+
+float CalculateLandingTime(
+	float PreviousTime,
+	float CurrentTime,
+	const FVector& PreviousPosition,
+	const FVector& CurrentPosition,
+	const FVector& LandingLocation,
+	const FVector& UpDirection)
+{
+	if (!FMath::IsFinite(PreviousTime) || !FMath::IsFinite(CurrentTime) ||
+		CurrentTime < PreviousTime || PreviousPosition.ContainsNaN() ||
+		CurrentPosition.ContainsNaN() || LandingLocation.ContainsNaN() ||
+		UpDirection.ContainsNaN() || UpDirection.IsNearlyZero())
+	{
+		return -1.0f;
+	}
+
+	const FVector SafeUpDirection = UpDirection.GetSafeNormal();
+	const float PreviousHeight = FVector::DotProduct(
+		PreviousPosition - LandingLocation,
+		SafeUpDirection);
+	const float CurrentHeight = FVector::DotProduct(
+		CurrentPosition - LandingLocation,
+		SafeUpDirection);
+	const float HeightDelta = PreviousHeight - CurrentHeight;
+	const float Alpha = HeightDelta > UE_SMALL_NUMBER
+		? FMath::Clamp(PreviousHeight / HeightDelta, 0.0f, 1.0f)
+		: 1.0f;
+	return FMath::Lerp(PreviousTime, CurrentTime, Alpha);
+}
+
+FRpgTrajectoryLandingPrediction MakeLandingPrediction(
+	bool bCanPublishPrediction,
+	bool bHasWalkableHit,
+	bool bHardReset,
+	float TimeToLand,
+	float PredictionHorizon,
+	const FVector& LandingLocation,
+	const FVector& LandingNormal)
+{
+	FRpgTrajectoryLandingPrediction Result;
+	if (!bCanPublishPrediction || !bHasWalkableHit || bHardReset ||
+		!FMath::IsFinite(TimeToLand) || !FMath::IsFinite(PredictionHorizon) ||
+		TimeToLand < 0.0f || PredictionHorizon <= 0.0f ||
+		TimeToLand > PredictionHorizon + UE_KINDA_SMALL_NUMBER ||
+		LandingLocation.ContainsNaN() || LandingNormal.ContainsNaN() ||
+		LandingNormal.IsNearlyZero())
+	{
+		return Result;
+	}
+
+	Result.LandingLocation = LandingLocation;
+	Result.LandingNormal = LandingNormal.GetSafeNormal(
+		UE_SMALL_NUMBER,
+		FVector::UpVector);
+	Result.TimeToLand = FMath::Clamp(TimeToLand, 0.0f, PredictionHorizon);
+	Result.bIsValid = true;
+	return Result;
+}
+
+FCollisionResult ResolveWorldCollision(
+	const ARpgCharacter& Character,
+	const URpgCharacterMovementComponent& MovementComponent,
+	const FRpgTrajectoryCollisionSettings& Settings,
+	const FTransformTrajectory& RawTrajectory,
+	bool bCanPublishPrediction,
+	bool bHardReset)
+{
+	check(IsInGameThread());
+	FCollisionResult Result;
+	Result.CorrectedTrajectory = RawTrajectory;
+	UWorld* World = Character.GetWorld();
+	if (!World)
+	{
+		return Result;
+	}
+
+	FCollisionQueryParams QueryParams(
+		SCENE_QUERY_STAT(RpgPoseSearchTrajectory),
+		Settings.bTraceComplex,
+		&Character);
+	QueryParams.AddIgnoredActor(&Character);
+	const FVector GravityAcceleration =
+		MovementComponent.GetGravityDirection() * -MovementComponent.GetGravityZ();
+	const FTrajectoryCollisionResolution Resolution = ResolveCollision(
+		Settings,
+		GravityAcceleration,
+		MovementComponent.IsFalling(),
+		RawTrajectory,
+		Result.CorrectedTrajectory,
+		[World, &QueryParams](
+			FHitResult& OutHit,
+			const FVector& TraceStart,
+			const FVector& TraceEnd,
+			ECollisionChannel TraceChannel,
+			const FCollisionShape& CollisionShape)
+		{
+			return World->SweepSingleByChannel(
+				OutHit,
+				TraceStart,
+				TraceEnd,
+				FQuat::Identity,
+				TraceChannel,
+				CollisionShape,
+				QueryParams);
+		},
+		[&MovementComponent](const FHitResult& HitResult)
+		{
+			return MovementComponent.IsWalkable(HitResult);
+		});
+	Result.WorldQueryCount = Resolution.WorldQueryCount;
+	Result.LandingPrediction = MakeLandingPrediction(
+		bCanPublishPrediction,
+		Resolution.bHasWalkableLanding,
+		bHardReset,
+		Resolution.TimeToLand,
+		Resolution.PredictionHorizon,
+		Resolution.LandingLocation,
+		Resolution.LandingNormal);
+	return Result;
+}
+
+#if WITH_DEV_AUTOMATION_TESTS
+FRpgTrajectoryLandingPrediction ResolveCollisionForTest(
+	const FRpgTrajectoryCollisionSettings& Settings,
+	const FVector& GravityAcceleration,
+	bool bIsFalling,
+	const FTransformTrajectory& RawTrajectory,
+	const TArray<FHitResult>& QueryHits,
+	const TArray<bool>& QueryWalkability,
+	FTransformTrajectory& OutTrajectory,
+	int32& OutWorldQueryCount,
+	TArray<FVector>* OutTraceStarts,
+	TArray<FVector>* OutTraceEnds)
+{
+	int32 QueryIndex = 0;
+	int32 LastQueryIndex = INDEX_NONE;
+	const FTrajectoryCollisionResolution Resolution = ResolveCollision(
+		Settings,
+		GravityAcceleration,
+		bIsFalling,
+		RawTrajectory,
+		OutTrajectory,
+		[&QueryHits, &QueryIndex, &LastQueryIndex, OutTraceStarts, OutTraceEnds](
+			FHitResult& OutHit,
+			const FVector& TraceStart,
+			const FVector& TraceEnd,
+			ECollisionChannel,
+			const FCollisionShape&)
+		{
+			if (OutTraceStarts)
+			{
+				OutTraceStarts->Add(TraceStart);
+			}
+			if (OutTraceEnds)
+			{
+				OutTraceEnds->Add(TraceEnd);
+			}
+			LastQueryIndex = QueryIndex++;
+			if (!QueryHits.IsValidIndex(LastQueryIndex))
+			{
+				OutHit = FHitResult();
+				return false;
+			}
+
+			OutHit = QueryHits[LastQueryIndex];
+			return OutHit.bBlockingHit != 0;
+		},
+		[&QueryWalkability, &LastQueryIndex](const FHitResult&)
+		{
+			return QueryWalkability.IsValidIndex(LastQueryIndex) &&
+				QueryWalkability[LastQueryIndex];
+		});
+	OutWorldQueryCount = Resolution.WorldQueryCount;
+	return MakeLandingPrediction(
+		bIsFalling,
+		Resolution.bHasWalkableLanding,
+		false,
+		Resolution.TimeToLand,
+		Resolution.PredictionHorizon,
+		Resolution.LandingLocation,
+		Resolution.LandingNormal);
+}
+#endif
+}

--- a/Source/SurvivalRpg/Animation/RpgPoseSearchTrajectory.h
+++ b/Source/SurvivalRpg/Animation/RpgPoseSearchTrajectory.h
@@ -1,0 +1,146 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "Animation/TrajectoryTypes.h"
+#include "Engine/EngineTypes.h"
+
+#include "RpgPoseSearchTrajectory.generated.h"
+
+class ARpgCharacter;
+class URpgCharacterMovementComponent;
+struct FHitResult;
+
+/**
+ * Game-thread collision policy for the cosmetic Pose Search trajectory.
+ *
+ * The project resolves at most the configured number of future samples per update. None of
+ * these bounded sweeps changes CharacterMovement, collision, replication, or touchdown state.
+ */
+USTRUCT(BlueprintType)
+struct SURVIVALRPG_API FRpgTrajectoryCollisionSettings
+{
+	GENERATED_BODY()
+
+	/** Enables game-thread gravity and world-collision correction for generated Pose Search trajectories. */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Trajectory Collision")
+	bool bEnabled = true;
+
+	/** Height in centimeters retained between a corrected trajectory sample and the hit floor. */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Trajectory Collision", meta = (ClampMin = "0.001", ClampMax = "10.0", UIMin = "0.001", UIMax = "2.0", Units = "cm"))
+	float FloorOffset = 0.01f;
+
+	/** Maximum vertical obstacle/floor search range per future sample, in centimeters. */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Trajectory Collision", meta = (ClampMin = "1.0", ClampMax = "1000.0", UIMin = "50.0", UIMax = "300.0", Units = "cm"))
+	float MaxObstacleHeight = 150.0f;
+
+	/** Radius of each bounded walkability sweep, in centimeters. */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Trajectory Collision", meta = (ClampMin = "0.1", ClampMax = "20.0", UIMin = "0.5", UIMax = "10.0", Units = "cm"))
+	float SweepRadius = 2.0f;
+
+	/** Maximum future samples swept per update; clamped to the generated 15-sample GASP horizon. */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Trajectory Collision", meta = (ClampMin = "1", ClampMax = "15", UIMin = "1", UIMax = "15"))
+	int32 MaxPredictionSamples = 15;
+
+	/** Collision channel used by cosmetic prediction sweeps; defaults to Visibility like GASP. */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Trajectory Collision")
+	TEnumAsByte<ECollisionChannel> TraceChannel = ECC_Visibility;
+
+	/** Uses complex geometry for cosmetic prediction traces; disabled by default to keep the hot path bounded. */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Rpg|Animation|Trajectory Collision")
+	bool bTraceComplex = false;
+};
+
+/** Pointer-free, cosmetic prediction of the next walkable landing within the trajectory horizon. */
+USTRUCT(BlueprintType)
+struct SURVIVALRPG_API FRpgTrajectoryLandingPrediction
+{
+	GENERATED_BODY()
+
+	/** Predicted world-space contact point from the first validated walkable trajectory collision. */
+	UPROPERTY(BlueprintReadOnly, Category = "Rpg|Animation|Trajectory Collision")
+	FVector LandingLocation = FVector::ZeroVector;
+
+	/** Unit world-space normal at the predicted walkable contact. */
+	UPROPERTY(BlueprintReadOnly, Category = "Rpg|Animation|Trajectory Collision")
+	FVector LandingNormal = FVector::UpVector;
+
+	/** Seconds until predicted contact; -1 means there is no valid airborne prediction. */
+	UPROPERTY(BlueprintReadOnly, Category = "Rpg|Animation|Trajectory Collision", meta = (Units = "s"))
+	float TimeToLand = -1.0f;
+
+	/** True only for a finite, walkable airborne hit inside the current prediction horizon. */
+	UPROPERTY(BlueprintReadOnly, Category = "Rpg|Animation|Trajectory Collision")
+	bool bIsValid = false;
+};
+
+/** Project-owned trajectory sampling contract, validation, and game-thread collision helpers. */
+namespace RpgPoseSearchTrajectory
+{
+	/** Exact sampling arguments authored by GASP's Update_Trajectory function. */
+	inline constexpr float HistorySamplingInterval = -1.0f;
+	inline constexpr int32 HistorySampleCount = 30;
+	inline constexpr float PredictionSamplingInterval = 0.1f;
+	inline constexpr int32 PredictionSampleCount = 15;
+
+	/** Game-thread collision output published to the AnimInstance proxy as value-only data. */
+	struct SURVIVALRPG_API FCollisionResult
+	{
+		FTransformTrajectory CorrectedTrajectory;
+		FRpgTrajectoryLandingPrediction LandingPrediction;
+		int32 WorldQueryCount = 0;
+	};
+
+	/** Returns false for an empty trajectory or any non-finite or non-monotonic sample. */
+	SURVIVALRPG_API bool IsTransformTrajectoryFinite(const FTransformTrajectory& Trajectory);
+
+	/** Validates the bounded designer-authored collision policy against the generated GASP horizon. */
+	SURVIVALRPG_API bool IsCollisionSettingsRuntimeValid(
+		const FRpgTrajectoryCollisionSettings& Settings);
+
+	/** Interpolates a bounded first-contact time between two ballistic samples and a floor plane. */
+	SURVIVALRPG_API float CalculateLandingTime(
+		float PreviousTime,
+		float CurrentTime,
+		const FVector& PreviousPosition,
+		const FVector& CurrentPosition,
+		const FVector& LandingLocation,
+		const FVector& UpDirection);
+
+	/** Sanitizes a walkable game-thread hit into the pointer-free airborne prediction contract. */
+	SURVIVALRPG_API FRpgTrajectoryLandingPrediction MakeLandingPrediction(
+		bool bCanPublishPrediction,
+		bool bHasWalkableHit,
+		bool bHardReset,
+		float TimeToLand,
+		float PredictionHorizon,
+		const FVector& LandingLocation,
+		const FVector& LandingNormal);
+
+	/**
+	 * Applies gravity and bounded walkability sweeps to the future trajectory on the game thread.
+	 * CharacterMovement remains authoritative; the returned correction and landing prediction are cosmetic.
+	 */
+	SURVIVALRPG_API FCollisionResult ResolveWorldCollision(
+		const ARpgCharacter& Character,
+		const URpgCharacterMovementComponent& MovementComponent,
+		const FRpgTrajectoryCollisionSettings& Settings,
+		const FTransformTrajectory& RawTrajectory,
+		bool bCanPublishPrediction,
+		bool bHardReset);
+
+#if WITH_DEV_AUTOMATION_TESTS
+	/** Runs the production resolver against deterministic query results for bounded automation coverage. */
+	SURVIVALRPG_API FRpgTrajectoryLandingPrediction ResolveCollisionForTest(
+		const FRpgTrajectoryCollisionSettings& Settings,
+		const FVector& GravityAcceleration,
+		bool bIsFalling,
+		const FTransformTrajectory& RawTrajectory,
+		const TArray<FHitResult>& QueryHits,
+		const TArray<bool>& QueryWalkability,
+		FTransformTrajectory& OutTrajectory,
+		int32& OutWorldQueryCount,
+		TArray<FVector>* OutTraceStarts = nullptr,
+		TArray<FVector>* OutTraceEnds = nullptr);
+#endif
+}

--- a/Source/SurvivalRpgEditor/Private/Animation/RpgMotionMatchingDatabaseResolverTests.cpp
+++ b/Source/SurvivalRpgEditor/Private/Animation/RpgMotionMatchingDatabaseResolverTests.cpp
@@ -8,6 +8,7 @@
 #include "Misc/AutomationTest.h"
 #include "PoseSearch/PoseSearchDatabase.h"
 #include "SurvivalRpg/Animation/RpgAnimInstance.h"
+#include "SurvivalRpg/Animation/RpgPoseSearchTrajectory.h"
 #include "SurvivalRpg/Core/Character/RpgCharacter.h"
 #include "UObject/UObjectGlobals.h"
 
@@ -21,17 +22,17 @@ bool FRpgMotionMatchingDatabaseResolverTest::RunTest(const FString& Parameters)
 {
 	TestTrue(
 		TEXT("Trajectory history uses GASP's adaptive sampling interval"),
-		FMath::IsNearlyEqual(URpgAnimInstance::TrajectoryHistorySamplingInterval, -1.0f));
+		FMath::IsNearlyEqual(RpgPoseSearchTrajectory::HistorySamplingInterval, -1.0f));
 	TestEqual(
 		TEXT("Trajectory history keeps GASP's 30 samples"),
-		URpgAnimInstance::TrajectoryHistorySampleCount,
+		RpgPoseSearchTrajectory::HistorySampleCount,
 		30);
 	TestTrue(
 		TEXT("Trajectory prediction samples at GASP's 0.1 second interval"),
-		FMath::IsNearlyEqual(URpgAnimInstance::TrajectoryPredictionSamplingInterval, 0.1f));
+		FMath::IsNearlyEqual(RpgPoseSearchTrajectory::PredictionSamplingInterval, 0.1f));
 	TestEqual(
 		TEXT("Trajectory prediction keeps GASP's 15 samples"),
-		URpgAnimInstance::TrajectoryPredictionSampleCount,
+		RpgPoseSearchTrajectory::PredictionSampleCount,
 		15);
 	TestEqual(
 		TEXT("Sprint Stops begin at GASP's inclusive 550 cm/s boundary"),

--- a/Source/SurvivalRpgEditor/Private/Animation/RpgTrajectoryCollisionRuntimeTests.cpp
+++ b/Source/SurvivalRpgEditor/Private/Animation/RpgTrajectoryCollisionRuntimeTests.cpp
@@ -10,6 +10,7 @@
 #include "Misc/AutomationTest.h"
 #include "PoseSearch/PoseSearchDatabase.h"
 #include "SurvivalRpg/Animation/RpgAnimInstance.h"
+#include "SurvivalRpg/Animation/RpgPoseSearchTrajectory.h"
 #include "UObject/UnrealType.h"
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(
@@ -77,18 +78,18 @@ bool FRpgTrajectoryCollisionRuntimeTest::RunTest(const FString& Parameters)
 		Sample.Position = FVector(static_cast<double>(Index) * 10.0, 0.0, 100.0);
 		Sample.Facing = FQuat::Identity;
 	}
-	TestTrue(TEXT("A finite ordered trajectory passes the worker-snapshot contract"), URpgAnimInstance::IsTransformTrajectoryFinite(FiniteTrajectory));
-	TestFalse(TEXT("An empty trajectory fails closed"), URpgAnimInstance::IsTransformTrajectoryFinite(FTransformTrajectory()));
+	TestTrue(TEXT("A finite ordered trajectory passes the worker-snapshot contract"), RpgPoseSearchTrajectory::IsTransformTrajectoryFinite(FiniteTrajectory));
+	TestFalse(TEXT("An empty trajectory fails closed"), RpgPoseSearchTrajectory::IsTransformTrajectoryFinite(FTransformTrajectory()));
 
 	FTransformTrajectory UnsortedTrajectory = FiniteTrajectory;
 	UnsortedTrajectory.Samples[2].TimeInSeconds = -1.0f;
-	TestFalse(TEXT("A non-monotonic sample timeline fails closed"), URpgAnimInstance::IsTransformTrajectoryFinite(UnsortedTrajectory));
+	TestFalse(TEXT("A non-monotonic sample timeline fails closed"), RpgPoseSearchTrajectory::IsTransformTrajectoryFinite(UnsortedTrajectory));
 
 	FTransformTrajectory NanTrajectory = FiniteTrajectory;
 	NanTrajectory.Samples[1].Position.X = std::numeric_limits<double>::quiet_NaN();
-	TestFalse(TEXT("A non-finite sample position fails closed"), URpgAnimInstance::IsTransformTrajectoryFinite(NanTrajectory));
+	TestFalse(TEXT("A non-finite sample position fails closed"), RpgPoseSearchTrajectory::IsTransformTrajectoryFinite(NanTrajectory));
 
-	const float MidpointLandingTime = URpgAnimInstance::CalculateTrajectoryLandingTime(
+	const float MidpointLandingTime = RpgPoseSearchTrajectory::CalculateLandingTime(
 		0.0f,
 		0.2f,
 		FVector(0.0, 0.0, 100.0),
@@ -98,7 +99,7 @@ bool FRpgTrajectoryCollisionRuntimeTest::RunTest(const FString& Parameters)
 	TestTrue(TEXT("First contact is interpolated between bounding ballistic samples"), FMath::IsNearlyEqual(MidpointLandingTime, 0.1f));
 	TestEqual(
 		TEXT("Invalid ballistic input cannot manufacture a landing time"),
-		URpgAnimInstance::CalculateTrajectoryLandingTime(
+		RpgPoseSearchTrajectory::CalculateLandingTime(
 			0.2f,
 			0.1f,
 			FVector::ZeroVector,
@@ -108,7 +109,7 @@ bool FRpgTrajectoryCollisionRuntimeTest::RunTest(const FString& Parameters)
 		-1.0f);
 
 	const FRpgTrajectoryLandingPrediction ValidPrediction =
-		URpgAnimInstance::MakeTrajectoryLandingPrediction(
+		RpgPoseSearchTrajectory::MakeLandingPrediction(
 			true,
 			true,
 			false,
@@ -121,7 +122,7 @@ bool FRpgTrajectoryCollisionRuntimeTest::RunTest(const FString& Parameters)
 	TestTrue(TEXT("Published TimeToLand remains finite"), FMath::IsFinite(ValidPrediction.TimeToLand));
 
 	const FRpgTrajectoryLandingPrediction NoHitPrediction =
-		URpgAnimInstance::MakeTrajectoryLandingPrediction(
+		RpgPoseSearchTrajectory::MakeLandingPrediction(
 			true,
 			false,
 			false,
@@ -134,7 +135,7 @@ bool FRpgTrajectoryCollisionRuntimeTest::RunTest(const FString& Parameters)
 
 	TestFalse(
 		TEXT("A teleport/owner-role hard reset rejects even a fresh-looking hit"),
-		URpgAnimInstance::MakeTrajectoryLandingPrediction(
+		RpgPoseSearchTrajectory::MakeLandingPrediction(
 			true,
 			true,
 			true,
@@ -144,7 +145,7 @@ bool FRpgTrajectoryCollisionRuntimeTest::RunTest(const FString& Parameters)
 			FVector::UpVector).bIsValid);
 	TestFalse(
 		TEXT("Grounded state cannot publish predictive landing data"),
-		URpgAnimInstance::MakeTrajectoryLandingPrediction(
+		RpgPoseSearchTrajectory::MakeLandingPrediction(
 			false,
 			true,
 			false,
@@ -154,7 +155,7 @@ bool FRpgTrajectoryCollisionRuntimeTest::RunTest(const FString& Parameters)
 			FVector::UpVector).bIsValid);
 	TestFalse(
 		TEXT("A hit beyond the inspected horizon fails closed"),
-		URpgAnimInstance::MakeTrajectoryLandingPrediction(
+		RpgPoseSearchTrajectory::MakeLandingPrediction(
 			true,
 			true,
 			false,
@@ -173,7 +174,7 @@ bool FRpgTrajectoryCollisionRuntimeTest::RunTest(const FString& Parameters)
 	FTransformTrajectory FlatStepCorrectedTrajectory;
 	int32 FlatStepQueryCount = 0;
 	const FRpgTrajectoryLandingPrediction FlatStepPrediction =
-		URpgAnimInstance::ResolveTrajectoryCollisionForTest(
+		RpgPoseSearchTrajectory::ResolveCollisionForTest(
 			DefaultSettings,
 			GravityAcceleration,
 			true,
@@ -212,7 +213,7 @@ bool FRpgTrajectoryCollisionRuntimeTest::RunTest(const FString& Parameters)
 	FTransformTrajectory RampCorrectedTrajectory;
 	int32 RampQueryCount = 0;
 	const FRpgTrajectoryLandingPrediction RampPrediction =
-		URpgAnimInstance::ResolveTrajectoryCollisionForTest(
+		RpgPoseSearchTrajectory::ResolveCollisionForTest(
 			DefaultSettings,
 			GravityAcceleration,
 			true,
@@ -250,7 +251,7 @@ bool FRpgTrajectoryCollisionRuntimeTest::RunTest(const FString& Parameters)
 	TArray<FVector> GroundedTraceStarts;
 	TArray<FVector> GroundedTraceEnds;
 	const FRpgTrajectoryLandingPrediction GroundedSurfacePrediction =
-		URpgAnimInstance::ResolveTrajectoryCollisionForTest(
+		RpgPoseSearchTrajectory::ResolveCollisionForTest(
 			DefaultSettings,
 			GravityAcceleration,
 			false,
@@ -316,7 +317,7 @@ bool FRpgTrajectoryCollisionRuntimeTest::RunTest(const FString& Parameters)
 	TArray<FVector> FastFloorTraceStarts;
 	TArray<FVector> FastFloorTraceEnds;
 	const FRpgTrajectoryLandingPrediction FastFloorPrediction =
-		URpgAnimInstance::ResolveTrajectoryCollisionForTest(
+		RpgPoseSearchTrajectory::ResolveCollisionForTest(
 			DefaultSettings,
 			GravityAcceleration,
 			true,
@@ -357,7 +358,7 @@ bool FRpgTrajectoryCollisionRuntimeTest::RunTest(const FString& Parameters)
 	TArray<FVector> EdgeTraceStarts;
 	TArray<FVector> EdgeTraceEnds;
 	const FRpgTrajectoryLandingPrediction EdgePrediction =
-		URpgAnimInstance::ResolveTrajectoryCollisionForTest(
+		RpgPoseSearchTrajectory::ResolveCollisionForTest(
 			DefaultSettings,
 			GravityAcceleration,
 			true,
@@ -395,7 +396,7 @@ bool FRpgTrajectoryCollisionRuntimeTest::RunTest(const FString& Parameters)
 	FTransformTrajectory WalkabilityCorrectedTrajectory;
 	int32 WalkabilityQueryCount = 0;
 	const FRpgTrajectoryLandingPrediction WalkabilityPrediction =
-		URpgAnimInstance::ResolveTrajectoryCollisionForTest(
+		RpgPoseSearchTrajectory::ResolveCollisionForTest(
 			DefaultSettings,
 			GravityAcceleration,
 			true,
@@ -417,7 +418,7 @@ bool FRpgTrajectoryCollisionRuntimeTest::RunTest(const FString& Parameters)
 	int32 FarContactQueryCount = 0;
 	int32 NearContactQueryCount = 0;
 	const FRpgTrajectoryLandingPrediction FarContactPrediction =
-		URpgAnimInstance::ResolveTrajectoryCollisionForTest(
+		RpgPoseSearchTrajectory::ResolveCollisionForTest(
 			DefaultSettings,
 			GravityAcceleration,
 			true,
@@ -427,7 +428,7 @@ bool FRpgTrajectoryCollisionRuntimeTest::RunTest(const FString& Parameters)
 			FarContactTrajectory,
 			FarContactQueryCount);
 	const FRpgTrajectoryLandingPrediction NearContactPrediction =
-		URpgAnimInstance::ResolveTrajectoryCollisionForTest(
+		RpgPoseSearchTrajectory::ResolveCollisionForTest(
 			DefaultSettings,
 			GravityAcceleration,
 			true,
@@ -444,7 +445,7 @@ bool FRpgTrajectoryCollisionRuntimeTest::RunTest(const FString& Parameters)
 	FTransformTrajectory BudgetCorrectedTrajectory;
 	int32 BudgetQueryCount = 0;
 	const FRpgTrajectoryLandingPrediction BudgetPrediction =
-		URpgAnimInstance::ResolveTrajectoryCollisionForTest(
+		RpgPoseSearchTrajectory::ResolveCollisionForTest(
 			DefaultSettings,
 			GravityAcceleration,
 			true,
@@ -465,7 +466,7 @@ bool FRpgTrajectoryCollisionRuntimeTest::RunTest(const FString& Parameters)
 	FTransformTrajectory InvalidBoundsTrajectory;
 	int32 InvalidBoundsQueryCount = -1;
 	const FRpgTrajectoryLandingPrediction InvalidBoundsPrediction =
-		URpgAnimInstance::ResolveTrajectoryCollisionForTest(
+		RpgPoseSearchTrajectory::ResolveCollisionForTest(
 			InvalidBoundsSettings,
 			GravityAcceleration,
 			true,
@@ -482,7 +483,7 @@ bool FRpgTrajectoryCollisionRuntimeTest::RunTest(const FString& Parameters)
 	FTransformTrajectory InvalidChannelTrajectory;
 	int32 InvalidChannelQueryCount = -1;
 	const FRpgTrajectoryLandingPrediction InvalidChannelPrediction =
-		URpgAnimInstance::ResolveTrajectoryCollisionForTest(
+		RpgPoseSearchTrajectory::ResolveCollisionForTest(
 			InvalidChannelSettings,
 			GravityAcceleration,
 			true,


### PR DESCRIPTION
## Summary

- add a source-to-project ownership map for the adopted GASP CMC responsibilities
- extract trajectory sampling, validation, world collision, and landing prediction from `URpgAnimInstance` into the focused `RpgPoseSearchTrajectory` seam
- update the existing runtime tests to exercise the extracted owner while preserving reflected names, defaults, and AnimBP-facing properties

## Why

Issue #81 requires the oversized AnimInstance to be decomposed along the updated native-foundation/designer-owned-content boundary. This first slice isolates one engine-facing, game-thread responsibility without changing locomotion behavior or expanding the runtime role architecture.

## Behavior and scope

- preserves GASP sampling at `-1.0 / 30 / 0.1 / 15`
- preserves bounded sphere sweeps, CMC walkability filtering, explicit invalid no-hit prediction, and floor-plane projection
- keeps trajectory generation orchestration and snapshot lifetime in proxy `PreUpdate`
- adds no new `UObject` classes and no replicated or saved state
- changes no animation assets, Pose Search databases, PawnData, Experiences, or default pawn selection

## Validation

- UE 5.8 `SurvivalRpgEditor` full build: 103/103 actions succeeded
- final incremental build: 15/15 actions succeeded
- `SurvivalRpg.Animation.Trajectory.CollisionAndTimeToLand`: 1/1 passed headless
- complete `SurvivalRpg.Animation` suite: 18/18 passed headless
- no-PCH/header-only compile for the new public header passed
- `git diff --check` passed

## Follow-up

This is part of #81 and does not close it. A later slice will replace package-path presentation classification with explicit validated designer-owned profile membership. New locomotion families, Sprint authority (#62), cutover, and manual multiplayer acceptance remain out of scope.
