### PR TITLE
Extract GASP turn-in-place runtime

### DIFF
--- a/Plugins/RpgGaspLocomotion/Docs/README.md
+++ b/Plugins/RpgGaspLocomotion/Docs/README.md
@@ -46,6 +46,8 @@ The complete source-to-target mapping and cleanup policy is recorded in `Curated
 
 The production chooser is the focused pointer-free `RpgMotionMatchingRuntime`. It consumes value-only movement snapshots and first resolves stable `ERpgMotionMatchingDatabaseRole` values; only afterward does the `URpgAnimInstance` callback facade map those roles to its configured database pointers. Ground roles preserve the fixed Idle/Walk/Run/Sprint shapes of 1/2/4/2, overlapping stop boundaries, the explicit Sprint-stop gait requirement, start/loop/pivot ordering, and domain-level interrupt behavior without making asset pointers part of chooser decisions.
 
+Controller-facing turn presentation is similarly split. `RpgTurnInPlaceRuntime` owns the pointer-free actor-yaw accumulator, 20/30/10-degree collection hysteresis, stability and recovery windows, one-shot request/search policy, reset edges, watchdog decisions, and the facing-only synthetic trajectory. `URpgAnimInstance` remains the stable Blueprint-property and AnimNode callback facade and alone owns the turn database, GC-tracked selected asset, and Blend Stack playback observation. This deliberately adapts GASP's simpler inclusive 50-degree OrientationIntent-versus-root predicate and 20 cm/s Chooser cap to the project's replicated capsule-facing policy and stricter 3 cm/s stationary gate; it never rotates authoritative gameplay state.
+
 Exactly 18 runtime databases participate in this role contract. Each carries exactly one matching `Rpg.MotionMatching.Role.*` tag and one state tag:
 
 - Grounded: `StandIdle`, `StandWalk`, `StandWalkStops`, `StandRunLoops`, `StandRunPivots`, `StandRunStarts`, `StandRunStops`, `StandSprint`, and `StandSprintStops` use `Rpg.MotionMatching.State.Grounded`.

--- a/Plugins/RpgGaspLocomotion/Docs/RuntimeOwnershipMap.md
+++ b/Plugins/RpgGaspLocomotion/Docs/RuntimeOwnershipMap.md
@@ -28,7 +28,7 @@ the sample project a runtime dependency.
 | `Get_MMInterruptMode` | `RpgMotionMatchingRuntime::ShouldInterruptGroundMotionMatching` plus explicit turn/landing request and playback latches in `URpgAnimInstance::UpdateGaspMotionMatching` | Focused value-only Motion Matching runtime coordinated by the native AnimNode callback | Interrupts also protect physical movement-domain changes and one-shot project turn/landing requests; they never become replicated gameplay state. |
 | `Update_MotionMatching_PostSelection` | `URpgAnimInstance::UpdateGaspMotionMatchingPostSelection` bridges selected database metadata; `RpgMotionMatchingRuntime::ResolvePostSelection` owns the pointer-free result and exclusive latch policy | Same callback/value-runtime split | Completed-search metadata is cosmetic only. Unlike source GASP, the project does not apply `Override Motion Matching Blend Settings`; the authored node retains uniform `0.2 s` blending after the FastFeet turn regression. |
 | `Update_States`, `Update_Logic` | Proxy movement snapshot plus native turn/jump/landing presentation lifecycles | Gameplay state in CharacterMovement/GAS; focused presentation runtimes and AnimBP/profile tuning | The sample's broad and experimental state controller is not copied. Physical airborne/grounded state always comes from CharacterMovement. |
-| `ShouldTurnInPlace` | `URpgAnimInstance` turn-in-place resolver, synthetic trajectory, latch, and watchdog | Focused turn-in-place runtime; feel thresholds in designer configuration | Turns remain controller-facing and cosmetic; they never rotate the authoritative actor. Extraction is pending in #81. |
+| `ShouldTurnInPlace` | `RpgTurnInPlaceRuntime` owns pointer-free eligibility, hysteresis, reset edges, request/search policy, timeouts, and synthetic facing; `URpgAnimInstance` retains the reflected facade plus GC-safe asset/Blend Stack bridge | Same split; feel thresholds move to designer configuration in #81 step 4 | Turns remain controller-facing and cosmetic; they never rotate the authoritative actor. GASP's inclusive 50-degree OrientationIntent/root predicate and Chooser 20 cm/s cap are intentionally adapted to project actor-yaw accumulation, 20/30/10-degree hysteresis, and the stricter 3 cm/s stationary gate. |
 | `JustLanded_Light`, `JustLanded_Heavy`, `Get_LandVelocity`, `PlayLand`, `PlayMovingLand` | Proxy pre-touchdown snapshot plus `URpgAnimInstance` landing resolver/latch/watchdog | Focused landing runtime; database membership and feel in assets | Landing begins only on the physical CMC touchdown edge. Idle/Walk/Run Light/Heavy are curated; Sprint landing remains deferred until authoritative Sprint issue #62. |
 | `AllowFootPinning`, foot-placement settings helpers | Proxy game-thread traces, `RpgFootPlacement` value helpers, `FAnimNode_RpgFootPlacement` | Existing focused native types/node plus AnimBP tuning | Project-local snapshots make the node worker-safe and preserve moving-base handling; crouch stays opted out by default. |
 | `Get_DesiredFacing`, `EnableSteering`, Orientation Warping gates | `URpgAnimInstance::GetGaspBlendStackInputs`, authored curves, and the immutable `FRpgGaspPresentationAssetLookup` | Existing AnimBP/presentation profile seam, with only value inputs supplied natively | `DA_RpgGaspPresentationProfile` explicitly preserves the old 170-sequence presentation domain without package/name reads on workers. Local fall, idle/crouch/TIP, and moving-landing adaptations remain unchanged. |
@@ -71,7 +71,8 @@ the sample project a runtime dependency.
 3. Split Motion Matching role resolution, turn-in-place, and jump/landing into focused value-only
    runtimes without changing serialized AnimBP names or behavior. Slice 3a now owns pointer-free
    role selection, ground-domain interruption, landing-role classification, and PostSelection
-   policy in `RpgMotionMatchingRuntime`; turn-in-place and jump/landing extraction remain pending.
+   policy in `RpgMotionMatchingRuntime`. Slice 3b moves the pointer-free turn-in-place lifecycle and
+   synthetic facing policy to `RpgTurnInPlaceRuntime`; jump/landing extraction remains pending.
 4. Externalize database-to-role mapping and feel tuning into an asset/profile seam; keep the
    AnimInstance as the stable AnimBP facade and engine callback coordinator.
 
@@ -123,3 +124,28 @@ families, Sprint authority, combat polish, and default PawnData cutover are sepa
   contracts while retaining coverage of the AnimInstance database-pointer bridge. The jump,
   landing, turn-in-place, and pilot asset contracts guard adjacent lifecycle and serialization
   behavior; the complete `SurvivalRpg.Animation` filter is the regression gate.
+
+## Slice 3b boundary and verification contract
+
+- **Authority and lifecycle:** actor rotation, CharacterMovement, GAS tags, montage state, and jump
+  state remain authoritative outside this cosmetic runtime. `URpgAnimInstance` assembles immutable
+  proxy/config/latch observations; `RpgTurnInPlaceRuntime` resolves only value state, Offset Root
+  policy, reset pulses, and synthetic facing. It never rotates the actor or reads an Actor,
+  Component, World, ASC, database, animation asset, or Blend Stack node.
+- **Native type count:** zero new `UObject` classes. Three non-reflected value structs, one search
+  enum, constants, and namespace functions move eligibility, yaw quantization, collection and
+  recovery hysteresis, hard-reset edges, request serial policy, timeouts, and trajectory facing out
+  of `URpgAnimInstance`.
+- **Replication and persistence:** none added or changed. The existing flat transient Blueprint
+  properties keep their names, types, and defaults as the stable read facade. The request state is
+  locally derived and cosmetic; it is neither replicated nor saved.
+- **Designer/editor work:** no Blueprint, DataAsset, Pose Search database, manifest, PawnData, or
+  Experience changes. The database pointer, GC-tracked selected asset, completed-search callback,
+  and Blend Stack playback observation remain in `URpgAnimInstance`; threshold externalization is
+  still issue #81 step 4, so no MCP/editor authoring is required.
+- **Stable tests:** `SurvivalRpg.Animation.TurnInPlace.AngleAndTrajectory` directly owns the pure
+  quantization, wrap-safe yaw, authored durations, and synthetic-sample contract.
+  `SurvivalRpg.Animation.TurnInPlace.StateMachine` retains the complete facade integration contract
+  for eligibility, hysteresis, serials, search priority, GC-safe selection, playback observation,
+  reset edges, timeouts, and 20/60/120-FPS stability. The pilot asset contract and complete
+  `SurvivalRpg.Animation` filter remain the serialization and regression gates.

--- a/Source/SurvivalRpg/Animation/RpgAnimInstance.cpp
+++ b/Source/SurvivalRpg/Animation/RpgAnimInstance.cpp
@@ -26,21 +26,6 @@
 
 namespace
 {
-constexpr float TurnInPlaceIdleSpeedThreshold = 3.0f;
-constexpr float TurnInPlaceCollectThreshold = 20.0f;
-constexpr float TurnInPlaceActivationThreshold = 30.0f;
-constexpr float TurnInPlaceCancelThreshold = 10.0f;
-constexpr float TurnInPlaceInactiveYawRateThreshold = 6.0f;
-constexpr float TurnInPlaceStableYawRateThreshold = 60.0f;
-constexpr float TurnInPlaceStabilityDuration = 0.08f;
-constexpr float TurnInPlaceCollectionTimeout = 0.2f;
-constexpr float TurnInPlaceRecoveryDuration = 0.15f;
-constexpr float TurnInPlaceSelectionTimeout = 0.25f;
-constexpr float TurnInPlaceActiveTimeout = 1.75f;
-constexpr float TurnInPlacePlaybackWatchdogSafetyMargin = 0.1f;
-constexpr float TurnInPlaceInactiveAccumulatorTimeout = 0.2f;
-constexpr float TurnInPlaceFinishedTimeTolerance = 0.05f;
-constexpr float TurnInPlaceLargePositionDelta = 200.0f;
 constexpr float LandingSelectionTimeout = 0.25f;
 constexpr float LandingActiveTimeout = 1.25f;
 constexpr float LandingPlaybackWatchdogSafetyMargin = 0.1f;
@@ -55,43 +40,6 @@ void ResetPoseSearchTrajectoryState(FRpgAnimInstanceProxy& Proxy)
 	Proxy.TransformTrajectory.Samples.Reset();
 	Proxy.TrajectoryLandingPrediction = FRpgTrajectoryLandingPrediction();
 	Proxy.DesiredControllerYawLastUpdate = 0.0f;
-}
-
-enum class ETurnInPlaceHardResetReason : uint8
-{
-	ProxySnapshot = 1 << 0,
-	UnsupportedRotationMode = 1 << 1,
-	BlockingGameplayTag = 1 << 2,
-	Montage = 1 << 3,
-	Crouch = 1 << 4,
-	UnsupportedMovementState = 1 << 5,
-};
-
-constexpr uint8 ToReasonMask(ETurnInPlaceHardResetReason Reason)
-{
-	return static_cast<uint8>(Reason);
-}
-
-constexpr bool SupportsTurnInPlace(ERpgCharacterRotationMode RotationMode)
-{
-	return RotationMode == ERpgCharacterRotationMode::CombatStrafe ||
-		RotationMode == ERpgCharacterRotationMode::Aim;
-}
-
-float CalculateTurnInPlacePlaybackWatchdogDuration(
-	float RemainingAnimationTime,
-	float PlayRate,
-	bool bLooping)
-{
-	if (bLooping || !FMath::IsFinite(PlayRate) || FMath::Abs(PlayRate) <= UE_SMALL_NUMBER)
-	{
-		return TurnInPlaceActiveTimeout;
-	}
-
-	return FMath::Max(
-		TurnInPlaceActiveTimeout,
-		FMath::Max(RemainingAnimationTime, 0.0f) / FMath::Abs(PlayRate) +
-			TurnInPlacePlaybackWatchdogSafetyMargin);
 }
 
 float CalculateLandingPlaybackWatchdogDuration(
@@ -497,7 +445,8 @@ void UpdateFootPlacementSnapshot(
 
 	const bool bLargeComponentJump =
 		bHadPreviousComponentTransform &&
-		Snapshot.ComponentDeltaWorld.SizeSquared() > FMath::Square(TurnInPlaceLargePositionDelta);
+		Snapshot.ComponentDeltaWorld.SizeSquared() >
+			FMath::Square(RpgTurnInPlaceRuntime::LargePositionDelta);
 	const bool bBaseIdentityChanged =
 		bHadPreviousComponentTransform &&
 		PreviousMovementBaseId != MovementBaseId;
@@ -568,95 +517,6 @@ void UpdateFootPlacementSnapshot(
 URpgAnimInstance::URpgAnimInstance(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
-}
-
-float URpgAnimInstance::QuantizeTurnInPlaceAngle(float SignedAngle)
-{
-	const float AbsoluteAngle = FMath::Min(FMath::Abs(SignedAngle), 180.0f);
-	if (AbsoluteAngle < TurnInPlaceActivationThreshold)
-	{
-		return 0.0f;
-	}
-
-	float QuantizedMagnitude = 180.0f;
-	if (AbsoluteAngle < 67.5f)
-	{
-		QuantizedMagnitude = 45.0f;
-	}
-	else if (AbsoluteAngle < 112.5f)
-	{
-		QuantizedMagnitude = 90.0f;
-	}
-	else if (AbsoluteAngle < 157.5f)
-	{
-		QuantizedMagnitude = 135.0f;
-	}
-
-	return SignedAngle < 0.0f ? -QuantizedMagnitude : QuantizedMagnitude;
-}
-
-float URpgAnimInstance::GetTurnInPlaceFacingDuration(float QuantizedAngle)
-{
-	const float AbsoluteAngle = FMath::Abs(QuantizedAngle);
-	if (AbsoluteAngle <= 45.0f)
-	{
-		return 0.45f;
-	}
-	if (AbsoluteAngle <= 90.0f)
-	{
-		return 0.65f;
-	}
-	if (AbsoluteAngle <= 135.0f)
-	{
-		return 0.85f;
-	}
-	return 1.0f;
-}
-
-float URpgAnimInstance::CalculateTurnInPlaceYawDelta(float PreviousActorYaw, float CurrentActorYaw)
-{
-	return FMath::FindDeltaAngleDegrees(PreviousActorYaw, CurrentActorYaw);
-}
-
-bool URpgAnimInstance::DidTurnInPlaceSupportChange(
-	bool bHasPreviousSnapshot,
-	ERpgCharacterRotationMode PreviousMode,
-	ERpgCharacterRotationMode CurrentMode)
-{
-	return bHasPreviousSnapshot && SupportsTurnInPlace(PreviousMode) != SupportsTurnInPlace(CurrentMode);
-}
-
-float URpgAnimInstance::CalculateTurnInPlaceSnapshotYawDelta(
-	float PreviousActorYaw,
-	float CurrentActorYaw,
-	bool bHardReset,
-	bool bSupportChanged)
-{
-	return bHardReset || bSupportChanged
-		? 0.0f
-		: CalculateTurnInPlaceYawDelta(PreviousActorYaw, CurrentActorYaw);
-}
-
-FTransformTrajectory URpgAnimInstance::MakeTurnInPlaceSyntheticTrajectory(
-	const FTransformTrajectory& SourceTrajectory,
-	float CurrentActorYaw,
-	float AccumulatedYaw,
-	float QuantizedAngle)
-{
-	FTransformTrajectory Result;
-	const float FacingDuration = GetTurnInPlaceFacingDuration(QuantizedAngle);
-	const float StartYaw = CurrentActorYaw - AccumulatedYaw;
-
-	Result.Samples.Reserve(SourceTrajectory.Samples.Num());
-	for (const FTransformTrajectorySample& SourceSample : SourceTrajectory.Samples)
-	{
-		FTransformTrajectorySample& Sample = Result.Samples.Add_GetRef(SourceSample);
-		const float FacingAlpha = Sample.TimeInSeconds <= 0.0f
-			? 0.0f
-			: FMath::Clamp(Sample.TimeInSeconds / FacingDuration, 0.0f, 1.0f);
-		Sample.Facing = FRotator(0.0f, StartYaw + QuantizedAngle * FacingAlpha, 0.0f).Quaternion();
-	}
-	return Result;
 }
 
 bool URpgAnimInstance::CanRunParallelWork() const
@@ -773,13 +633,14 @@ void FRpgAnimInstanceProxy::PreUpdate(UAnimInstance* InAnimInstance, float Delta
 		PreviousOwnerUniqueId != OwnerUniqueId ||
 		PreviousLocalRole != LocalRole ||
 		PreviousRemoteRole != RemoteRole;
-	bTurnInPlaceSupportChanged = URpgAnimInstance::DidTurnInPlaceSupportChange(
+	bTurnInPlaceSupportChanged = RpgTurnInPlaceRuntime::DidSupportChange(
 		bHasPreviousOwnerSnapshot,
 		PreviousRotationMode,
 		RotationMode);
 	const bool bLargePositionJump =
 		bHasPreviousOwnerSnapshot &&
-		FVector::DistSquared(PreviousActorLocation, ActorLocation) > FMath::Square(TurnInPlaceLargePositionDelta);
+		FVector::DistSquared(PreviousActorLocation, ActorLocation) >
+			FMath::Square(RpgTurnInPlaceRuntime::LargePositionDelta);
 	bTurnInPlaceHardReset = bOwnerOrRoleChanged || bLargePositionJump || MovementComponent->bJustTeleported;
 	if (bTurnInPlaceHardReset)
 	{
@@ -788,7 +649,7 @@ void FRpgAnimInstanceProxy::PreUpdate(UAnimInstance* InAnimInstance, float Delta
 		TrajectoryLandingPrediction = FRpgTrajectoryLandingPrediction();
 		DesiredControllerYawLastUpdate = 0.0f;
 	}
-	ActorYawDelta = URpgAnimInstance::CalculateTurnInPlaceSnapshotYawDelta(
+	ActorYawDelta = RpgTurnInPlaceRuntime::CalculateSnapshotYawDelta(
 		PreviousActorYaw,
 		ActorYaw,
 		bTurnInPlaceHardReset,
@@ -1930,20 +1791,43 @@ void URpgAnimInstance::NativeInitializeAnimation()
 	}
 }
 
-bool URpgAnimInstance::IsTurnInPlaceEligible(const FRpgAnimInstanceProxy& Proxy) const
+FRpgTurnInPlaceRuntimeState URpgAnimInstance::CaptureTurnInPlaceRuntimeState() const
 {
-	return
-		TurnInPlaceMotionMatchingDatabase != nullptr &&
-		JumpPhase == ERpgJumpPhase::Grounded &&
-		SupportsTurnInPlace(Proxy.RotationMode) &&
-		Proxy.MovementState == ERpgLocomotionMovementState::Grounded &&
-		Proxy.bIsMovingOnGround &&
-		!Proxy.bIsCrouching &&
-		!Proxy.bIsAnyMontagePlaying &&
-		!Proxy.bHasTurnInPlaceBlockingGameplayTag &&
-		Proxy.GroundSpeed <= TurnInPlaceIdleSpeedThreshold &&
-		!Proxy.bHasGroundedMoveIntent &&
-		!Proxy.TransformTrajectory.Samples.IsEmpty();
+	FRpgTurnInPlaceRuntimeState State;
+	State.State = TurnInPlaceState;
+	State.QueryAngle = TurnInPlaceQueryAngle;
+	State.AccumulatedYaw = TurnInPlaceAccumulatedYaw;
+	State.StateElapsed = TurnInPlaceStateElapsed;
+	State.StableElapsed = TurnInPlaceStableElapsed;
+	State.SelectionElapsed = TurnInPlaceSelectionElapsed;
+	State.PlaybackWatchdogDuration = TurnInPlacePlaybackWatchdogDuration;
+	State.RequestAccumulatedYaw = TurnInPlaceRequestAccumulatedYaw;
+	State.RequestSerial = TurnInPlaceRequestSerial;
+	State.InterruptedRequestSerial = TurnInPlaceInterruptedRequestSerial;
+	State.HardResetReasonsLastFrame = TurnInPlaceHardResetReasonsLastFrame;
+	return State;
+}
+
+void URpgAnimInstance::ApplyTurnInPlaceRuntimeResult(
+	const FRpgTurnInPlaceUpdateResult& Result)
+{
+	TurnInPlaceState = Result.State.State;
+	TurnInPlaceQueryAngle = Result.State.QueryAngle;
+	TurnInPlaceAccumulatedYaw = Result.State.AccumulatedYaw;
+	TurnInPlaceStateElapsed = Result.State.StateElapsed;
+	TurnInPlaceStableElapsed = Result.State.StableElapsed;
+	TurnInPlaceSelectionElapsed = Result.State.SelectionElapsed;
+	TurnInPlacePlaybackWatchdogDuration = Result.State.PlaybackWatchdogDuration;
+	TurnInPlaceRequestAccumulatedYaw = Result.State.RequestAccumulatedYaw;
+	TurnInPlaceRequestSerial = Result.State.RequestSerial;
+	TurnInPlaceInterruptedRequestSerial = Result.State.InterruptedRequestSerial;
+	TurnInPlaceHardResetReasonsLastFrame = Result.State.HardResetReasonsLastFrame;
+	OffsetRootRotationMode = Result.OffsetRootRotationMode;
+	bResetOffsetRootEveryFrame |= Result.bResetOffsetRootEveryFrame;
+	if (Result.bClearSelection)
+	{
+		ClearTurnInPlaceSelection();
+	}
 }
 
 void URpgAnimInstance::ClearTurnInPlaceSelection()
@@ -1952,7 +1836,7 @@ void URpgAnimInstance::ClearTurnInPlaceSelection()
 	TurnInPlaceSelectedAssetStartTime = 0.0f;
 	TurnInPlaceSelectedAssetRemainingTime = MAX_flt;
 	TurnInPlaceSelectedRequestSerial = 0;
-	TurnInPlacePlaybackWatchdogDuration = TurnInPlaceActiveTimeout;
+	TurnInPlacePlaybackWatchdogDuration = RpgTurnInPlaceRuntime::ActiveTimeout;
 	bTurnInPlacePoseSelected = false;
 	bTurnInPlaceSelectedAssetLooping = false;
 	bTurnInPlaceSelectionLatched = false;
@@ -1962,263 +1846,69 @@ void URpgAnimInstance::ClearTurnInPlaceSelection()
 
 void URpgAnimInstance::ResetTurnInPlaceRuntime(bool bHardResetOffset)
 {
-	TurnInPlaceState = ERpgTurnInPlaceState::Inactive;
-	TurnInPlaceQueryAngle = 0.0f;
-	TurnInPlaceAccumulatedYaw = 0.0f;
-	TurnInPlaceStateElapsed = 0.0f;
-	TurnInPlaceStableElapsed = 0.0f;
-	TurnInPlaceSelectionElapsed = 0.0f;
-	TurnInPlaceRequestAccumulatedYaw = 0.0f;
-	ClearTurnInPlaceSelection();
+	ApplyTurnInPlaceRuntimeResult(RpgTurnInPlaceRuntime::Reset(
+		CaptureTurnInPlaceRuntimeState(),
+		bHardResetOffset));
 	TurnInPlaceSyntheticTrajectory.Samples.Reset();
-	OffsetRootRotationMode = EOffsetRootBoneMode::Interpolate;
-	bResetOffsetRootEveryFrame |= bHardResetOffset;
 }
 
 void URpgAnimInstance::BeginTurnInPlaceRecovery(bool bHardResetOffset)
 {
-	TurnInPlaceState = ERpgTurnInPlaceState::Recovering;
-	TurnInPlaceStateElapsed = 0.0f;
-	TurnInPlaceStableElapsed = 0.0f;
-	TurnInPlaceSelectionElapsed = 0.0f;
-	ClearTurnInPlaceSelection();
+	ApplyTurnInPlaceRuntimeResult(RpgTurnInPlaceRuntime::BeginRecovery(
+		CaptureTurnInPlaceRuntimeState(),
+		bHardResetOffset));
 	TurnInPlaceSyntheticTrajectory.Samples.Reset();
-	OffsetRootRotationMode = EOffsetRootBoneMode::Interpolate;
-	bResetOffsetRootEveryFrame |= bHardResetOffset;
 }
 
 void URpgAnimInstance::BeginTurnInPlaceRequest(float QuantizedAngle)
 {
-	TurnInPlaceState = ERpgTurnInPlaceState::Active;
-	TurnInPlaceQueryAngle = QuantizedAngle;
-	TurnInPlaceStateElapsed = 0.0f;
-	TurnInPlaceStableElapsed = 0.0f;
-	TurnInPlaceSelectionElapsed = 0.0f;
-	TurnInPlaceRequestAccumulatedYaw = TurnInPlaceAccumulatedYaw;
-	ClearTurnInPlaceSelection();
-	++TurnInPlaceRequestSerial;
-	if (TurnInPlaceRequestSerial == 0)
-	{
-		++TurnInPlaceRequestSerial;
-	}
-	OffsetRootRotationMode = EOffsetRootBoneMode::Accumulate;
+	ApplyTurnInPlaceRuntimeResult(RpgTurnInPlaceRuntime::BeginRequest(
+		CaptureTurnInPlaceRuntimeState(),
+		QuantizedAngle));
 }
 
 void URpgAnimInstance::UpdateTurnInPlaceRuntime(float DeltaSeconds, const FRpgAnimInstanceProxy& Proxy)
 {
-	const float SafeDeltaSeconds = FMath::Max(DeltaSeconds, 0.0f);
 	bResetOffsetRootEveryFrame = bTurnInPlaceInitializationResetPending;
 	bTurnInPlaceInitializationResetPending = false;
-	const float AbsoluteActorYawRate = SafeDeltaSeconds > UE_SMALL_NUMBER
-		? FMath::Abs(Proxy.ActorYawDelta) / SafeDeltaSeconds
-		: (FMath::IsNearlyZero(Proxy.ActorYawDelta) ? 0.0f : MAX_flt);
 
-	const bool bAirborneCancelsTurnInPlace =
-		Proxy.MovementState == ERpgLocomotionMovementState::Airborne;
-	uint8 HardResetReasons = 0;
-	const auto AddHardResetReason = [&HardResetReasons](
-		bool bCondition,
-		ETurnInPlaceHardResetReason Reason)
+	FRpgTurnInPlaceEligibilitySnapshot Eligibility;
+	Eligibility.RotationMode = Proxy.RotationMode;
+	Eligibility.MovementState = Proxy.MovementState;
+	Eligibility.GroundSpeed = Proxy.GroundSpeed;
+	Eligibility.bHasTurnDatabase = TurnInPlaceMotionMatchingDatabase != nullptr;
+	Eligibility.bJumpPhaseGrounded = JumpPhase == ERpgJumpPhase::Grounded;
+	Eligibility.bIsMovingOnGround = Proxy.bIsMovingOnGround;
+	Eligibility.bIsCrouching = Proxy.bIsCrouching;
+	Eligibility.bIsAnyMontagePlaying = Proxy.bIsAnyMontagePlaying;
+	Eligibility.bHasBlockingGameplayTag = Proxy.bHasTurnInPlaceBlockingGameplayTag;
+	Eligibility.bHasGroundedMoveIntent = Proxy.bHasGroundedMoveIntent;
+	Eligibility.bHasTrajectory = !Proxy.TransformTrajectory.Samples.IsEmpty();
+
+	FRpgTurnInPlaceUpdateSnapshot Snapshot;
+	Snapshot.RotationMode = Proxy.RotationMode;
+	Snapshot.MovementState = Proxy.MovementState;
+	Snapshot.ActorYawDelta = Proxy.ActorYawDelta;
+	Snapshot.bEligible = RpgTurnInPlaceRuntime::IsEligible(Eligibility);
+	Snapshot.bProxyHardReset = Proxy.bTurnInPlaceHardReset;
+	Snapshot.bSupportChanged = Proxy.bTurnInPlaceSupportChanged;
+	Snapshot.bHasBlockingGameplayTag = Proxy.bHasTurnInPlaceBlockingGameplayTag;
+	Snapshot.bIsAnyMontagePlaying = Proxy.bIsAnyMontagePlaying;
+	Snapshot.bIsCrouching = Proxy.bIsCrouching;
+	Snapshot.bSelectionLatched = bTurnInPlaceSelectionLatched;
+	Snapshot.bPlaybackObserved = bTurnInPlacePlaybackObserved;
+	Snapshot.bPoseSelected = bTurnInPlacePoseSelected;
+	Snapshot.bCompletionArmed = bTurnInPlaceCompletionArmed;
+
+	const FRpgTurnInPlaceUpdateResult Result = RpgTurnInPlaceRuntime::Update(
+		CaptureTurnInPlaceRuntimeState(),
+		Snapshot,
+		DeltaSeconds);
+	ApplyTurnInPlaceRuntimeResult(Result);
+
+	if (Result.bUseSyntheticTrajectory)
 	{
-		if (bCondition)
-		{
-			HardResetReasons |= ToReasonMask(Reason);
-		}
-	};
-	AddHardResetReason(Proxy.bTurnInPlaceHardReset, ETurnInPlaceHardResetReason::ProxySnapshot);
-	AddHardResetReason(!SupportsTurnInPlace(Proxy.RotationMode), ETurnInPlaceHardResetReason::UnsupportedRotationMode);
-	AddHardResetReason(Proxy.bHasTurnInPlaceBlockingGameplayTag, ETurnInPlaceHardResetReason::BlockingGameplayTag);
-	AddHardResetReason(Proxy.bIsAnyMontagePlaying, ETurnInPlaceHardResetReason::Montage);
-	AddHardResetReason(Proxy.bIsCrouching, ETurnInPlaceHardResetReason::Crouch);
-	AddHardResetReason(
-		!bAirborneCancelsTurnInPlace &&
-			Proxy.MovementState != ERpgLocomotionMovementState::Grounded,
-		ETurnInPlaceHardResetReason::UnsupportedMovementState);
-	if (HardResetReasons != 0 || bAirborneCancelsTurnInPlace)
-	{
-		const bool bHasTurnStateToClear =
-			TurnInPlaceState != ERpgTurnInPlaceState::Inactive ||
-			FMath::Abs(TurnInPlaceAccumulatedYaw) > UE_KINDA_SMALL_NUMBER;
-		const bool bHasNewHardResetReason =
-			(HardResetReasons & ~TurnInPlaceHardResetReasonsLastFrame) != 0;
-		// Entering the air always cancels TIR ownership, but a regular moving jump must retain
-		// Offset Root's interpolated locomotion offset. Only real TIR state/yaw needs a pulse;
-		// every newly added teleport, montage, stance, tag, or unsupported-policy reason gets
-		// its own one-shot edge even while another reason remains active. A rotation-policy
-		// transition is also an event so an early airborne/override return cannot consume it.
-		const bool bPulseHardReset =
-			bHasTurnStateToClear ||
-			bHasNewHardResetReason ||
-			Proxy.bTurnInPlaceSupportChanged;
-		ResetTurnInPlaceRuntime(bPulseHardReset);
-		// Do not let a clean airborne-only cancel mask a later montage/tag/policy reset in the air.
-		TurnInPlaceHardResetReasonsLastFrame = HardResetReasons;
-		LocomotionTrajectory = Proxy.TransformTrajectory;
-		return;
-	}
-	TurnInPlaceHardResetReasonsLastFrame = 0;
-
-	if (Proxy.bTurnInPlaceSupportChanged)
-	{
-		// Entering a controller-facing mode can rotate the capsule from an arbitrary free-camera
-		// heading in one frame. Treat that policy transition as a reset, not authored turn intent.
-		// Recovery also absorbs the short network-smoothing tail on simulated proxies.
-		BeginTurnInPlaceRecovery(true);
-		LocomotionTrajectory = Proxy.TransformTrajectory;
-		return;
-	}
-
-	const bool bEligible = IsTurnInPlaceEligible(Proxy);
-	if (!bEligible)
-	{
-		if (TurnInPlaceState == ERpgTurnInPlaceState::Collecting ||
-			TurnInPlaceState == ERpgTurnInPlaceState::Active)
-		{
-			BeginTurnInPlaceRecovery(false);
-		}
-		else if (TurnInPlaceState == ERpgTurnInPlaceState::Recovering)
-		{
-			TurnInPlaceStateElapsed += SafeDeltaSeconds;
-			if (TurnInPlaceStateElapsed >= TurnInPlaceRecoveryDuration)
-			{
-				ResetTurnInPlaceRuntime(false);
-			}
-		}
-		else
-		{
-			ResetTurnInPlaceRuntime(false);
-		}
-
-		LocomotionTrajectory = Proxy.TransformTrajectory;
-		return;
-	}
-
-	TurnInPlaceStateElapsed += SafeDeltaSeconds;
-	if (TurnInPlaceState != ERpgTurnInPlaceState::Recovering)
-	{
-		TurnInPlaceAccumulatedYaw = FMath::Clamp(
-			TurnInPlaceAccumulatedYaw + Proxy.ActorYawDelta,
-			-180.0f,
-			180.0f);
-	}
-
-	switch (TurnInPlaceState)
-	{
-	case ERpgTurnInPlaceState::Inactive:
-		OffsetRootRotationMode = EOffsetRootBoneMode::Interpolate;
-		if (AbsoluteActorYawRate <= TurnInPlaceInactiveYawRateThreshold)
-		{
-			TurnInPlaceStableElapsed += SafeDeltaSeconds;
-			if (TurnInPlaceStableElapsed >= TurnInPlaceInactiveAccumulatorTimeout)
-			{
-				TurnInPlaceAccumulatedYaw = 0.0f;
-			}
-		}
-		else
-		{
-			TurnInPlaceStableElapsed = 0.0f;
-		}
-
-		if (FMath::Abs(TurnInPlaceAccumulatedYaw) >= TurnInPlaceCollectThreshold)
-		{
-			TurnInPlaceState = ERpgTurnInPlaceState::Collecting;
-			TurnInPlaceStateElapsed = 0.0f;
-			TurnInPlaceStableElapsed = 0.0f;
-			OffsetRootRotationMode = EOffsetRootBoneMode::Accumulate;
-		}
-		break;
-
-	case ERpgTurnInPlaceState::Collecting:
-		OffsetRootRotationMode = EOffsetRootBoneMode::Accumulate;
-		if (FMath::Abs(TurnInPlaceAccumulatedYaw) < TurnInPlaceCancelThreshold)
-		{
-			BeginTurnInPlaceRecovery(false);
-			break;
-		}
-
-		TurnInPlaceStableElapsed = AbsoluteActorYawRate <= TurnInPlaceStableYawRateThreshold
-			? TurnInPlaceStableElapsed + SafeDeltaSeconds
-			: 0.0f;
-		if (FMath::Abs(TurnInPlaceAccumulatedYaw) >= TurnInPlaceActivationThreshold &&
-			(TurnInPlaceStableElapsed >= TurnInPlaceStabilityDuration ||
-			 TurnInPlaceStateElapsed >= TurnInPlaceCollectionTimeout))
-		{
-			BeginTurnInPlaceRequest(QuantizeTurnInPlaceAngle(TurnInPlaceAccumulatedYaw));
-		}
-		else if (TurnInPlaceStateElapsed >= TurnInPlaceCollectionTimeout)
-		{
-			BeginTurnInPlaceRecovery(false);
-		}
-		break;
-
-	case ERpgTurnInPlaceState::Active:
-	{
-		OffsetRootRotationMode = bTurnInPlaceSelectionLatched
-			? EOffsetRootBoneMode::LockOffsetIncreaseAndConsumeAnimation
-			: EOffsetRootBoneMode::Accumulate;
-		if (FMath::Abs(TurnInPlaceAccumulatedYaw) < TurnInPlaceCancelThreshold)
-		{
-			BeginTurnInPlaceRecovery(false);
-			break;
-		}
-
-		if (CanRetargetTurnInPlaceRequest())
-		{
-			const float UpdatedQueryAngle = QuantizeTurnInPlaceAngle(TurnInPlaceAccumulatedYaw);
-			const float AdditionalYaw = TurnInPlaceAccumulatedYaw - TurnInPlaceRequestAccumulatedYaw;
-			const bool bDirectionChanged =
-				!FMath::IsNearlyZero(UpdatedQueryAngle) &&
-				FMath::Sign(UpdatedQueryAngle) != FMath::Sign(TurnInPlaceQueryAngle);
-			const bool bQuantizedBucketChanged =
-				!FMath::IsNearlyZero(UpdatedQueryAngle) &&
-				!FMath::IsNearlyEqual(UpdatedQueryAngle, TurnInPlaceQueryAngle);
-			if (FMath::Abs(AdditionalYaw) >= TurnInPlaceActivationThreshold &&
-				(bDirectionChanged || bQuantizedBucketChanged))
-			{
-				BeginTurnInPlaceRequest(UpdatedQueryAngle);
-				break;
-			}
-		}
-
-		if (!bTurnInPlaceSelectionLatched)
-		{
-			TurnInPlaceSelectionElapsed += SafeDeltaSeconds;
-			if (TurnInPlaceSelectionElapsed >= TurnInPlaceSelectionTimeout)
-			{
-				BeginTurnInPlaceRecovery(true);
-				break;
-			}
-		}
-		else if (bTurnInPlaceCompletionArmed)
-		{
-			BeginTurnInPlaceRecovery(false);
-			break;
-		}
-		else if (bTurnInPlacePlaybackObserved && !bTurnInPlacePoseSelected)
-		{
-			BeginTurnInPlaceRecovery(true);
-			break;
-		}
-
-		if (TurnInPlaceStateElapsed >= TurnInPlacePlaybackWatchdogDuration)
-		{
-			BeginTurnInPlaceRecovery(true);
-		}
-		break;
-	}
-
-	case ERpgTurnInPlaceState::Recovering:
-		OffsetRootRotationMode = EOffsetRootBoneMode::Interpolate;
-		if (TurnInPlaceStateElapsed >= TurnInPlaceRecoveryDuration)
-		{
-			ResetTurnInPlaceRuntime(false);
-		}
-		break;
-	}
-
-	if (TurnInPlaceState == ERpgTurnInPlaceState::Active)
-	{
-		TurnInPlaceSyntheticTrajectory = MakeTurnInPlaceSyntheticTrajectory(
+		TurnInPlaceSyntheticTrajectory = RpgTurnInPlaceRuntime::MakeSyntheticTrajectory(
 			Proxy.TransformTrajectory,
 			Proxy.ActorYaw,
 			TurnInPlaceAccumulatedYaw,
@@ -2234,22 +1924,12 @@ void URpgAnimInstance::UpdateTurnInPlaceRuntime(float DeltaSeconds, const FRpgAn
 
 bool URpgAnimInstance::ConsumeTurnInPlaceForceInterruptRequest()
 {
-	if (TurnInPlaceState != ERpgTurnInPlaceState::Active ||
-		!TurnInPlaceMotionMatchingDatabase ||
-		TurnInPlaceInterruptedRequestSerial == TurnInPlaceRequestSerial)
-	{
-		return false;
-	}
-
-	TurnInPlaceInterruptedRequestSerial = TurnInPlaceRequestSerial;
-	return true;
-}
-
-bool URpgAnimInstance::CanRetargetTurnInPlaceRequest() const
-{
-	return TurnInPlaceState == ERpgTurnInPlaceState::Active &&
-		!bTurnInPlaceSelectionLatched &&
-		TurnInPlaceInterruptedRequestSerial != TurnInPlaceRequestSerial;
+	FRpgTurnInPlaceRuntimeState State = CaptureTurnInPlaceRuntimeState();
+	const bool bConsumed = RpgTurnInPlaceRuntime::ConsumeForceInterrupt(
+		TurnInPlaceMotionMatchingDatabase != nullptr,
+		State);
+	TurnInPlaceInterruptedRequestSerial = State.InterruptedRequestSerial;
+	return bConsumed;
 }
 
 bool URpgAnimInstance::TryLatchTurnInPlaceSelection(
@@ -2275,7 +1955,7 @@ bool URpgAnimInstance::TryLatchTurnInPlaceSelection(
 		SelectedAsset->GetPlayLength() - TurnInPlaceSelectedAssetStartTime,
 		0.0f);
 	TurnInPlaceSelectedRequestSerial = SelectionRequestSerial;
-	TurnInPlacePlaybackWatchdogDuration = CalculateTurnInPlacePlaybackWatchdogDuration(
+	TurnInPlacePlaybackWatchdogDuration = RpgTurnInPlaceRuntime::CalculatePlaybackWatchdogDuration(
 		TurnInPlaceSelectedAssetRemainingTime,
 		1.0f,
 		bSelectedAssetLooping);
@@ -2304,7 +1984,8 @@ void URpgAnimInstance::UpdateTurnInPlaceLatchedPlayback(
 	}
 
 	const float SafeDeltaSeconds = FMath::Max(DeltaSeconds, 0.0f);
-	const float CompletionLeadTime = TurnInPlaceFinishedTimeTolerance + SafeDeltaSeconds;
+	const float CompletionLeadTime =
+		RpgTurnInPlaceRuntime::FinishedTimeTolerance + SafeDeltaSeconds;
 	if (CurrentAsset == TurnInPlaceSelectedAsset.Get())
 	{
 		const bool bFirstPlaybackObservation = !bTurnInPlacePlaybackObserved;
@@ -2318,7 +1999,8 @@ void URpgAnimInstance::UpdateTurnInPlaceLatchedPlayback(
 			0.0f);
 		if (bFirstPlaybackObservation)
 		{
-			TurnInPlacePlaybackWatchdogDuration = CalculateTurnInPlacePlaybackWatchdogDuration(
+			TurnInPlacePlaybackWatchdogDuration =
+				RpgTurnInPlaceRuntime::CalculatePlaybackWatchdogDuration(
 				TurnInPlaceSelectedAssetRemainingTime,
 				CurrentAssetPlayRate,
 				bTurnInPlaceSelectedAssetLooping);
@@ -2349,32 +2031,6 @@ void URpgAnimInstance::UpdateTurnInPlaceLatchedPlayback(
 	}
 
 	bTurnInPlacePoseSelected = false;
-}
-
-URpgAnimInstance::ETurnInPlaceSearchMode URpgAnimInstance::ResolveTurnInPlaceSearchMode(
-	bool bForceNewRequest) const
-{
-	if (bForceNewRequest &&
-		TurnInPlaceState == ERpgTurnInPlaceState::Active &&
-		TurnInPlaceMotionMatchingDatabase)
-	{
-		return ETurnInPlaceSearchMode::SearchRequestedTurn;
-	}
-
-	if (TurnInPlaceState == ERpgTurnInPlaceState::Active &&
-		bTurnInPlaceSelectionLatched &&
-		!bTurnInPlaceCompletionArmed)
-	{
-		return ETurnInPlaceSearchMode::ContinueSelectedTurn;
-	}
-
-	return ETurnInPlaceSearchMode::NormalLocomotion;
-}
-
-bool URpgAnimInstance::AllowsMovingProceduralNodes() const
-{
-	return TurnInPlaceState == ERpgTurnInPlaceState::Inactive ||
-		TurnInPlaceState == ERpgTurnInPlaceState::Recovering;
 }
 
 void URpgAnimInstance::ClearLandingSelection()
@@ -2965,10 +2621,15 @@ void URpgAnimInstance::UpdateGaspMotionMatching(
 			AnimationContext ? AnimationContext->GetDeltaTime() : 0.0f);
 	}
 
-	const ETurnInPlaceSearchMode SearchMode =
-		ResolveTurnInPlaceSearchMode(bForceNewTurnRequest);
+	const ERpgTurnInPlaceSearchMode SearchMode =
+		RpgTurnInPlaceRuntime::ResolveSearchMode(
+			CaptureTurnInPlaceRuntimeState(),
+			bForceNewTurnRequest,
+			TurnInPlaceMotionMatchingDatabase != nullptr,
+			bTurnInPlaceSelectionLatched,
+			bTurnInPlaceCompletionArmed);
 	const bool bForceNewLandingRequest =
-		SearchMode == ETurnInPlaceSearchMode::NormalLocomotion &&
+		SearchMode == ERpgTurnInPlaceSearchMode::NormalLocomotion &&
 		ConsumeLandingForceInterruptRequest();
 
 	if (JumpPhase == ERpgJumpPhase::Landing && bLandingSelectionLatched)
@@ -3005,12 +2666,12 @@ void URpgAnimInstance::UpdateGaspMotionMatching(
 
 	TArray<UPoseSearchDatabase*, TInlineAllocator<5>> DatabasesToSearch;
 	EPoseSearchInterruptMode InterruptMode = EPoseSearchInterruptMode::InterruptOnDatabaseChange;
-	if (SearchMode == ETurnInPlaceSearchMode::SearchRequestedTurn)
+	if (SearchMode == ERpgTurnInPlaceSearchMode::SearchRequestedTurn)
 	{
 		DatabasesToSearch.Add(TurnInPlaceMotionMatchingDatabase);
 		InterruptMode = EPoseSearchInterruptMode::ForceInterrupt;
 	}
-	else if (SearchMode == ETurnInPlaceSearchMode::ContinueSelectedTurn)
+	else if (SearchMode == ERpgTurnInPlaceSearchMode::ContinueSelectedTurn)
 	{
 		// An empty searchable set with DoNotInterrupt keeps only the current database's Continuing Pose.
 		// It prevents a full TIR-database search from selecting another clip when the indexed range ends.
@@ -3155,7 +2816,7 @@ void URpgAnimInstance::GetGaspBlendStackInputs(
 	const bool bAllowsSampleProceduralNodes =
 		!bIsCrouching &&
 		!bIsAnyMontagePlaying &&
-		AllowsMovingProceduralNodes();
+		RpgTurnInPlaceRuntime::AllowsMovingProceduralNodes(TurnInPlaceState);
 
 	float EnableWarpingCurveValue = 0.0f;
 	if (const UAnimSequenceBase* CurrentSequence = Cast<UAnimSequenceBase>(CurrentAnimAsset))

--- a/Source/SurvivalRpg/Animation/RpgAnimInstance.h
+++ b/Source/SurvivalRpg/Animation/RpgAnimInstance.h
@@ -16,6 +16,7 @@
 #include "RpgGaspPresentationProfile.h"
 #include "RpgMotionMatchingRuntime.h"
 #include "RpgPoseSearchTrajectory.h"
+#include "RpgTurnInPlaceRuntime.h"
 #include "SurvivalRpg/Core/Character/RpgCharacterRotationMode.h"
 #include "RpgAnimInstance.generated.h"
 
@@ -352,25 +353,6 @@ public:
 
 	/** Returns the one project-owned locomotion-state tag required for a database role. */
 	static FName GetMotionMatchingDatabaseStateTag(ERpgMotionMatchingDatabaseRole Role);
-
-	/** Returns the signed authored turn angle nearest to a request, or zero below the 30-degree activation threshold. */
-	static float QuantizeTurnInPlaceAngle(float SignedAngle);
-
-	/** Returns the synthetic facing horizon in seconds for an authored 45/90/135/180-degree turn. */
-	static float GetTurnInPlaceFacingDuration(float QuantizedAngle);
-
-	/** Calculates a wrap-safe signed actor-yaw delta in degrees for the cosmetic turn accumulator. */
-	static float CalculateTurnInPlaceYawDelta(float PreviousActorYaw, float CurrentActorYaw);
-
-	/**
-	 * Builds a facing-only world-space trajectory whose facing advances monotonically through the requested authored turn.
-	 * Source sample count, times, and positions are preserved exactly.
-	 */
-	static FTransformTrajectory MakeTurnInPlaceSyntheticTrajectory(
-		const FTransformTrajectory& SourceTrajectory,
-		float CurrentActorYaw,
-		float AccumulatedYaw,
-		float QuantizedAngle);
 
 	/**
 	 * Resolves the current Blend Stack playback state and the bounded moving-locomotion inputs used by GASP nodes.
@@ -861,35 +843,17 @@ private:
 		bool bEnableSteering = false;
 	};
 
-	/** Database policy applied by the generic pre-update callback to the upcoming Motion Matching search. */
-	enum class ETurnInPlaceSearchMode : uint8
-	{
-		NormalLocomotion,
-		SearchRequestedTurn,
-		ContinueSelectedTurn,
-	};
-
-	/** Detects a transition across the Free versus controller-facing turn-in-place policy boundary. */
-	static bool DidTurnInPlaceSupportChange(
-		bool bHasPreviousSnapshot,
-		ERpgCharacterRotationMode PreviousMode,
-		ERpgCharacterRotationMode CurrentMode);
-	/** Rebases actor yaw when the owner snapshot is invalidated or the facing policy changes. */
-	static float CalculateTurnInPlaceSnapshotYawDelta(
-		float PreviousActorYaw,
-		float CurrentActorYaw,
-		bool bHardReset,
-		bool bSupportChanged);
+	/** Captures the flat compatibility fields for one pointer-free turn-in-place decision. */
+	FRpgTurnInPlaceRuntimeState CaptureTurnInPlaceRuntimeState() const;
+	/** Applies one value result without moving the GC-tracked selection out of this facade. */
+	void ApplyTurnInPlaceRuntimeResult(const FRpgTurnInPlaceUpdateResult& Result);
 	void UpdateTurnInPlaceRuntime(float DeltaSeconds, const FRpgAnimInstanceProxy& Proxy);
 	void BeginTurnInPlaceRequest(float QuantizedAngle);
 	void BeginTurnInPlaceRecovery(bool bHardResetOffset);
 	void ResetTurnInPlaceRuntime(bool bHardResetOffset);
 	/** Clears only the cosmetic selection/playback latch; request serials remain monotonic. */
 	void ClearTurnInPlaceSelection();
-	bool IsTurnInPlaceEligible(const FRpgAnimInstanceProxy& Proxy) const;
 	bool ConsumeTurnInPlaceForceInterruptRequest();
-	/** Allows request retargeting only until the generic pre-update callback dispatches its first TIR search. */
-	bool CanRetargetTurnInPlaceRequest() const;
 	/** Latches the first valid TIR SearchResult from the completed node search for the request serial. */
 	bool TryLatchTurnInPlaceSelection(
 		UAnimationAsset* SelectedAsset,
@@ -904,11 +868,6 @@ private:
 		float CurrentAssetLength,
 		float CurrentAssetPlayRate,
 		float DeltaSeconds);
-	/** Resolves the upcoming search policy without issuing more than one full TIR search per request. */
-	ETurnInPlaceSearchMode ResolveTurnInPlaceSearchMode(bool bForceNewRequest) const;
-	/** Allows moving procedural nodes during a movement-driven recovery, but never during collection or playback. */
-	bool AllowsMovingProceduralNodes() const;
-
 	/** Advances landing state and permits only the initial request plus one bounded stationary-to-moving handoff. */
 	void UpdateJumpPhaseRuntime(float DeltaSeconds, const FRpgAnimInstanceProxy& Proxy);
 	void BeginAirbornePhase(bool bAscendingTakeoff);

--- a/Source/SurvivalRpg/Animation/RpgTurnInPlaceRuntime.cpp
+++ b/Source/SurvivalRpg/Animation/RpgTurnInPlaceRuntime.cpp
@@ -1,0 +1,492 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+#include "RpgTurnInPlaceRuntime.h"
+
+#include "RpgAnimInstance.h"
+
+namespace
+{
+enum class ETurnInPlaceHardResetReason : uint8
+{
+	ProxySnapshot = 1 << 0,
+	UnsupportedRotationMode = 1 << 1,
+	BlockingGameplayTag = 1 << 2,
+	Montage = 1 << 3,
+	Crouch = 1 << 4,
+	UnsupportedMovementState = 1 << 5,
+};
+
+constexpr uint8 ToReasonMask(ETurnInPlaceHardResetReason Reason)
+{
+	return static_cast<uint8>(Reason);
+}
+
+void AddHardResetReason(
+	uint8& Reasons,
+	bool bCondition,
+	ETurnInPlaceHardResetReason Reason)
+{
+	if (bCondition)
+	{
+		Reasons |= ToReasonMask(Reason);
+	}
+}
+}
+
+bool RpgTurnInPlaceRuntime::SupportsTurnInPlace(
+	ERpgCharacterRotationMode RotationMode)
+{
+	return RotationMode == ERpgCharacterRotationMode::CombatStrafe ||
+		RotationMode == ERpgCharacterRotationMode::Aim;
+}
+
+float RpgTurnInPlaceRuntime::QuantizeAngle(float SignedAngle)
+{
+	const float AbsoluteAngle = FMath::Min(FMath::Abs(SignedAngle), 180.0f);
+	if (AbsoluteAngle < ActivationThreshold)
+	{
+		return 0.0f;
+	}
+
+	float QuantizedMagnitude = 180.0f;
+	if (AbsoluteAngle < 67.5f)
+	{
+		QuantizedMagnitude = 45.0f;
+	}
+	else if (AbsoluteAngle < 112.5f)
+	{
+		QuantizedMagnitude = 90.0f;
+	}
+	else if (AbsoluteAngle < 157.5f)
+	{
+		QuantizedMagnitude = 135.0f;
+	}
+
+	return SignedAngle < 0.0f ? -QuantizedMagnitude : QuantizedMagnitude;
+}
+
+float RpgTurnInPlaceRuntime::GetFacingDuration(float QuantizedAngle)
+{
+	const float AbsoluteAngle = FMath::Abs(QuantizedAngle);
+	if (AbsoluteAngle <= 45.0f)
+	{
+		return 0.45f;
+	}
+	if (AbsoluteAngle <= 90.0f)
+	{
+		return 0.65f;
+	}
+	if (AbsoluteAngle <= 135.0f)
+	{
+		return 0.85f;
+	}
+	return 1.0f;
+}
+
+float RpgTurnInPlaceRuntime::CalculateYawDelta(
+	float PreviousActorYaw,
+	float CurrentActorYaw)
+{
+	return FMath::FindDeltaAngleDegrees(PreviousActorYaw, CurrentActorYaw);
+}
+
+bool RpgTurnInPlaceRuntime::DidSupportChange(
+	bool bHasPreviousSnapshot,
+	ERpgCharacterRotationMode PreviousMode,
+	ERpgCharacterRotationMode CurrentMode)
+{
+	return bHasPreviousSnapshot &&
+		SupportsTurnInPlace(PreviousMode) != SupportsTurnInPlace(CurrentMode);
+}
+
+float RpgTurnInPlaceRuntime::CalculateSnapshotYawDelta(
+	float PreviousActorYaw,
+	float CurrentActorYaw,
+	bool bHardReset,
+	bool bSupportChanged)
+{
+	return bHardReset || bSupportChanged
+		? 0.0f
+		: CalculateYawDelta(PreviousActorYaw, CurrentActorYaw);
+}
+
+FTransformTrajectory RpgTurnInPlaceRuntime::MakeSyntheticTrajectory(
+	const FTransformTrajectory& SourceTrajectory,
+	float CurrentActorYaw,
+	float AccumulatedYaw,
+	float QuantizedAngle)
+{
+	FTransformTrajectory Result;
+	const float FacingDuration = GetFacingDuration(QuantizedAngle);
+	const float StartYaw = CurrentActorYaw - AccumulatedYaw;
+
+	Result.Samples.Reserve(SourceTrajectory.Samples.Num());
+	for (const FTransformTrajectorySample& SourceSample : SourceTrajectory.Samples)
+	{
+		FTransformTrajectorySample& Sample = Result.Samples.Add_GetRef(SourceSample);
+		const float FacingAlpha = Sample.TimeInSeconds <= 0.0f
+			? 0.0f
+			: FMath::Clamp(Sample.TimeInSeconds / FacingDuration, 0.0f, 1.0f);
+		Sample.Facing = FRotator(
+			0.0f,
+			StartYaw + QuantizedAngle * FacingAlpha,
+			0.0f).Quaternion();
+	}
+	return Result;
+}
+
+float RpgTurnInPlaceRuntime::CalculatePlaybackWatchdogDuration(
+	float RemainingAnimationTime,
+	float PlayRate,
+	bool bLooping)
+{
+	if (bLooping || !FMath::IsFinite(PlayRate) || FMath::Abs(PlayRate) <= UE_SMALL_NUMBER)
+	{
+		return ActiveTimeout;
+	}
+
+	return FMath::Max(
+		ActiveTimeout,
+		FMath::Max(RemainingAnimationTime, 0.0f) / FMath::Abs(PlayRate) +
+			PlaybackWatchdogSafetyMargin);
+}
+
+bool RpgTurnInPlaceRuntime::IsEligible(
+	const FRpgTurnInPlaceEligibilitySnapshot& Snapshot)
+{
+	return Snapshot.bHasTurnDatabase &&
+		Snapshot.bJumpPhaseGrounded &&
+		SupportsTurnInPlace(Snapshot.RotationMode) &&
+		Snapshot.MovementState == ERpgLocomotionMovementState::Grounded &&
+		Snapshot.bIsMovingOnGround &&
+		!Snapshot.bIsCrouching &&
+		!Snapshot.bIsAnyMontagePlaying &&
+		!Snapshot.bHasBlockingGameplayTag &&
+		Snapshot.GroundSpeed <= IdleSpeedThreshold &&
+		!Snapshot.bHasGroundedMoveIntent &&
+		Snapshot.bHasTrajectory;
+}
+
+FRpgTurnInPlaceUpdateResult RpgTurnInPlaceRuntime::Reset(
+	const FRpgTurnInPlaceRuntimeState& State,
+	bool bHardResetOffset)
+{
+	FRpgTurnInPlaceUpdateResult Result;
+	Result.State = State;
+	Result.State.State = ERpgTurnInPlaceState::Inactive;
+	Result.State.QueryAngle = 0.0f;
+	Result.State.AccumulatedYaw = 0.0f;
+	Result.State.StateElapsed = 0.0f;
+	Result.State.StableElapsed = 0.0f;
+	Result.State.SelectionElapsed = 0.0f;
+	Result.State.PlaybackWatchdogDuration = ActiveTimeout;
+	Result.State.RequestAccumulatedYaw = 0.0f;
+	Result.OffsetRootRotationMode = EOffsetRootBoneMode::Interpolate;
+	Result.bResetOffsetRootEveryFrame = bHardResetOffset;
+	Result.bClearSelection = true;
+	return Result;
+}
+
+FRpgTurnInPlaceUpdateResult RpgTurnInPlaceRuntime::BeginRecovery(
+	const FRpgTurnInPlaceRuntimeState& State,
+	bool bHardResetOffset)
+{
+	FRpgTurnInPlaceUpdateResult Result;
+	Result.State = State;
+	Result.State.State = ERpgTurnInPlaceState::Recovering;
+	Result.State.StateElapsed = 0.0f;
+	Result.State.StableElapsed = 0.0f;
+	Result.State.SelectionElapsed = 0.0f;
+	Result.State.PlaybackWatchdogDuration = ActiveTimeout;
+	Result.OffsetRootRotationMode = EOffsetRootBoneMode::Interpolate;
+	Result.bResetOffsetRootEveryFrame = bHardResetOffset;
+	Result.bClearSelection = true;
+	return Result;
+}
+
+FRpgTurnInPlaceUpdateResult RpgTurnInPlaceRuntime::BeginRequest(
+	const FRpgTurnInPlaceRuntimeState& State,
+	float QuantizedAngle)
+{
+	FRpgTurnInPlaceUpdateResult Result;
+	Result.State = State;
+	Result.State.State = ERpgTurnInPlaceState::Active;
+	Result.State.QueryAngle = QuantizedAngle;
+	Result.State.StateElapsed = 0.0f;
+	Result.State.StableElapsed = 0.0f;
+	Result.State.SelectionElapsed = 0.0f;
+	Result.State.PlaybackWatchdogDuration = ActiveTimeout;
+	Result.State.RequestAccumulatedYaw = Result.State.AccumulatedYaw;
+	++Result.State.RequestSerial;
+	if (Result.State.RequestSerial == 0)
+	{
+		++Result.State.RequestSerial;
+	}
+	Result.OffsetRootRotationMode = EOffsetRootBoneMode::Accumulate;
+	Result.bClearSelection = true;
+	Result.bUseSyntheticTrajectory = true;
+	return Result;
+}
+
+FRpgTurnInPlaceUpdateResult RpgTurnInPlaceRuntime::Update(
+	const FRpgTurnInPlaceRuntimeState& State,
+	const FRpgTurnInPlaceUpdateSnapshot& Snapshot,
+	float DeltaSeconds)
+{
+	FRpgTurnInPlaceUpdateResult Result;
+	Result.State = State;
+	const float SafeDeltaSeconds = FMath::Max(DeltaSeconds, 0.0f);
+	const float AbsoluteActorYawRate = SafeDeltaSeconds > UE_SMALL_NUMBER
+		? FMath::Abs(Snapshot.ActorYawDelta) / SafeDeltaSeconds
+		: (FMath::IsNearlyZero(Snapshot.ActorYawDelta) ? 0.0f : MAX_flt);
+
+	const bool bAirborneCancelsTurnInPlace =
+		Snapshot.MovementState == ERpgLocomotionMovementState::Airborne;
+	uint8 HardResetReasons = 0;
+	AddHardResetReason(
+		HardResetReasons,
+		Snapshot.bProxyHardReset,
+		ETurnInPlaceHardResetReason::ProxySnapshot);
+	AddHardResetReason(
+		HardResetReasons,
+		!SupportsTurnInPlace(Snapshot.RotationMode),
+		ETurnInPlaceHardResetReason::UnsupportedRotationMode);
+	AddHardResetReason(
+		HardResetReasons,
+		Snapshot.bHasBlockingGameplayTag,
+		ETurnInPlaceHardResetReason::BlockingGameplayTag);
+	AddHardResetReason(
+		HardResetReasons,
+		Snapshot.bIsAnyMontagePlaying,
+		ETurnInPlaceHardResetReason::Montage);
+	AddHardResetReason(
+		HardResetReasons,
+		Snapshot.bIsCrouching,
+		ETurnInPlaceHardResetReason::Crouch);
+	AddHardResetReason(
+		HardResetReasons,
+		!bAirborneCancelsTurnInPlace &&
+			Snapshot.MovementState != ERpgLocomotionMovementState::Grounded,
+		ETurnInPlaceHardResetReason::UnsupportedMovementState);
+	if (HardResetReasons != 0 || bAirborneCancelsTurnInPlace)
+	{
+		const bool bHasTurnStateToClear =
+			Result.State.State != ERpgTurnInPlaceState::Inactive ||
+			FMath::Abs(Result.State.AccumulatedYaw) > UE_KINDA_SMALL_NUMBER;
+		const bool bHasNewHardResetReason =
+			(HardResetReasons & ~Result.State.HardResetReasonsLastFrame) != 0;
+		// Airborne movement releases TIR without disturbing ordinary locomotion interpolation.
+		// Real retained turn state and each newly added teleport, policy, tag, montage, or stance
+		// reason still receive one reset edge, even while another reason remains active.
+		const bool bPulseHardReset =
+			bHasTurnStateToClear ||
+			bHasNewHardResetReason ||
+			Snapshot.bSupportChanged;
+		Result = Reset(Result.State, bPulseHardReset);
+		Result.State.HardResetReasonsLastFrame = HardResetReasons;
+		return Result;
+	}
+	Result.State.HardResetReasonsLastFrame = 0;
+
+	if (Snapshot.bSupportChanged)
+	{
+		return BeginRecovery(Result.State, true);
+	}
+
+	if (!Snapshot.bEligible)
+	{
+		if (Result.State.State == ERpgTurnInPlaceState::Collecting ||
+			Result.State.State == ERpgTurnInPlaceState::Active)
+		{
+			return BeginRecovery(Result.State, false);
+		}
+		if (Result.State.State == ERpgTurnInPlaceState::Recovering)
+		{
+			Result.State.StateElapsed += SafeDeltaSeconds;
+			if (Result.State.StateElapsed >= RecoveryDuration)
+			{
+				return Reset(Result.State, false);
+			}
+			Result.OffsetRootRotationMode = EOffsetRootBoneMode::Interpolate;
+			return Result;
+		}
+		return Reset(Result.State, false);
+	}
+
+	Result.State.StateElapsed += SafeDeltaSeconds;
+	if (Result.State.State != ERpgTurnInPlaceState::Recovering)
+	{
+		Result.State.AccumulatedYaw = FMath::Clamp(
+			Result.State.AccumulatedYaw + Snapshot.ActorYawDelta,
+			-180.0f,
+			180.0f);
+	}
+
+	switch (Result.State.State)
+	{
+	case ERpgTurnInPlaceState::Inactive:
+		Result.OffsetRootRotationMode = EOffsetRootBoneMode::Interpolate;
+		if (AbsoluteActorYawRate <= InactiveYawRateThreshold)
+		{
+			Result.State.StableElapsed += SafeDeltaSeconds;
+			if (Result.State.StableElapsed >= InactiveAccumulatorTimeout)
+			{
+				Result.State.AccumulatedYaw = 0.0f;
+			}
+		}
+		else
+		{
+			Result.State.StableElapsed = 0.0f;
+		}
+
+		if (FMath::Abs(Result.State.AccumulatedYaw) >= CollectThreshold)
+		{
+			Result.State.State = ERpgTurnInPlaceState::Collecting;
+			Result.State.StateElapsed = 0.0f;
+			Result.State.StableElapsed = 0.0f;
+			Result.OffsetRootRotationMode = EOffsetRootBoneMode::Accumulate;
+		}
+		break;
+
+	case ERpgTurnInPlaceState::Collecting:
+		Result.OffsetRootRotationMode = EOffsetRootBoneMode::Accumulate;
+		if (FMath::Abs(Result.State.AccumulatedYaw) < CancelThreshold)
+		{
+			return BeginRecovery(Result.State, false);
+		}
+
+		Result.State.StableElapsed = AbsoluteActorYawRate <= StableYawRateThreshold
+			? Result.State.StableElapsed + SafeDeltaSeconds
+			: 0.0f;
+		if (FMath::Abs(Result.State.AccumulatedYaw) >= ActivationThreshold &&
+			(Result.State.StableElapsed >= StabilityDuration ||
+			 Result.State.StateElapsed >= CollectionTimeout))
+		{
+			return BeginRequest(
+				Result.State,
+				QuantizeAngle(Result.State.AccumulatedYaw));
+		}
+		if (Result.State.StateElapsed >= CollectionTimeout)
+		{
+			return BeginRecovery(Result.State, false);
+		}
+		break;
+
+	case ERpgTurnInPlaceState::Active:
+		Result.OffsetRootRotationMode = Snapshot.bSelectionLatched
+			? EOffsetRootBoneMode::LockOffsetIncreaseAndConsumeAnimation
+			: EOffsetRootBoneMode::Accumulate;
+		if (FMath::Abs(Result.State.AccumulatedYaw) < CancelThreshold)
+		{
+			return BeginRecovery(Result.State, false);
+		}
+
+		if (CanRetarget(Result.State, Snapshot.bSelectionLatched))
+		{
+			const float UpdatedQueryAngle = QuantizeAngle(Result.State.AccumulatedYaw);
+			const float AdditionalYaw =
+				Result.State.AccumulatedYaw - Result.State.RequestAccumulatedYaw;
+			const bool bDirectionChanged =
+				!FMath::IsNearlyZero(UpdatedQueryAngle) &&
+				FMath::Sign(UpdatedQueryAngle) != FMath::Sign(Result.State.QueryAngle);
+			const bool bQuantizedBucketChanged =
+				!FMath::IsNearlyZero(UpdatedQueryAngle) &&
+				!FMath::IsNearlyEqual(UpdatedQueryAngle, Result.State.QueryAngle);
+			if (FMath::Abs(AdditionalYaw) >= ActivationThreshold &&
+				(bDirectionChanged || bQuantizedBucketChanged))
+			{
+				return BeginRequest(Result.State, UpdatedQueryAngle);
+			}
+		}
+
+		if (!Snapshot.bSelectionLatched)
+		{
+			Result.State.SelectionElapsed += SafeDeltaSeconds;
+			if (Result.State.SelectionElapsed >= SelectionTimeout)
+			{
+				return BeginRecovery(Result.State, true);
+			}
+		}
+		else if (Snapshot.bCompletionArmed)
+		{
+			return BeginRecovery(Result.State, false);
+		}
+		else if (Snapshot.bPlaybackObserved && !Snapshot.bPoseSelected)
+		{
+			return BeginRecovery(Result.State, true);
+		}
+
+		if (Result.State.StateElapsed >= Result.State.PlaybackWatchdogDuration)
+		{
+			return BeginRecovery(Result.State, true);
+		}
+		break;
+
+	case ERpgTurnInPlaceState::Recovering:
+		Result.OffsetRootRotationMode = EOffsetRootBoneMode::Interpolate;
+		if (Result.State.StateElapsed >= RecoveryDuration)
+		{
+			return Reset(Result.State, false);
+		}
+		break;
+	}
+
+	Result.bUseSyntheticTrajectory =
+		Result.State.State == ERpgTurnInPlaceState::Active;
+	return Result;
+}
+
+bool RpgTurnInPlaceRuntime::ConsumeForceInterrupt(
+	bool bHasTurnDatabase,
+	FRpgTurnInPlaceRuntimeState& State)
+{
+	if (State.State != ERpgTurnInPlaceState::Active ||
+		!bHasTurnDatabase ||
+		State.InterruptedRequestSerial == State.RequestSerial)
+	{
+		return false;
+	}
+
+	State.InterruptedRequestSerial = State.RequestSerial;
+	return true;
+}
+
+bool RpgTurnInPlaceRuntime::CanRetarget(
+	const FRpgTurnInPlaceRuntimeState& State,
+	bool bSelectionLatched)
+{
+	return State.State == ERpgTurnInPlaceState::Active &&
+		!bSelectionLatched &&
+		State.InterruptedRequestSerial != State.RequestSerial;
+}
+
+ERpgTurnInPlaceSearchMode RpgTurnInPlaceRuntime::ResolveSearchMode(
+	const FRpgTurnInPlaceRuntimeState& State,
+	bool bForceNewRequest,
+	bool bHasTurnDatabase,
+	bool bSelectionLatched,
+	bool bCompletionArmed)
+{
+	if (bForceNewRequest &&
+		State.State == ERpgTurnInPlaceState::Active &&
+		bHasTurnDatabase)
+	{
+		return ERpgTurnInPlaceSearchMode::SearchRequestedTurn;
+	}
+
+	if (State.State == ERpgTurnInPlaceState::Active &&
+		bSelectionLatched &&
+		!bCompletionArmed)
+	{
+		return ERpgTurnInPlaceSearchMode::ContinueSelectedTurn;
+	}
+
+	return ERpgTurnInPlaceSearchMode::NormalLocomotion;
+}
+
+bool RpgTurnInPlaceRuntime::AllowsMovingProceduralNodes(
+	ERpgTurnInPlaceState State)
+{
+	return State == ERpgTurnInPlaceState::Inactive ||
+		State == ERpgTurnInPlaceState::Recovering;
+}

--- a/Source/SurvivalRpg/Animation/RpgTurnInPlaceRuntime.h
+++ b/Source/SurvivalRpg/Animation/RpgTurnInPlaceRuntime.h
@@ -1,0 +1,182 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Animation/TrajectoryTypes.h"
+#include "AnimationWarpingTypes.h"
+
+enum class ERpgCharacterRotationMode : uint8;
+enum class ERpgLocomotionMovementState : uint8;
+enum class ERpgTurnInPlaceState : uint8;
+
+/** Database policy requested by the cosmetic turn-in-place lifecycle for the next node update. */
+enum class ERpgTurnInPlaceSearchMode : uint8
+{
+	NormalLocomotion,
+	SearchRequestedTurn,
+	ContinueSelectedTurn,
+};
+
+/** Pointer-free state assembled from the stable flat AnimInstance facade for one runtime decision. */
+struct SURVIVALRPG_API FRpgTurnInPlaceRuntimeState
+{
+	ERpgTurnInPlaceState State{};
+	float QueryAngle = 0.0f;
+	float AccumulatedYaw = 0.0f;
+	float StateElapsed = 0.0f;
+	float StableElapsed = 0.0f;
+	float SelectionElapsed = 0.0f;
+	float PlaybackWatchdogDuration = 0.0f;
+	float RequestAccumulatedYaw = 0.0f;
+	uint32 RequestSerial = 0;
+	uint32 InterruptedRequestSerial = 0;
+	uint8 HardResetReasonsLastFrame = 0;
+};
+
+/** Immutable value inputs used to decide whether a stationary controller-facing turn is allowed. */
+struct SURVIVALRPG_API FRpgTurnInPlaceEligibilitySnapshot
+{
+	ERpgCharacterRotationMode RotationMode{};
+	ERpgLocomotionMovementState MovementState{};
+	float GroundSpeed = 0.0f;
+	bool bHasTurnDatabase = false;
+	bool bJumpPhaseGrounded = false;
+	bool bIsMovingOnGround = false;
+	bool bIsCrouching = false;
+	bool bIsAnyMontagePlaying = false;
+	bool bHasBlockingGameplayTag = false;
+	bool bHasGroundedMoveIntent = false;
+	bool bHasTrajectory = false;
+};
+
+/** Immutable proxy and callback observations consumed by one value-only lifecycle update. */
+struct SURVIVALRPG_API FRpgTurnInPlaceUpdateSnapshot
+{
+	ERpgCharacterRotationMode RotationMode{};
+	ERpgLocomotionMovementState MovementState{};
+	float ActorYawDelta = 0.0f;
+	bool bEligible = false;
+	bool bProxyHardReset = false;
+	bool bSupportChanged = false;
+	bool bHasBlockingGameplayTag = false;
+	bool bIsAnyMontagePlaying = false;
+	bool bIsCrouching = false;
+	bool bSelectionLatched = false;
+	bool bPlaybackObserved = false;
+	bool bPoseSelected = false;
+	bool bCompletionArmed = false;
+};
+
+/** Value result applied back to the AnimInstance facade after one deterministic transition. */
+struct SURVIVALRPG_API FRpgTurnInPlaceUpdateResult
+{
+	FRpgTurnInPlaceRuntimeState State;
+	EOffsetRootBoneMode OffsetRootRotationMode = EOffsetRootBoneMode::Interpolate;
+	bool bResetOffsetRootEveryFrame = false;
+	bool bClearSelection = false;
+	bool bUseSyntheticTrajectory = false;
+};
+
+/** Deterministic cosmetic turn-in-place policy adapted from GASP's ShouldTurnInPlace domain. */
+namespace RpgTurnInPlaceRuntime
+{
+	inline constexpr float IdleSpeedThreshold = 3.0f;
+	inline constexpr float CollectThreshold = 20.0f;
+	inline constexpr float ActivationThreshold = 30.0f;
+	inline constexpr float CancelThreshold = 10.0f;
+	inline constexpr float InactiveYawRateThreshold = 6.0f;
+	inline constexpr float StableYawRateThreshold = 60.0f;
+	inline constexpr float StabilityDuration = 0.08f;
+	inline constexpr float CollectionTimeout = 0.2f;
+	inline constexpr float RecoveryDuration = 0.15f;
+	inline constexpr float SelectionTimeout = 0.25f;
+	inline constexpr float ActiveTimeout = 1.75f;
+	inline constexpr float PlaybackWatchdogSafetyMargin = 0.1f;
+	inline constexpr float InactiveAccumulatorTimeout = 0.2f;
+	inline constexpr float FinishedTimeTolerance = 0.05f;
+	inline constexpr float LargePositionDelta = 200.0f;
+
+	/** Returns whether the replicated rotation policy permits controller-facing turn presentation. */
+	SURVIVALRPG_API bool SupportsTurnInPlace(ERpgCharacterRotationMode RotationMode);
+
+	/** Returns the signed authored turn angle nearest to the request, or zero below activation. */
+	SURVIVALRPG_API float QuantizeAngle(float SignedAngle);
+
+	/** Returns the synthetic facing horizon for an authored 45/90/135/180-degree turn. */
+	SURVIVALRPG_API float GetFacingDuration(float QuantizedAngle);
+
+	/** Calculates a wrap-safe signed actor-yaw delta in degrees. */
+	SURVIVALRPG_API float CalculateYawDelta(float PreviousActorYaw, float CurrentActorYaw);
+
+	/** Detects a transition across the Free versus controller-facing presentation boundary. */
+	SURVIVALRPG_API bool DidSupportChange(
+		bool bHasPreviousSnapshot,
+		ERpgCharacterRotationMode PreviousMode,
+		ERpgCharacterRotationMode CurrentMode);
+
+	/** Rebases actor yaw when the owner snapshot or facing policy changes. */
+	SURVIVALRPG_API float CalculateSnapshotYawDelta(
+		float PreviousActorYaw,
+		float CurrentActorYaw,
+		bool bHardReset,
+		bool bSupportChanged);
+
+	/** Builds a facing-only trajectory while preserving source sample times and positions exactly. */
+	SURVIVALRPG_API FTransformTrajectory MakeSyntheticTrajectory(
+		const FTransformTrajectory& SourceTrajectory,
+		float CurrentActorYaw,
+		float AccumulatedYaw,
+		float QuantizedAngle);
+
+	/** Resolves a bounded wall-clock watchdog for the selected non-looping animation. */
+	SURVIVALRPG_API float CalculatePlaybackWatchdogDuration(
+		float RemainingAnimationTime,
+		float PlayRate,
+		bool bLooping);
+
+	/** Evaluates the pointer-free stationary controller-facing eligibility contract. */
+	SURVIVALRPG_API bool IsEligible(const FRpgTurnInPlaceEligibilitySnapshot& Snapshot);
+
+	/** Clears the value lifecycle while leaving monotonic request serials intact. */
+	SURVIVALRPG_API FRpgTurnInPlaceUpdateResult Reset(
+		const FRpgTurnInPlaceRuntimeState& State,
+		bool bHardResetOffset);
+
+	/** Starts bounded interpolation recovery and releases any selected presentation asset. */
+	SURVIVALRPG_API FRpgTurnInPlaceUpdateResult BeginRecovery(
+		const FRpgTurnInPlaceRuntimeState& State,
+		bool bHardResetOffset);
+
+	/** Starts or retargets one authored request while skipping serial zero. */
+	SURVIVALRPG_API FRpgTurnInPlaceUpdateResult BeginRequest(
+		const FRpgTurnInPlaceRuntimeState& State,
+		float QuantizedAngle);
+
+	/** Advances accumulation, hysteresis, reset edges, timeouts, and recovery from value inputs only. */
+	SURVIVALRPG_API FRpgTurnInPlaceUpdateResult Update(
+		const FRpgTurnInPlaceRuntimeState& State,
+		const FRpgTurnInPlaceUpdateSnapshot& Snapshot,
+		float DeltaSeconds);
+
+	/** Consumes at most one ForceInterrupt for the active request serial. */
+	SURVIVALRPG_API bool ConsumeForceInterrupt(
+		bool bHasTurnDatabase,
+		FRpgTurnInPlaceRuntimeState& State);
+
+	/** Allows request retargeting only before the first exclusive search is dispatched. */
+	SURVIVALRPG_API bool CanRetarget(
+		const FRpgTurnInPlaceRuntimeState& State,
+		bool bSelectionLatched);
+
+	/** Resolves exclusive search, continuing-pose hold, or normal locomotion for the next update. */
+	SURVIVALRPG_API ERpgTurnInPlaceSearchMode ResolveSearchMode(
+		const FRpgTurnInPlaceRuntimeState& State,
+		bool bForceNewRequest,
+		bool bHasTurnDatabase,
+		bool bSelectionLatched,
+		bool bCompletionArmed);
+
+	/** Allows moving procedural nodes only outside collection and active turn playback. */
+	SURVIVALRPG_API bool AllowsMovingProceduralNodes(ERpgTurnInPlaceState State);
+}

--- a/Source/SurvivalRpgEditor/Private/Animation/RpgGaspPilotAssetTests.cpp
+++ b/Source/SurvivalRpgEditor/Private/Animation/RpgGaspPilotAssetTests.cpp
@@ -1378,6 +1378,68 @@ bool FRpgGaspPilotAssetContractTest::RunTest(const FString& Parameters)
 				FString(TEXT("None")));
 		}
 
+		const FEnumProperty* TurnInPlaceStateProperty =
+			FindFProperty<FEnumProperty>(PilotAnimDefaults->GetClass(), TEXT("TurnInPlaceState"));
+		if (TestNotNull(TEXT("The cosmetic turn-in-place state is reflected"), TurnInPlaceStateProperty))
+		{
+			TestEqual(
+				TEXT("TurnInPlaceState keeps the explicit reflected enum contract"),
+				TurnInPlaceStateProperty->GetEnum(),
+				StaticEnum<ERpgTurnInPlaceState>());
+			TestTrue(
+				TEXT("TurnInPlaceState remains transient Blueprint-readable facade state"),
+				TurnInPlaceStateProperty->HasAllPropertyFlags(
+					CPF_Transient | CPF_BlueprintVisible | CPF_BlueprintReadOnly));
+		}
+		FString TurnInPlaceStateText;
+		if (TestTrue(
+			TEXT("The turn-in-place state default is readable"),
+			ReadPropertyText(PilotAnimDefaults, TEXT("TurnInPlaceState"), TurnInPlaceStateText)))
+		{
+			TestEqual(
+				TEXT("The turn-in-place facade starts inactive"),
+				TurnInPlaceStateText,
+				FString(TEXT("Inactive")));
+		}
+
+		for (const FName PropertyName : {
+			FName(TEXT("TurnInPlaceQueryAngle")),
+			FName(TEXT("TurnInPlaceAccumulatedYaw")),
+			FName(TEXT("TurnInPlaceStateElapsed")) })
+		{
+			float Value = -1.0f;
+			if (TestTrue(
+				*FString::Printf(TEXT("%s remains readable on the flat turn facade"), *PropertyName.ToString()),
+				ReadFloatProperty(PilotAnimDefaults, PropertyName, Value)))
+			{
+				TestEqual(
+					*FString::Printf(TEXT("%s retains its zero default"), *PropertyName.ToString()),
+					Value,
+					0.0f);
+				const FFloatProperty* Property =
+					FindFProperty<FFloatProperty>(PilotAnimDefaults->GetClass(), PropertyName);
+				TestTrue(
+					*FString::Printf(TEXT("%s remains transient Blueprint-readable facade state"), *PropertyName.ToString()),
+					Property && Property->HasAllPropertyFlags(
+						CPF_Transient | CPF_BlueprintVisible | CPF_BlueprintReadOnly));
+			}
+		}
+
+		const FStructProperty* TurnInPlaceTrajectoryProperty =
+			FindFProperty<FStructProperty>(PilotAnimDefaults->GetClass(), TEXT("TurnInPlaceSyntheticTrajectory"));
+		if (TestNotNull(
+			TEXT("The turn-in-place synthetic trajectory remains reflected"),
+			TurnInPlaceTrajectoryProperty))
+		{
+			TestTrue(
+				TEXT("The synthetic trajectory keeps the engine transform-trajectory type"),
+				TurnInPlaceTrajectoryProperty->Struct == FTransformTrajectory::StaticStruct());
+			TestTrue(
+				TEXT("The synthetic trajectory remains transient Blueprint-readable facade state"),
+				TurnInPlaceTrajectoryProperty->HasAllPropertyFlags(
+					CPF_Transient | CPF_BlueprintVisible | CPF_BlueprintReadOnly));
+		}
+
 		float LandingStateElapsed = -1.0f;
 		if (TestTrue(
 			TEXT("The landing elapsed debug value is readable"),

--- a/Source/SurvivalRpgEditor/Private/Animation/RpgTurnInPlaceRuntimeTests.cpp
+++ b/Source/SurvivalRpgEditor/Private/Animation/RpgTurnInPlaceRuntimeTests.cpp
@@ -7,6 +7,7 @@
 #include "PoseSearch/PoseSearchDatabase.h"
 #include "Components/SkeletalMeshComponent.h"
 #include "SurvivalRpg/Animation/RpgAnimInstance.h"
+#include "SurvivalRpg/Animation/RpgTurnInPlaceRuntime.h"
 #include "UObject/UObjectGlobals.h"
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(
@@ -39,20 +40,41 @@ bool FRpgTurnInPlaceAngleAndTrajectoryTest::RunTest(const FString& Parameters)
 		TestTrue(
 			FString::Printf(TEXT("%.2f degrees quantizes to %.0f"), TestCase.Input, TestCase.Expected),
 			FMath::IsNearlyEqual(
-				URpgAnimInstance::QuantizeTurnInPlaceAngle(TestCase.Input),
+				RpgTurnInPlaceRuntime::QuantizeAngle(TestCase.Input),
 				TestCase.Expected));
 	}
 
 	TestTrue(
 		TEXT("Positive yaw wrap is two degrees"),
-		FMath::IsNearlyEqual(URpgAnimInstance::CalculateTurnInPlaceYawDelta(179.0f, -179.0f), 2.0f));
+		FMath::IsNearlyEqual(RpgTurnInPlaceRuntime::CalculateYawDelta(179.0f, -179.0f), 2.0f));
 	TestTrue(
 		TEXT("Negative yaw wrap is minus two degrees"),
-		FMath::IsNearlyEqual(URpgAnimInstance::CalculateTurnInPlaceYawDelta(-179.0f, 179.0f), -2.0f));
-	TestTrue(TEXT("45-degree duration is 0.45 seconds"), FMath::IsNearlyEqual(URpgAnimInstance::GetTurnInPlaceFacingDuration(45.0f), 0.45f));
-	TestTrue(TEXT("90-degree duration is 0.65 seconds"), FMath::IsNearlyEqual(URpgAnimInstance::GetTurnInPlaceFacingDuration(90.0f), 0.65f));
-	TestTrue(TEXT("135-degree duration is 0.85 seconds"), FMath::IsNearlyEqual(URpgAnimInstance::GetTurnInPlaceFacingDuration(135.0f), 0.85f));
-	TestTrue(TEXT("180-degree duration is 1.0 second"), FMath::IsNearlyEqual(URpgAnimInstance::GetTurnInPlaceFacingDuration(180.0f), 1.0f));
+		FMath::IsNearlyEqual(RpgTurnInPlaceRuntime::CalculateYawDelta(-179.0f, 179.0f), -2.0f));
+	TestTrue(TEXT("45-degree duration is 0.45 seconds"), FMath::IsNearlyEqual(RpgTurnInPlaceRuntime::GetFacingDuration(45.0f), 0.45f));
+	TestTrue(TEXT("90-degree duration is 0.65 seconds"), FMath::IsNearlyEqual(RpgTurnInPlaceRuntime::GetFacingDuration(90.0f), 0.65f));
+	TestTrue(TEXT("135-degree duration is 0.85 seconds"), FMath::IsNearlyEqual(RpgTurnInPlaceRuntime::GetFacingDuration(135.0f), 0.85f));
+	TestTrue(TEXT("180-degree duration is 1.0 second"), FMath::IsNearlyEqual(RpgTurnInPlaceRuntime::GetFacingDuration(180.0f), 1.0f));
+	TestTrue(
+		TEXT("Looping playback uses the fixed stuck-playback watchdog"),
+		FMath::IsNearlyEqual(
+			RpgTurnInPlaceRuntime::CalculatePlaybackWatchdogDuration(4.0f, 0.5f, true),
+			RpgTurnInPlaceRuntime::ActiveTimeout));
+	TestTrue(
+		TEXT("A slow non-looping clip converts its remaining duration to wall-clock time"),
+		RpgTurnInPlaceRuntime::CalculatePlaybackWatchdogDuration(2.0f, 0.5f, false) > 4.0f);
+
+	FRpgTurnInPlaceRuntimeState WrappedRequestState;
+	WrappedRequestState.AccumulatedYaw = 90.0f;
+	WrappedRequestState.RequestSerial = MAX_uint32;
+	const FRpgTurnInPlaceUpdateResult WrappedRequest =
+		RpgTurnInPlaceRuntime::BeginRequest(WrappedRequestState, 90.0f);
+	TestEqual(TEXT("Turn request serial wrap skips reserved zero"), WrappedRequest.State.RequestSerial, 1u);
+	TestTrue(TEXT("A new request clears the previous selection bridge"), WrappedRequest.bClearSelection);
+	TestTrue(
+		TEXT("A new request restores the bounded selection watchdog"),
+		FMath::IsNearlyEqual(
+			WrappedRequest.State.PlaybackWatchdogDuration,
+			RpgTurnInPlaceRuntime::ActiveTimeout));
 
 	FTransformTrajectory SourceTrajectory;
 	const FVector CurrentPosition(100.0f, 200.0f, 25.0f);
@@ -65,7 +87,7 @@ bool FRpgTurnInPlaceAngleAndTrajectoryTest::RunTest(const FString& Parameters)
 		Sample.Facing = FRotator(0.0f, 100.0f, 0.0f).Quaternion();
 	}
 
-	const FTransformTrajectory SyntheticTrajectory = URpgAnimInstance::MakeTurnInPlaceSyntheticTrajectory(
+	const FTransformTrajectory SyntheticTrajectory = RpgTurnInPlaceRuntime::MakeSyntheticTrajectory(
 		SourceTrajectory,
 		100.0f,
 		90.0f,
@@ -90,7 +112,7 @@ bool FRpgTurnInPlaceAngleAndTrajectoryTest::RunTest(const FString& Parameters)
 	}
 	TestTrue(TEXT("Synthetic trajectory reaches the authored target facing"), FMath::IsNearlyEqual(PreviousProgress, 90.0f));
 
-	const FTransformTrajectory NegativeSyntheticTrajectory = URpgAnimInstance::MakeTurnInPlaceSyntheticTrajectory(
+	const FTransformTrajectory NegativeSyntheticTrajectory = RpgTurnInPlaceRuntime::MakeSyntheticTrajectory(
 		SourceTrajectory,
 		-90.0f,
 		-90.0f,
@@ -111,7 +133,7 @@ bool FRpgTurnInPlaceAngleAndTrajectoryTest::RunTest(const FString& Parameters)
 		TEXT("Negative synthetic trajectory reaches the authored target facing"),
 		FMath::IsNearlyEqual(PreviousNegativeProgress, -90.0f));
 
-	const FTransformTrajectory DirectHalfTurnTrajectory = URpgAnimInstance::MakeTurnInPlaceSyntheticTrajectory(
+	const FTransformTrajectory DirectHalfTurnTrajectory = RpgTurnInPlaceRuntime::MakeSyntheticTrajectory(
 		SourceTrajectory,
 		180.0f,
 		180.0f,
@@ -141,31 +163,31 @@ bool FRpgTurnInPlaceStateMachineTest::RunTest(const FString& Parameters)
 {
 	TestFalse(
 		TEXT("The first owner snapshot cannot report a turn-in-place policy transition"),
-		URpgAnimInstance::DidTurnInPlaceSupportChange(
+		RpgTurnInPlaceRuntime::DidSupportChange(
 			false,
 			ERpgCharacterRotationMode::Free,
 			ERpgCharacterRotationMode::CombatStrafe));
 	TestTrue(
 		TEXT("Free to CombatStrafe crosses the turn-in-place policy boundary"),
-		URpgAnimInstance::DidTurnInPlaceSupportChange(
+		RpgTurnInPlaceRuntime::DidSupportChange(
 			true,
 			ERpgCharacterRotationMode::Free,
 			ERpgCharacterRotationMode::CombatStrafe));
 	TestTrue(
 		TEXT("Aim to Free crosses the turn-in-place policy boundary"),
-		URpgAnimInstance::DidTurnInPlaceSupportChange(
+		RpgTurnInPlaceRuntime::DidSupportChange(
 			true,
 			ERpgCharacterRotationMode::Aim,
 			ERpgCharacterRotationMode::Free));
 	TestFalse(
 		TEXT("CombatStrafe to Aim preserves the shared controller-facing policy"),
-		URpgAnimInstance::DidTurnInPlaceSupportChange(
+		RpgTurnInPlaceRuntime::DidSupportChange(
 			true,
 			ERpgCharacterRotationMode::CombatStrafe,
 			ERpgCharacterRotationMode::Aim));
 	TestTrue(
 		TEXT("A policy-boundary snapshot discards even a 180-degree actor-yaw jump"),
-		FMath::IsNearlyZero(URpgAnimInstance::CalculateTurnInPlaceSnapshotYawDelta(
+		FMath::IsNearlyZero(RpgTurnInPlaceRuntime::CalculateSnapshotYawDelta(
 			0.0f,
 			180.0f,
 			false,
@@ -173,7 +195,7 @@ bool FRpgTurnInPlaceStateMachineTest::RunTest(const FString& Parameters)
 	TestTrue(
 		TEXT("An established controller-facing snapshot retains normal authored turn intent"),
 		FMath::IsNearlyEqual(
-			URpgAnimInstance::CalculateTurnInPlaceSnapshotYawDelta(0.0f, 90.0f, false, false),
+			RpgTurnInPlaceRuntime::CalculateSnapshotYawDelta(0.0f, 90.0f, false, false),
 			90.0f));
 
 	USkeletalMeshComponent* AnimInstanceOuter = NewObject<USkeletalMeshComponent>();
@@ -205,14 +227,44 @@ bool FRpgTurnInPlaceStateMachineTest::RunTest(const FString& Parameters)
 	CurrentTrajectorySample.TimeInSeconds = 0.0f;
 	CurrentTrajectorySample.Position = FVector::ZeroVector;
 	CurrentTrajectorySample.Facing = FQuat::Identity;
+	const auto IsTurnInPlaceEligible = [&]()
+	{
+		FRpgTurnInPlaceEligibilitySnapshot Eligibility;
+		Eligibility.RotationMode = Proxy.RotationMode;
+		Eligibility.MovementState = Proxy.MovementState;
+		Eligibility.GroundSpeed = Proxy.GroundSpeed;
+		Eligibility.bHasTurnDatabase = AnimInstance->TurnInPlaceMotionMatchingDatabase != nullptr;
+		Eligibility.bJumpPhaseGrounded = AnimInstance->JumpPhase == ERpgJumpPhase::Grounded;
+		Eligibility.bIsMovingOnGround = Proxy.bIsMovingOnGround;
+		Eligibility.bIsCrouching = Proxy.bIsCrouching;
+		Eligibility.bIsAnyMontagePlaying = Proxy.bIsAnyMontagePlaying;
+		Eligibility.bHasBlockingGameplayTag = Proxy.bHasTurnInPlaceBlockingGameplayTag;
+		Eligibility.bHasGroundedMoveIntent = Proxy.bHasGroundedMoveIntent;
+		Eligibility.bHasTrajectory = !Proxy.TransformTrajectory.Samples.IsEmpty();
+		return RpgTurnInPlaceRuntime::IsEligible(Eligibility);
+	};
+	const auto ResolveTurnInPlaceSearchMode = [&](bool bForceNewRequest)
+	{
+		return RpgTurnInPlaceRuntime::ResolveSearchMode(
+			AnimInstance->CaptureTurnInPlaceRuntimeState(),
+			bForceNewRequest,
+			AnimInstance->TurnInPlaceMotionMatchingDatabase != nullptr,
+			AnimInstance->bTurnInPlaceSelectionLatched,
+			AnimInstance->bTurnInPlaceCompletionArmed);
+	};
 
 	Proxy.RotationMode = ERpgCharacterRotationMode::Free;
-	TestFalse(TEXT("Free rotation mode disables turn-in-place eligibility"), AnimInstance->IsTurnInPlaceEligible(Proxy));
+	TestFalse(TEXT("Free rotation mode disables turn-in-place eligibility"), IsTurnInPlaceEligible());
 	Proxy.RotationMode = ERpgCharacterRotationMode::CombatStrafe;
-	TestTrue(TEXT("Combat strafe rotation mode allows turn-in-place eligibility"), AnimInstance->IsTurnInPlaceEligible(Proxy));
+	TestTrue(TEXT("Combat strafe rotation mode allows turn-in-place eligibility"), IsTurnInPlaceEligible());
 	Proxy.RotationMode = ERpgCharacterRotationMode::Aim;
-	TestTrue(TEXT("Aim rotation mode allows turn-in-place eligibility"), AnimInstance->IsTurnInPlaceEligible(Proxy));
+	TestTrue(TEXT("Aim rotation mode allows turn-in-place eligibility"), IsTurnInPlaceEligible());
 	Proxy.RotationMode = ERpgCharacterRotationMode::CombatStrafe;
+	Proxy.GroundSpeed = RpgTurnInPlaceRuntime::IdleSpeedThreshold;
+	TestTrue(TEXT("The project stationary gate includes exactly three centimeters per second"), IsTurnInPlaceEligible());
+	Proxy.GroundSpeed = RpgTurnInPlaceRuntime::IdleSpeedThreshold + KINDA_SMALL_NUMBER;
+	TestFalse(TEXT("Turn-in-place eligibility rejects speeds just above three centimeters per second"), IsTurnInPlaceEligible());
+	Proxy.GroundSpeed = 0.0f;
 
 	AnimInstance->ResetTurnInPlaceRuntime(false);
 	Proxy.ActorYawDelta = 20.0f;
@@ -257,8 +309,8 @@ bool FRpgTurnInPlaceStateMachineTest::RunTest(const FString& Parameters)
 	TestTrue(TEXT("A request issues its TIR ForceInterrupt exactly once"), bForceSelectedRequest);
 	TestTrue(
 		TEXT("The one forced update searches the exclusive TIR database"),
-		AnimInstance->ResolveTurnInPlaceSearchMode(bForceSelectedRequest) ==
-			URpgAnimInstance::ETurnInPlaceSearchMode::SearchRequestedTurn);
+		ResolveTurnInPlaceSearchMode(bForceSelectedRequest) ==
+			ERpgTurnInPlaceSearchMode::SearchRequestedTurn);
 	TestFalse(
 		TEXT("The same request cannot issue a second TIR ForceInterrupt"),
 		AnimInstance->ConsumeTurnInPlaceForceInterruptRequest());
@@ -273,12 +325,14 @@ bool FRpgTurnInPlaceStateMachineTest::RunTest(const FString& Parameters)
 		FMath::IsNearlyEqual(AnimInstance->TurnInPlaceQueryAngle, 90.0f));
 	TestFalse(
 		TEXT("The dispatched request is no longer eligible for pre-search retargeting"),
-		AnimInstance->CanRetargetTurnInPlaceRequest());
+		RpgTurnInPlaceRuntime::CanRetarget(
+			AnimInstance->CaptureTurnInPlaceRuntimeState(),
+			AnimInstance->bTurnInPlaceSelectionLatched));
 	Proxy.ActorYawDelta = 0.0f;
 	TestTrue(
 		TEXT("An unsuccessful one-shot request does not reopen the TIR database"),
-		AnimInstance->ResolveTurnInPlaceSearchMode(false) ==
-			URpgAnimInstance::ETurnInPlaceSearchMode::NormalLocomotion);
+		ResolveTurnInPlaceSearchMode(false) ==
+			ERpgTurnInPlaceSearchMode::NormalLocomotion);
 	TestFalse(
 		TEXT("A stale request serial cannot latch the current SearchResult"),
 		AnimInstance->TryLatchTurnInPlaceSelection(
@@ -313,8 +367,8 @@ bool FRpgTurnInPlaceStateMachineTest::RunTest(const FString& Parameters)
 	TestTrue(TEXT("The previous completed SearchResult remains latched through a transient mismatch"), AnimInstance->bTurnInPlacePoseSelected);
 	TestTrue(
 		TEXT("A latched selection closes full TIR search and keeps only its Continuing Pose"),
-		AnimInstance->ResolveTurnInPlaceSearchMode(false) ==
-			URpgAnimInstance::ETurnInPlaceSearchMode::ContinueSelectedTurn);
+		ResolveTurnInPlaceSearchMode(false) ==
+			ERpgTurnInPlaceSearchMode::ContinueSelectedTurn);
 	AnimInstance->UpdateTurnInPlaceLatchedPlayback(SelectedTurn, 0.25f, 1.25f, 1.0f, 0.01f);
 	TestTrue(TEXT("The Blend Stack eventually observes the exact latched asset"), AnimInstance->bTurnInPlacePlaybackObserved);
 	AnimInstance->UpdateTurnInPlaceRuntime(0.01f, Proxy);
@@ -330,8 +384,8 @@ bool FRpgTurnInPlaceStateMachineTest::RunTest(const FString& Parameters)
 	TestFalse(TEXT("The full asset remains unfinished when the database's default indexed range has ended"), AnimInstance->bTurnInPlaceCompletionArmed);
 	TestTrue(
 		TEXT("An invalid SearchResult at the indexed-range end cannot reopen the TIR database"),
-		AnimInstance->ResolveTurnInPlaceSearchMode(false) ==
-			URpgAnimInstance::ETurnInPlaceSearchMode::ContinueSelectedTurn);
+		ResolveTurnInPlaceSearchMode(false) ==
+			ERpgTurnInPlaceSearchMode::ContinueSelectedTurn);
 	AnimInstance->UpdateTurnInPlaceRuntime(0.01f, Proxy);
 	TestEqual(TEXT("Indexed-range exhaustion does not end the latched Blend Stack playback"), AnimInstance->TurnInPlaceState, ERpgTurnInPlaceState::Active);
 	TestFalse(TEXT("Indexed-range exhaustion does not hard-reset Offset Root"), AnimInstance->bResetOffsetRootEveryFrame);
@@ -340,8 +394,8 @@ bool FRpgTurnInPlaceStateMachineTest::RunTest(const FString& Parameters)
 	TestTrue(TEXT("Natural full-asset completion is armed one update ahead"), AnimInstance->bTurnInPlaceCompletionArmed);
 	TestTrue(
 		TEXT("Natural completion selects normal locomotion for the upcoming pre-update search"),
-		AnimInstance->ResolveTurnInPlaceSearchMode(false) ==
-			URpgAnimInstance::ETurnInPlaceSearchMode::NormalLocomotion);
+		ResolveTurnInPlaceSearchMode(false) ==
+			ERpgTurnInPlaceSearchMode::NormalLocomotion);
 	AnimInstance->UpdateTurnInPlaceRuntime(0.01f, Proxy);
 	TestEqual(TEXT("Natural completion enters recovery"), AnimInstance->TurnInPlaceState, ERpgTurnInPlaceState::Recovering);
 	TestFalse(TEXT("Natural completion never hard-resets Offset Root"), AnimInstance->bResetOffsetRootEveryFrame);
@@ -396,9 +450,11 @@ bool FRpgTurnInPlaceStateMachineTest::RunTest(const FString& Parameters)
 	TestEqual(TEXT("Movement before TIR selection exits immediately to recovery"), AnimInstance->TurnInPlaceState, ERpgTurnInPlaceState::Recovering);
 	TestTrue(
 		TEXT("Preselection movement exit chooses the normal gait database policy"),
-		AnimInstance->ResolveTurnInPlaceSearchMode(false) ==
-			URpgAnimInstance::ETurnInPlaceSearchMode::NormalLocomotion);
-	TestTrue(TEXT("Moving procedural nodes are allowed during movement recovery"), AnimInstance->AllowsMovingProceduralNodes());
+		ResolveTurnInPlaceSearchMode(false) ==
+			ERpgTurnInPlaceSearchMode::NormalLocomotion);
+	TestTrue(
+		TEXT("Moving procedural nodes are allowed during movement recovery"),
+		RpgTurnInPlaceRuntime::AllowsMovingProceduralNodes(AnimInstance->TurnInPlaceState));
 	TestFalse(TEXT("Preselection movement exit does not hard-reset Offset Root"), AnimInstance->bResetOffsetRootEveryFrame);
 
 	AnimInstance->ResetTurnInPlaceRuntime(false);
@@ -418,9 +474,11 @@ bool FRpgTurnInPlaceStateMachineTest::RunTest(const FString& Parameters)
 	TestEqual(TEXT("Mid-clip movement exits immediately to recovery"), AnimInstance->TurnInPlaceState, ERpgTurnInPlaceState::Recovering);
 	TestTrue(
 		TEXT("Mid-clip movement exit releases the selection lock to the gait database"),
-		AnimInstance->ResolveTurnInPlaceSearchMode(false) ==
-			URpgAnimInstance::ETurnInPlaceSearchMode::NormalLocomotion);
-	TestTrue(TEXT("Mid-clip movement recovery keeps moving procedural nodes enabled"), AnimInstance->AllowsMovingProceduralNodes());
+		ResolveTurnInPlaceSearchMode(false) ==
+			ERpgTurnInPlaceSearchMode::NormalLocomotion);
+	TestTrue(
+		TEXT("Mid-clip movement recovery keeps moving procedural nodes enabled"),
+		RpgTurnInPlaceRuntime::AllowsMovingProceduralNodes(AnimInstance->TurnInPlaceState));
 	TestFalse(TEXT("Mid-clip movement exit does not hard-reset Offset Root"), AnimInstance->bResetOffsetRootEveryFrame);
 
 	Proxy.bHasGroundedMoveIntent = false;


### PR DESCRIPTION
## Summary

- extract pointer-free turn-in-place policy and lifecycle state into `RpgTurnInPlaceRuntime`
- keep `URpgAnimInstance` as the reflected, GC-safe and AnimNode-facing bridge
- preserve the existing project-specific GASP behavior for eligibility, yaw accumulation, hysteresis, quantization, reset edges, request/search serials, watchdogs and synthetic facing
- add direct value-runtime coverage, reflected-property compatibility checks and updated ownership documentation

## Why

This is the next behavior-neutral part of #81 slice 3. Motion Matching selection moved in #92; this follow-up removes turn-in-place policy/math from the AnimInstance monolith while keeping the serialized and Blueprint-facing contract stable.

## Scope

- no reflected property names, types or defaults changed
- no callback-order, database binding, asset, PawnData, Experience, replication or persistence changes
- no new UObject types or designer-authored assets
- intentional deviations from stock UE 5.8 GASP remain documented and tested, including the inclusive 3 cm/s stationary gate and the project-specific synthetic-facing path
- Jump/Landing runtime extraction and database/tuning externalization remain separate follow-ups

## Verification

- UE 5.8 `SurvivalRpgEditor Win64 Development` build succeeded
- `SurvivalRpg.Animation.TurnInPlace`: 2/2 passed
- `SurvivalRpg.Animation`: 19/19 passed
- staged diff check clean
- independent C++/thread-safety, GASP-parity and scope/documentation reviews clean

A real two-client/late-join/default-slot smoke was not run for this value-only slice; that remains part of the broader migration/cutover gate.

Part of #81.
