### PR TITLE
Fix GASP simulated-proxy trajectory and correction history

### DIFF
--- a/Plugins/RpgGaspLocomotion/Docs/README.md
+++ b/Plugins/RpgGaspLocomotion/Docs/README.md
@@ -5,10 +5,11 @@ This content-only plugin owns the curated Game Animation Sample Project (GASP) l
 The behavior-preserving source-to-project responsibility map and the staged issue #81 extraction
 order are recorded in [RuntimeOwnershipMap.md](RuntimeOwnershipMap.md).
 
-Issue #81's real listen-server/two-client acceptance procedure is recorded in
+Issues #81 and #97's real listen-server acceptance procedure is recorded in
 [the GASP real-network smoke runbook](../../../docs/gasp-network-smoke.md). It uses an actual PIE
-network session; rendered pose-selection, warping, Foot Placement, and correction quality remain a
-separate visual inspection boundary.
+network session with one initial client plus moving and stationary late joins; rendered
+pose-selection, warping, Foot Placement, and correction quality remain a separate visual
+inspection boundary.
 
 ## Curated slice
 

--- a/Plugins/RpgGaspLocomotion/Docs/RuntimeOwnershipMap.md
+++ b/Plugins/RpgGaspLocomotion/Docs/RuntimeOwnershipMap.md
@@ -24,6 +24,8 @@ the sample project a runtime dependency.
 | GASP CMC source responsibility | Current SurvivalRpg owner | Target owner | Intentional adaptation |
 | --- | --- | --- | --- |
 | `Update_PropertiesFromCharacter`, `Update_EssentialValues` | `InitializeWithAbilitySystem` for the ASC/tag map; `FRpgAnimInstanceProxy::PreUpdate` for the value snapshot | Existing ASC lifecycle plus proxy snapshot boundary | ASC delegates are initialized on the game thread. `PreUpdate` copies mirrored tag booleans and reads CharacterMovement/world state; no sample character hierarchy is imported. |
+| Character acceleration replication and analog trajectory intent | `ARpgCharacter::ShouldReplicateAcceleration`, UE 5.8 `FRepMovement`, and base `UCharacterMovementComponent::UpdateProxyAcceleration` | The same character-scoped engine path | The project opts only RPG characters into UE 5.8's native acceleration payload. Simulated proxies reconstruct both acceleration and `AnalogInputModifier`; there is no parallel custom acceleration property and no project-wide CVar override. |
+| Network correction and semantic-teleport presentation resets | `URpgCharacterMovementComponent` local discontinuity serial, `ARpgCharacter` teleport epoch, and proxy `PreUpdate` | Existing Character/CharacterMovement authority plus one local presentation edge | Autonomous corrections compare the server location with the saved client location at the same acknowledged timestamp. Ordinary simulated-proxy smoothing never resets history; only semantic teleports or corrections beyond UE's no-smoothing range do. The AnimInstance no longer treats transient `bJustTeleported` as a durable network event. |
 | `Update_Trajectory` | Proxy `PreUpdate` orchestrates `PoseSearchGenerateTransformTrajectory`; `RpgPoseSearchTrajectory` owns its sampling constants and validation/correction helpers | Same split: proxy owns generation and snapshot lifetime; focused native helper owns the sampling/correction mechanism | Controller-yaw extrapolation is disabled for the controller-facing project character; raw history stays separate from worker-facing corrected output. |
 | `HandleTransformTrajectoryWorldCollisions` | `RpgPoseSearchTrajectory::ResolveWorldCollision` | Focused game-thread trajectory helper | Uses bounded sphere sweeps, CharacterMovement walkability, explicit validity, floor projection, and a pointer-free landing prediction. It never changes movement or touchdown authority. |
 | `Update_MotionMatching` | `URpgAnimInstance::UpdateGaspMotionMatching` bridges the AnimNode callback and the immutable database-role cache; `RpgMotionMatchingRuntime` owns pointer-free role selection; `DA_RpgGaspPresentationProfile` owns the exact 18-database hard-reference set | Same callback/runtime/profile split | Profile Role tags are read once while the AnimInstance builds the bidirectional cache on the game thread; whole-legacy mode derives the same cache from reflected slot roles. Worker callbacks use only role values and cached pointers. The project excludes GASP BranchIn, experimental state-machine, Foley, and broad Chooser dependencies. |
@@ -40,6 +42,15 @@ the sample project a runtime dependency.
 | Slide and other optional locomotion families | Not adopted; no runtime owner | No #81 owner; Adopt/Defer/Reject decision belongs to audit issue #74 | #81 does not pre-approve content families or grow the AnimInstance role architecture. |
 | `Debug_ExperimentalStateMachine`, full GASP Mover/Traversal stack, sample camera, Foley | Not adopted; no runtime owner | No runtime owner without a dedicated isolated feature evaluation | These sample subsystems are outside the CMC pilot contract and are never incidental dependencies. Curated traversal assets may only enter later through project-owned CMC/GAS/Motion-Warping seams. |
 | Sample character/mode composition | Existing `BP_Rpg_Character_GASP`, `DA_PawnData_GASP`, and pilot Experience | Existing Lyra-derived pilot composition remains unchanged | Only the GASP sample character hierarchy is not adopted. #81 does not change PawnData, Experience selection, or the default pawn cutover. |
+
+## Network transform-space contract
+
+| Data or consumer | Authoritative or presentation frame | Contract |
+| --- | --- | --- |
+| Velocity, acceleration, `AnalogInputModifier`, MovementMode, floor/base state, and correction distance | CharacterMovement and the collision capsule | These values remain gameplay/network truth. Owner corrections compare the server position with the saved client move at the same acknowledged timestamp; smoothed mesh state never feeds movement authority. |
+| Local owner, standalone, and ordinary authority presentation | Actor/capsule transform | Their presentation snapshot uses the actor transform because it is not a network-smoothed remote view. |
+| SimulatedProxy and listen-server remote AutonomousProxy presentation | Skeletal-mesh component transform with the authored base translation and rotation offsets removed | One reconstructed presentation frame supplies snapshot location/yaw, local velocity/acceleration, Aim and locomotion angles, Pose Search trajectory history, and turn-in-place facing. This prevents capsule correction and mesh smoothing from being applied as two independent visual turns. |
+| Foot Placement | Smoothed mesh component plus game-thread floor/base traces | Foot locks and trace snapshots stay in the same visual frame as the rendered mesh. A shared semantic-discontinuity pulse resets their history; ordinary network smoothing does not. |
 
 ## Slice 1 boundary and verification contract
 
@@ -223,24 +234,27 @@ families, Sprint authority, combat polish, and default PawnData cutover are sepa
   continue to protect defaults, boundary behavior, serialization compatibility, and the unchanged
   authority/safety mechanisms.
 
-## Issue #81 real-network acceptance boundary
+## Issues #81 and #97 real-network acceptance boundary
 
 - **Authority and lifecycle:** the editor-only acceptance test drives the existing Experience,
-  PawnData, CharacterMovement, ASC, and AnimInstance paths. It adds no gameplay authority,
-  replicated production state, persistence, or alternate runtime owner.
-- **Topology:** the CQTest starts a listen host and one external client, then late-joins a second
-  external client while the original subject is moving. That subject is observed as Authority,
-  AutonomousProxy, and SimulatedProxy.
+  PawnData, CharacterMovement, ASC, and AnimInstance paths. Issue #97 keeps gameplay authority in
+  CharacterMovement, replaces the project-specific acceleration payload with UE 5.8
+  `FRepMovement`, and adds only a semantic teleport epoch plus local presentation-reset serial.
+- **Topology:** the CQTest starts a listen host and one external client, late-joins a second client
+  while the original subject is moving, then late-joins a third client while that subject is
+  stationary. The subject is observed as Authority, AutonomousProxy, and SimulatedProxy.
 - **Network profile:** the test uses `PktLag=60` and `PktLagVariance=10`; configured packet loss,
   reordering, and duplication remain zero.
 - **Stable test:**
   `SurvivalRpg.Network.GaspPilotPIE.ReplicationLateJoinCorrectionAndDefaultSlotMontage` protects
-  replicated acceleration, late-join reconstruction, start/stop/reversal, a 90-degree facing
-  change activating and completing the TIR lifecycle, stance, jump and
-  landing state, grounded Foot Placement snapshots, owner correction, ASC `DefaultSlot` montage
-  plumbing, authoritative root motion, and stable post-montage convergence.
-- **Runtime/content delta:** zero production runtime classes and zero content assets. The test and
-  its replicated movement-base fixture are confined to `SurvivalRpgEditor` and reuse the existing
+  native acceleration and analog-input reconstruction at 25/50/100%, moving/stationary late join,
+  start/stop/reversal, a 90-degree facing change activating and completing the TIR lifecycle,
+  stance, jump and landing state, grounded Foot Placement snapshots, role-correct owner correction
+  and semantic-teleport resets, ASC `DefaultSlot` montage plumbing, authoritative root motion, and
+  stable post-montage convergence.
+- **Runtime/content delta:** zero new production runtime classes and zero content assets. Existing
+  Character, CharacterMovement, and AnimInstance seams own the #97 behavior. The test and its
+  replicated movement-base fixture remain confined to `SurvivalRpgEditor` and reuse the existing
   CQTest PIE seam.
 - **Evidence boundary:** reflected state and authoritative movement are automated. Rendered pose
   selection, warping, IK quality, gameplay-notify behavior, packaged multi-process networking,

--- a/Source/SurvivalRpg/Animation/RpgAnimInstance.cpp
+++ b/Source/SurvivalRpg/Animation/RpgAnimInstance.cpp
@@ -34,6 +34,29 @@ void ResetPoseSearchTrajectoryState(FRpgAnimInstanceProxy& Proxy)
 	Proxy.DesiredControllerYawLastUpdate = 0.0f;
 }
 
+FTransform GetPresentationActorTransform(const ARpgCharacter& Character)
+{
+	const bool bUsesNetworkSmoothedPresentation =
+		Character.GetLocalRole() == ROLE_SimulatedProxy ||
+		Character.GetRemoteRole() == ROLE_AutonomousProxy;
+	const USkeletalMeshComponent* Mesh = Character.GetMesh();
+	if (!bUsesNetworkSmoothedPresentation || !IsValid(Mesh))
+	{
+		return Character.GetActorTransform();
+	}
+
+	// Network smoothing lives on the mesh relative to the capsule. Remove only the
+	// authored mesh offset so trajectory, local motion, and turn-in-place all observe
+	// the same smoothed presentation frame without feeding skeletal pose into the result.
+	FQuat PresentationRotation =
+		Mesh->GetComponentQuat() * Character.GetBaseRotationOffset().Inverse();
+	PresentationRotation.Normalize();
+	const FVector PresentationLocation =
+		Mesh->GetComponentLocation() -
+		PresentationRotation.RotateVector(Character.GetBaseTranslationOffset());
+	return FTransform(PresentationRotation, PresentationLocation);
+}
+
 struct FRpgFootPlacementTraceResult
 {
 	FVector GroundPointWorld = FVector::ZeroVector;
@@ -418,10 +441,6 @@ void UpdateFootPlacementSnapshot(
 			FVector::UpVector);
 	}
 
-	const bool bLargeComponentJump =
-		bHadPreviousComponentTransform &&
-		Snapshot.ComponentDeltaWorld.SizeSquared() >
-			FMath::Square(RpgTurnInPlaceRuntime::LargePositionDelta);
 	const bool bBaseIdentityChanged =
 		bHadPreviousComponentTransform &&
 		PreviousMovementBaseId != MovementBaseId;
@@ -435,7 +454,6 @@ void UpdateFootPlacementSnapshot(
 		bSourceEligible && !Proxy.bPreviousFootPlacementSourceEligible;
 	Snapshot.bReset =
 		Proxy.bTurnInPlaceHardReset ||
-		bLargeComponentJump ||
 		bBaseIdentityChanged ||
 		bSourceBecameEligible ||
 		!bSourceEligible;
@@ -577,6 +595,7 @@ void FRpgAnimInstanceProxy::PreUpdate(UAnimInstance* InAnimInstance, float Delta
 		bWasAirborneForLanding = false;
 		bTurnInPlaceHardReset = true;
 		PreviousOwnerUniqueId = 0;
+		PreviousAnimationDiscontinuitySerial = 0;
 		bHasPreviousOwnerSnapshot = false;
 		return;
 	}
@@ -593,13 +612,15 @@ void FRpgAnimInstanceProxy::PreUpdate(UAnimInstance* InAnimInstance, float Delta
 		bWasAirborneForLanding = false;
 		bTurnInPlaceHardReset = true;
 		PreviousOwnerUniqueId = 0;
+		PreviousAnimationDiscontinuitySerial = 0;
 		bHasPreviousOwnerSnapshot = false;
 		return;
 	}
 
-	const FQuat ActorRotation = Character->GetActorQuat();
-	ActorYaw = Character->GetActorRotation().Yaw;
-	ActorLocation = Character->GetActorLocation();
+	const FTransform PresentationActorTransform = GetPresentationActorTransform(*Character);
+	const FQuat ActorRotation = PresentationActorTransform.GetRotation();
+	ActorYaw = ActorRotation.Rotator().Yaw;
+	ActorLocation = PresentationActorTransform.GetLocation();
 	const uint32 OwnerUniqueId = Character->GetUniqueID();
 	const uint8 LocalRole = static_cast<uint8>(Character->GetLocalRole());
 	const uint8 RemoteRole = static_cast<uint8>(Character->GetRemoteRole());
@@ -612,17 +633,17 @@ void FRpgAnimInstanceProxy::PreUpdate(UAnimInstance* InAnimInstance, float Delta
 		bHasPreviousOwnerSnapshot,
 		PreviousRotationMode,
 		RotationMode);
-	const bool bLargePositionJump =
+	const uint32 AnimationDiscontinuitySerial =
+		MovementComponent->GetAnimationDiscontinuitySerial();
+	const bool bAnimationDiscontinuity =
 		bHasPreviousOwnerSnapshot &&
-		FVector::DistSquared(PreviousActorLocation, ActorLocation) >
-			FMath::Square(RpgTurnInPlaceRuntime::LargePositionDelta);
-	bTurnInPlaceHardReset = bOwnerOrRoleChanged || bLargePositionJump || MovementComponent->bJustTeleported;
+		AnimationDiscontinuitySerial != PreviousAnimationDiscontinuitySerial;
+	bTurnInPlaceHardReset =
+		bOwnerOrRoleChanged || bAnimationDiscontinuity;
 	if (bTurnInPlaceHardReset)
 	{
-		RawTransformTrajectory.Samples.Reset();
-		TransformTrajectory.Samples.Reset();
-		TrajectoryLandingPrediction = FRpgTrajectoryLandingPrediction();
-		DesiredControllerYawLastUpdate = 0.0f;
+		ResetPoseSearchTrajectoryState(*this);
+		++AnimationHistoryResetCount;
 	}
 	ActorYawDelta = RpgTurnInPlaceRuntime::CalculateSnapshotYawDelta(
 		PreviousActorYaw,
@@ -635,6 +656,7 @@ void FRpgAnimInstanceProxy::PreUpdate(UAnimInstance* InAnimInstance, float Delta
 	PreviousRemoteRole = RemoteRole;
 	PreviousActorYaw = ActorYaw;
 	PreviousActorLocation = ActorLocation;
+	PreviousAnimationDiscontinuitySerial = AnimationDiscontinuitySerial;
 	PreviousRotationMode = RotationMode;
 	bHasPreviousOwnerSnapshot = true;
 
@@ -722,7 +744,8 @@ void FRpgAnimInstanceProxy::PreUpdate(UAnimInstance* InAnimInstance, float Delta
 		*MovementComponent,
 		DeltaSeconds);
 
-	const FRotator AimDelta = (Character->GetBaseAimRotation() - Character->GetActorRotation()).GetNormalized();
+	const FRotator AimDelta =
+		(Character->GetBaseAimRotation() - ActorRotation.Rotator()).GetNormalized();
 	AimYaw = AimDelta.Yaw;
 	AimPitch = AimDelta.Pitch;
 	LocomotionAngle = bHasVelocity
@@ -2275,6 +2298,7 @@ void URpgAnimInstance::NativeThreadSafeUpdateAnimation(float DeltaSeconds)
 	LocalVelocity = Proxy.LocalVelocity;
 	WorldAcceleration = Proxy.WorldAcceleration;
 	LocalAcceleration = Proxy.LocalAcceleration;
+	AnimationHistoryResetCount = Proxy.AnimationHistoryResetCount;
 	LocomotionGroundSpeed = Proxy.GroundSpeed;
 	VerticalVelocity = Proxy.VerticalVelocity;
 	GroundDistance = Proxy.GroundDistance;
@@ -2488,6 +2512,15 @@ void URpgAnimInstance::UpdateGaspMotionMatching(
 				? EPoseSearchInterruptMode::InterruptOnDatabaseChange
 				: EPoseSearchInterruptMode::DoNotInterrupt;
 		}
+	}
+
+	if (Proxy.bTurnInPlaceHardReset)
+	{
+		// A discontinuity invalidates the current Continuing Pose even when the resolved
+		// database set happens to remain unchanged across the correction or teleport.
+		InterruptMode = EPoseSearchInterruptMode::ForceInterruptAndInvalidateContinuingPose;
+		CurrentMotionMatchingDatabaseRole = ERpgMotionMatchingDatabaseRole::None;
+		bCurrentMotionMatchingResultIsContinuingPose = false;
 	}
 
 	PreviousGroundMotionMatchingDomainState = CurrentGroundDomainState;

--- a/Source/SurvivalRpg/Animation/RpgAnimInstance.h
+++ b/Source/SurvivalRpg/Animation/RpgAnimInstance.h
@@ -253,6 +253,8 @@ struct SURVIVALRPG_API FRpgAnimInstanceProxy : public FAnimInstanceProxy
 	bool bIsAnyMontagePlaying = false;
 	bool bHasTurnInPlaceBlockingGameplayTag = false;
 	bool bTurnInPlaceHardReset = true;
+	/** Number of unified presentation-history resets emitted by game-thread snapshots. */
+	int32 AnimationHistoryResetCount = 0;
 	/** True when the game-thread snapshot crosses between free-facing and turn-in-place-capable rotation. */
 	bool bTurnInPlaceSupportChanged = false;
 
@@ -267,6 +269,7 @@ struct SURVIVALRPG_API FRpgAnimInstanceProxy : public FAnimInstanceProxy
 	uint8 PreviousRemoteRole = 0;
 	float PreviousActorYaw = 0.0f;
 	FVector PreviousActorLocation = FVector::ZeroVector;
+	uint32 PreviousAnimationDiscontinuitySerial = 0;
 	ERpgCharacterRotationMode PreviousRotationMode = ERpgCharacterRotationMode::Free;
 	bool bHasPreviousOwnerSnapshot = false;
 
@@ -525,6 +528,13 @@ protected:
 	UPROPERTY(BlueprintReadOnly, Transient, Category = "Rpg|Animation|Locomotion")
 	FVector LocalAcceleration = FVector::ZeroVector;
 
+	/**
+	 * Monotonic local diagnostic count for unified trajectory, landing, foot-placement, and turn-in-place history resets.
+	 * It is presentation-only and is not authoritative or replicated.
+	 */
+	UPROPERTY(BlueprintReadOnly, Transient, Category = "Rpg|Animation|Diagnostics")
+	int32 AnimationHistoryResetCount = 0;
+
 	/** Horizontal speed in centimeters per second. */
 	UPROPERTY(BlueprintReadOnly, Transient, Category = "Rpg|Animation|Locomotion", Meta = (Units = "cm/s"))
 	float LocomotionGroundSpeed = 0.0f;
@@ -554,7 +564,7 @@ protected:
 	float AimPitch = 0.0f;
 
 	/**
-	 * Signed movement angle relative to the owning actor's forward axis.
+	 * Signed movement angle relative to the network-smoothed presentation forward axis.
 	 * The graph-driven Orientation Warping node compares it with animation root motion; cosmetic-only, in degrees.
 	 */
 	UPROPERTY(BlueprintReadOnly, Transient, Category = "Rpg|Animation|Motion Matching", Meta = (Units = "deg"))

--- a/Source/SurvivalRpg/Animation/RpgFootPlacementTypes.h
+++ b/Source/SurvivalRpg/Animation/RpgFootPlacementTypes.h
@@ -224,7 +224,7 @@ struct SURVIVALRPG_API FRpgFootPlacementSnapshot
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
 	bool bGrounded = false;
 
-	/** True when teleport, owner/role, base, or large-transform changes require lock state to be discarded. */
+	/** True when a semantic discontinuity, owner/role change, or movement-base change discards lock state. */
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Animation|Foot Placement")
 	bool bReset = true;
 

--- a/Source/SurvivalRpg/Animation/RpgTurnInPlaceRuntime.h
+++ b/Source/SurvivalRpg/Animation/RpgTurnInPlaceRuntime.h
@@ -84,7 +84,6 @@ namespace RpgTurnInPlaceRuntime
 {
 	inline constexpr float PlaybackWatchdogSafetyMargin = 0.1f;
 	inline constexpr float FinishedTimeTolerance = 0.05f;
-	inline constexpr float LargePositionDelta = 200.0f;
 
 	/** Returns whether the replicated rotation policy permits controller-facing turn presentation. */
 	SURVIVALRPG_API bool SupportsTurnInPlace(ERpgCharacterRotationMode RotationMode);

--- a/Source/SurvivalRpg/Core/Character/RpgCharacter.cpp
+++ b/Source/SurvivalRpg/Core/Character/RpgCharacter.cpp
@@ -28,44 +28,6 @@
 #include "SurvivalRpg/GameplayTags/RpgGameplayTags.h"
 #include "Net/UnrealNetwork.h"
 
-void FRpgReplicatedAcceleration::SetFromAcceleration(const FVector& InAcceleration, double MaxAcceleration)
-{
-	if (MaxAcceleration <= UE_SMALL_NUMBER)
-	{
-		*this = FRpgReplicatedAcceleration();
-		return;
-	}
-
-	const FVector ClampedAcceleration = InAcceleration.GetClampedToMaxSize(MaxAcceleration);
-	const double XYMagnitude = FMath::Min(ClampedAcceleration.Size2D(), MaxAcceleration);
-	double XYRadians = FMath::Atan2(ClampedAcceleration.Y, ClampedAcceleration.X);
-	if (XYRadians < 0.0)
-	{
-		XYRadians += UE_TWO_PI;
-	}
-
-	XYRadians = FMath::Clamp(XYRadians, 0.0, static_cast<double>(UE_TWO_PI));
-	AccelXYRadians = static_cast<uint8>(FMath::RoundToInt((XYRadians / UE_TWO_PI) * 255.0));
-	AccelXYMagnitude = static_cast<uint8>(FMath::RoundToInt((XYMagnitude / MaxAcceleration) * 255.0));
-	AccelZ = static_cast<int8>(FMath::RoundToInt(FMath::Clamp(ClampedAcceleration.Z / MaxAcceleration, -1.0, 1.0) * 127.0));
-}
-
-FVector FRpgReplicatedAcceleration::ToAcceleration(double MaxAcceleration) const
-{
-	if (MaxAcceleration <= UE_SMALL_NUMBER)
-	{
-		return FVector::ZeroVector;
-	}
-
-	const double UnpackedXYMagnitude = static_cast<double>(AccelXYMagnitude) * MaxAcceleration / 255.0;
-	const double UnpackedXYRadians = static_cast<double>(AccelXYRadians) * UE_TWO_PI / 255.0;
-	FVector Result = FVector::ZeroVector;
-	FMath::PolarToCartesian(UnpackedXYMagnitude, UnpackedXYRadians, Result.X, Result.Y);
-	Result.Z = static_cast<double>(AccelZ) * MaxAcceleration / 127.0;
-	return Result;
-}
-
-
 ARpgCharacter::ARpgCharacter(const FObjectInitializer& ObjectInitializer) : 
 	Super(ObjectInitializer.SetDefaultSubobjectClass<URpgCharacterMovementComponent>(CharacterMovementComponentName))
 {
@@ -466,39 +428,42 @@ void ARpgCharacter::BeginPlay()
 	RefreshRotationMode();
 }
 
+void ARpgCharacter::TeleportSucceeded(bool bIsATest)
+{
+	Super::TeleportSucceeded(bIsATest);
+	if (bIsATest || !HasAuthority())
+	{
+		return;
+	}
+
+	++AnimationTeleportEpoch;
+	if (AnimationTeleportEpoch == 0)
+	{
+		++AnimationTeleportEpoch;
+	}
+	ForceNetUpdate();
+}
+
 void ARpgCharacter::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
 {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 
-	DOREPLIFETIME_CONDITION(ThisClass, ReplicatedAcceleration, COND_SimulatedOnly);
+	DOREPLIFETIME_CONDITION(ThisClass, AnimationTeleportEpoch, COND_SimulatedOnly);
 	DOREPLIFETIME_CONDITION_NOTIFY(ThisClass, RotationMode, COND_None, REPNOTIFY_Always);
 }
 
-void ARpgCharacter::PreReplication(IRepChangedPropertyTracker& ChangedPropertyTracker)
+bool ARpgCharacter::ShouldReplicateAcceleration() const
 {
-	Super::PreReplication(ChangedPropertyTracker);
-
-	const UCharacterMovementComponent* MovementComponent = GetCharacterMovement();
-	const double MaxAcceleration = MovementComponent ? MovementComponent->GetMaxAcceleration() : 0.0;
-	if (!MovementComponent || MaxAcceleration <= UE_SMALL_NUMBER)
-	{
-		ReplicatedAcceleration = FRpgReplicatedAcceleration();
-		return;
-	}
-
-	ReplicatedAcceleration.SetFromAcceleration(MovementComponent->GetCurrentAcceleration(), MaxAcceleration);
+	return true;
 }
 
-void ARpgCharacter::OnRep_ReplicatedAcceleration()
+void ARpgCharacter::OnRep_AnimationTeleportEpoch()
 {
-	URpgCharacterMovementComponent* MovementComponent = Cast<URpgCharacterMovementComponent>(GetCharacterMovement());
-	if (!MovementComponent)
+	if (URpgCharacterMovementComponent* MovementComponent =
+		Cast<URpgCharacterMovementComponent>(GetCharacterMovement()))
 	{
-		return;
+		MovementComponent->NotifyReplicatedAnimationTeleport();
 	}
-
-	MovementComponent->SetReplicatedAcceleration(
-		ReplicatedAcceleration.ToAcceleration(MovementComponent->GetMaxAcceleration()));
 }
 
 void ARpgCharacter::OnAbilitySystemInitialized()

--- a/Source/SurvivalRpg/Core/Character/RpgCharacter.h
+++ b/Source/SurvivalRpg/Core/Character/RpgCharacter.h
@@ -24,34 +24,6 @@ class URpgCharacterMovementComponent;
 class URpgEquipmentManagerComponent;
 struct FGameplayTag;
 
-/**
- * Compact server-owned acceleration state replicated to simulated proxies for locomotion animation.
- * XY direction and magnitude are quantized independently; Z preserves signed acceleration.
- */
-USTRUCT()
-struct SURVIVALRPG_API FRpgReplicatedAcceleration
-{
-	GENERATED_BODY()
-
-	/** Quantizes a movement acceleration vector against the owning movement component's maximum. */
-	void SetFromAcceleration(const FVector& InAcceleration, double MaxAcceleration);
-
-	/** Reconstructs the acceleration vector for remote movement simulation. */
-	FVector ToAcceleration(double MaxAcceleration) const;
-
-	/** XY acceleration direction mapped from [0, 2 PI] to [0, 255]. */
-	UPROPERTY()
-	uint8 AccelXYRadians = 0;
-
-	/** XY acceleration magnitude mapped from [0, MaxAcceleration] to [0, 255]. */
-	UPROPERTY()
-	uint8 AccelXYMagnitude = 0;
-
-	/** Signed Z acceleration mapped from [-MaxAcceleration, MaxAcceleration] to [-127, 127]. */
-	UPROPERTY()
-	int8 AccelZ = 0;
-};
-
 UCLASS()
 class SURVIVALRPG_API ARpgCharacter : public AModularCharacter, public IAbilitySystemInterface
 {
@@ -62,7 +34,6 @@ public:
 	explicit ARpgCharacter(const FObjectInitializer& ObjectInitializer = FObjectInitializer::Get());
 	virtual void BeginPlay() override;
 	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
-	virtual void PreReplication(IRepChangedPropertyTracker& ChangedPropertyTracker) override;
 	
 	UFUNCTION(BlueprintCallable, Category = "Rpg|Character")
 	ARpgPlayerController* GetRpgPlayerController() const;
@@ -124,8 +95,15 @@ public:
 	virtual void OnRep_PlayerState() override;
 	
 	virtual void FellOutOfWorld(const class UDamageType& dmgType) override;
+	virtual void TeleportSucceeded(bool bIsATest) override;
 
 protected:
+	/**
+	 * Includes acceleration in UE 5.8's replicated movement payload for simulated proxies.
+	 * The engine reconstructs both acceleration and analog input magnitude from this single snapshot.
+	 */
+	virtual bool ShouldReplicateAcceleration() const override;
+
 	// Called when the game starts or when spawned
 	
 	virtual void OnAbilitySystemInitialized();
@@ -188,6 +166,17 @@ private:
 	UFUNCTION()
 	void OnRep_RotationMode();
 
+	/**
+	 * Server-owned semantic teleport epoch sent only to simulated proxies.
+	 * Ordinary replicated movement corrections never mutate it.
+	 */
+	UPROPERTY(Transient, ReplicatedUsing = OnRep_AnimationTeleportEpoch)
+	uint16 AnimationTeleportEpoch = 0;
+
+	/** Converts a replicated gameplay teleport into one local presentation-history edge. */
+	UFUNCTION()
+	void OnRep_AnimationTeleportEpoch();
+
 	/** ASC whose rotation request-tag delegates are currently registered. */
 	TWeakObjectPtr<URpgAbilitySystemComponent> RotationModeAbilitySystem;
 
@@ -198,14 +187,6 @@ private:
 	ERpgCharacterRotationMode LastAppliedRotationMode = ERpgCharacterRotationMode::CombatStrafe;
 	bool bHasAppliedRotationPolicy = false;
 
-	/** Latest server acceleration, replicated only to simulated proxies and consumed by CharacterMovement. */
-	UPROPERTY(Transient, ReplicatedUsing = OnRep_ReplicatedAcceleration)
-	FRpgReplicatedAcceleration ReplicatedAcceleration;
-
-	/** Reconstructs acceleration for remote CharacterMovement simulation after replication. */
-	UFUNCTION()
-	void OnRep_ReplicatedAcceleration();
-	
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Character", Meta = (AllowPrivateAccess = "true"))
 	TObjectPtr<URpgPawnExtensionComponent> PawnExtensionComponent;
 

--- a/Source/SurvivalRpg/Core/Character/RpgCharacterMovementComponent.cpp
+++ b/Source/SurvivalRpg/Core/Character/RpgCharacterMovementComponent.cpp
@@ -23,14 +23,117 @@ URpgCharacterMovementComponent::URpgCharacterMovementComponent(const FObjectInit
 	
 }
 
-void URpgCharacterMovementComponent::SimulateMovement(float DeltaTime)
+void URpgCharacterMovementComponent::OnTeleported()
 {
-	// Base proxy simulation derives acceleration from velocity when no engine-level
-	// acceleration payload is present. Preserve the project's own replicated value,
-	// including the valid zero default that may not trigger an initial OnRep.
-	const FVector ReplicatedAcceleration = Acceleration;
-	Super::SimulateMovement(DeltaTime);
-	Acceleration = ReplicatedAcceleration;
+	Super::OnTeleported();
+	MarkAnimationDiscontinuity();
+}
+
+void URpgCharacterMovementComponent::NotifyReplicatedAnimationTeleport()
+{
+	MarkAnimationDiscontinuity();
+}
+
+void URpgCharacterMovementComponent::OnClientCorrectionReceived(
+	FNetworkPredictionData_Client_Character& ClientData,
+	float TimeStamp,
+	FVector NewLocation,
+	FVector NewVelocity,
+	FMovementBaseInterfaceData* NewMovementBaseInterfaceData,
+	FName NewBaseBoneName,
+	bool bHasBase,
+	bool bBaseRelativePosition,
+	uint8 ServerMovementMode,
+	FVector ServerGravityDirection)
+{
+	// NewLocation is already converted to world space by ClientAdjustPosition. Compare
+	// it with the acknowledged move from the same timestamp, not the client's current
+	// location which may be many unacknowledged moves ahead under latency. Classify the
+	// adjustment before replay, then fold historical responses into one tick batch.
+	if (UpdatedComponent)
+	{
+		const FVector ClientLocationAtCorrectedMove =
+			ClientData.LastAckedMove.IsValid()
+				? ClientData.LastAckedMove->SavedLocation
+				: UpdatedComponent->GetComponentLocation();
+		bHasPendingAnimationCorrection = true;
+		bPendingAnimationCorrectionDiscontinuity |= FVector::DistSquared(
+			ClientLocationAtCorrectedMove,
+			NewLocation) > FMath::Square(NetworkLargeClientCorrectionDistance);
+	}
+
+	Super::OnClientCorrectionReceived(
+		ClientData,
+		TimeStamp,
+		NewLocation,
+		NewVelocity,
+		NewMovementBaseInterfaceData,
+		NewBaseBoneName,
+		bHasBase,
+		bBaseRelativePosition,
+		ServerMovementMode,
+		ServerGravityDirection);
+}
+
+bool URpgCharacterMovementComponent::ClientUpdatePositionAfterServerUpdate()
+{
+	const bool bHadPendingAnimationCorrection = bHasPendingAnimationCorrection;
+	const bool bShouldMarkAnimationDiscontinuity =
+		bPendingAnimationCorrectionDiscontinuity;
+	const bool bReplayedMoves = Super::ClientUpdatePositionAfterServerUpdate();
+
+	if (bHadPendingAnimationCorrection)
+	{
+		bHasPendingAnimationCorrection = false;
+		bPendingAnimationCorrectionDiscontinuity = false;
+		if (bShouldMarkAnimationDiscontinuity)
+		{
+			MarkAnimationDiscontinuity();
+		}
+	}
+
+	return bReplayedMoves;
+}
+
+void URpgCharacterMovementComponent::SmoothCorrection(
+	const FVector& OldLocation,
+	const FQuat& OldRotation,
+	const FVector& NewLocation,
+	const FQuat& NewRotation)
+{
+	// Ordinary simulated-proxy updates are intentionally left to network smoothing.
+	// Only an untagged correction beyond UE's actual no-smoothing distance is a hard fallback.
+	const FNetworkPredictionData_Client_Character* ClientData =
+		GetPredictionData_Client_Character();
+	const float NoSmoothDistance = ClientData
+		? ClientData->NoSmoothNetUpdateDist
+		: NetworkNoSmoothUpdateDistance;
+	const bool bHardSimulatedProxyCorrection =
+		CharacterOwner &&
+		CharacterOwner->GetLocalRole() == ROLE_SimulatedProxy &&
+		FVector::DistSquared(OldLocation, NewLocation) >
+			FMath::Square(FMath::Max(NoSmoothDistance, 0.0f));
+
+	Super::SmoothCorrection(OldLocation, OldRotation, NewLocation, NewRotation);
+	if (bHardSimulatedProxyCorrection)
+	{
+		MarkAnimationDiscontinuity();
+	}
+}
+
+void URpgCharacterMovementComponent::MarkAnimationDiscontinuity()
+{
+	if (LastAnimationDiscontinuityFrame == GFrameCounter)
+	{
+		return;
+	}
+
+	LastAnimationDiscontinuityFrame = GFrameCounter;
+	++AnimationDiscontinuitySerial;
+	if (AnimationDiscontinuitySerial == 0)
+	{
+		++AnimationDiscontinuitySerial;
+	}
 }
 
 bool URpgCharacterMovementComponent::CanAttemptJump() const
@@ -85,11 +188,6 @@ const FRpgCharacterGroundInfo& URpgCharacterMovementComponent::GetGroundInfo()
 	CachedGroundInfo.LastUpdateFrame = GFrameCounter;
 
 	return CachedGroundInfo;
-}
-
-void URpgCharacterMovementComponent::SetReplicatedAcceleration(const FVector& InAcceleration)
-{
-	Acceleration = InAcceleration;
 }
 
 FRotator URpgCharacterMovementComponent::GetDeltaRotation(float DeltaTime) const

--- a/Source/SurvivalRpg/Core/Character/RpgCharacterMovementComponent.h
+++ b/Source/SurvivalRpg/Core/Character/RpgCharacterMovementComponent.h
@@ -47,16 +47,57 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Rpg|CharacterMovement")
 	const FRpgCharacterGroundInfo& GetGroundInfo();
 
-	/** Supplies server acceleration to a simulated proxy so remote locomotion preserves starts, stops, and pivots. */
-	void SetReplicatedAcceleration(const FVector& InAcceleration);
+	/**
+	 * Returns the local monotonic signal for presentation-history discontinuities.
+	 * It is not replicated; each network role advances it from the correction or teleport it actually applies.
+	 */
+	uint32 GetAnimationDiscontinuitySerial() const { return AnimationDiscontinuitySerial; }
+
+	/** Applies the server's semantic teleport edge on a simulated proxy. */
+	void NotifyReplicatedAnimationTeleport();
+
+	//~UMovementComponent interface
+	virtual void OnTeleported() override;
+	//~End of UMovementComponent interface
 
 	//~UMovementComponent interface
 	virtual FRotator GetDeltaRotation(float DeltaTime) const override;
 	virtual float GetMaxSpeed() const override;
 	//~End of UMovementComponent interface
 protected:
-	virtual void SimulateMovement(float DeltaTime) override;
-protected:
+	virtual bool ClientUpdatePositionAfterServerUpdate() override;
+	virtual void OnClientCorrectionReceived(
+		FNetworkPredictionData_Client_Character& ClientData,
+		float TimeStamp,
+		FVector NewLocation,
+		FVector NewVelocity,
+		FMovementBaseInterfaceData* NewMovementBaseInterfaceData,
+		FName NewBaseBoneName,
+		bool bHasBase,
+		bool bBaseRelativePosition,
+		uint8 ServerMovementMode,
+		FVector ServerGravityDirection) override;
+	virtual void SmoothCorrection(
+		const FVector& OldLocation,
+		const FQuat& OldRotation,
+		const FVector& NewLocation,
+		const FQuat& NewRotation) override;
+
+	/** Advances the local history-reset edge without adding another replicated movement contract. */
+	void MarkAnimationDiscontinuity();
+
 	// Cached ground info for the character.  Do not access this directly!  It's only updated when accessed via GetGroundInfo().
 	FRpgCharacterGroundInfo CachedGroundInfo;
+
+	/** Local-only edge consumed once by the animation game-thread snapshot. */
+	uint32 AnimationDiscontinuitySerial = 0;
+
+	/** Frame used to coalesce a replicated teleport and its accompanying hard movement correction. */
+	uint64 LastAnimationDiscontinuityFrame = MAX_uint64;
+
+	/** True until the pending server correction and its saved moves have been evaluated together. */
+	bool bHasPendingAnimationCorrection = false;
+
+	/** True when any correction in the pending batch exceeds UE's large-correction threshold. */
+	bool bPendingAnimationCorrectionDiscontinuity = false;
 };

--- a/Source/SurvivalRpgEditor/Private/Animation/RpgAnimationFoundationTests.cpp
+++ b/Source/SurvivalRpgEditor/Private/Animation/RpgAnimationFoundationTests.cpp
@@ -1,5 +1,3 @@
-#include "SurvivalRpg/Core/Character/RpgCharacter.h"
-
 #if WITH_DEV_AUTOMATION_TESTS
 
 #include "Animation/AnimBlueprint.h"
@@ -8,50 +6,6 @@
 #include "Engine/Blueprint.h"
 #include "Misc/AutomationTest.h"
 #include "UObject/SoftObjectPath.h"
-
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(
-	FRpgReplicatedAccelerationRoundTripTest,
-	"SurvivalRpg.Animation.Network.ReplicatedAccelerationRoundTrip",
-	EAutomationTestFlags::EditorContext |
-		EAutomationTestFlags::EngineFilter)
-
-bool FRpgReplicatedAccelerationRoundTripTest::RunTest(const FString& Parameters)
-{
-	constexpr double MaxAcceleration = 2400.0;
-	// At full acceleration, half of an 8-bit angular bin contributes about 29.6 uu/s^2.
-	constexpr double QuantizationTolerance = 35.0;
-	constexpr double HalfAngularBinRadians = UE_PI / 255.0;
-
-	const FVector TestValues[] = {
-		FVector::ZeroVector,
-		FVector(MaxAcceleration, 0.0, 0.0),
-		FVector(0.0, -MaxAcceleration, 0.0),
-		FVector(
-			MaxAcceleration * FMath::Cos(HalfAngularBinRadians),
-			MaxAcceleration * FMath::Sin(HalfAngularBinRadians),
-			0.0),
-		FVector(MaxAcceleration * 2.0, 0.0, 0.0),
-		FVector(600.0, -1600.0, 900.0),
-		FVector(-450.0, 325.0, -1200.0),
-	};
-
-	for (const FVector& Input : TestValues)
-	{
-		FRpgReplicatedAcceleration Packed;
-		Packed.SetFromAcceleration(Input, MaxAcceleration);
-
-		const FVector Expected = Input.GetClampedToMaxSize(MaxAcceleration);
-		const FVector Actual = Packed.ToAcceleration(MaxAcceleration);
-		TestTrue(
-			*FString::Printf(TEXT("%s round-trips within quantization tolerance"), *Input.ToCompactString()),
-			Actual.Equals(Expected, QuantizationTolerance));
-	}
-
-	FRpgReplicatedAcceleration InvalidMaximum;
-	InvalidMaximum.SetFromAcceleration(FVector(100.0, 200.0, 300.0), 0.0);
-	TestEqual(TEXT("A non-positive maximum decodes to zero"), InvalidMaximum.ToAcceleration(0.0), FVector::ZeroVector);
-	return true;
-}
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 	FRpgRegularAnimationRemainsParallelTest,

--- a/Source/SurvivalRpgEditor/Private/Animation/RpgJumpPhaseRuntimeTests.cpp
+++ b/Source/SurvivalRpgEditor/Private/Animation/RpgJumpPhaseRuntimeTests.cpp
@@ -16,7 +16,6 @@
 #include "SurvivalRpg/Animation/RpgJumpRuntime.h"
 #include "SurvivalRpg/Animation/RpgLandingRuntime.h"
 #include "SurvivalRpg/Animation/RpgMotionMatchingRuntime.h"
-#include "SurvivalRpg/Core/Character/RpgCharacter.h"
 #include "UObject/Package.h"
 #include "UObject/UObjectGlobals.h"
 
@@ -944,12 +943,6 @@ bool FRpgJumpPhaseRuntimeTest::RunTest(const FString& Parameters)
 	constexpr double HeldAirborneMaximumAcceleration = 2400.0;
 	constexpr float HeldAirborneFrozenHorizontalSpeed = 4.0f;
 	const FVector AuthorityHeldAcceleration(HeldAirborneMaximumAcceleration, 0.0, 0.0);
-	FRpgReplicatedAcceleration PackedHeldAcceleration;
-	PackedHeldAcceleration.SetFromAcceleration(
-		AuthorityHeldAcceleration,
-		HeldAirborneMaximumAcceleration);
-	const FVector SimulatedHeldAcceleration = PackedHeldAcceleration.ToAcceleration(
-		HeldAirborneMaximumAcceleration);
 	struct FHeldAirborneNetworkView
 	{
 		const TCHAR* Name;
@@ -958,8 +951,8 @@ bool FRpgJumpPhaseRuntimeTest::RunTest(const FString& Parameters)
 	const FHeldAirborneNetworkView HeldAirborneNetworkViews[] =
 	{
 		{TEXT("Authority"), AuthorityHeldAcceleration},
-		{TEXT("Simulated Proxy"), SimulatedHeldAcceleration},
-		{TEXT("Late Join Simulated Proxy"), SimulatedHeldAcceleration},
+		{TEXT("Simulated Proxy"), AuthorityHeldAcceleration},
+		{TEXT("Late Join Simulated Proxy"), AuthorityHeldAcceleration},
 	};
 	const FVector GravityAcceleration(0.0, 0.0, -1000.0);
 

--- a/Source/SurvivalRpgEditor/Private/Animation/RpgMotionMatchingDatabaseResolverTests.cpp
+++ b/Source/SurvivalRpgEditor/Private/Animation/RpgMotionMatchingDatabaseResolverTests.cpp
@@ -15,7 +15,6 @@
 #include "SurvivalRpg/Animation/RpgGaspPresentationProfile.h"
 #include "SurvivalRpg/Animation/RpgMotionMatchingRuntime.h"
 #include "SurvivalRpg/Animation/RpgPoseSearchTrajectory.h"
-#include "SurvivalRpg/Core/Character/RpgCharacter.h"
 #include "UObject/UObjectGlobals.h"
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(
@@ -274,16 +273,12 @@ bool FRpgMotionMatchingDatabaseResolverTest::RunTest(const FString& Parameters)
 	// carries a small floor-projected Z remainder. Only horizontal velocity may open the moving Run domain.
 	constexpr double MaxAcceleration = 2400.0;
 	const FVector FullForwardAcceleration(MaxAcceleration, 0.0, 0.0);
-	FRpgReplicatedAcceleration PackedForwardAcceleration;
-	PackedForwardAcceleration.SetFromAcceleration(FullForwardAcceleration, MaxAcceleration);
-	const FVector ReplicatedForwardAcceleration =
-		PackedForwardAcceleration.ToAcceleration(MaxAcceleration);
 	const FVector NetworkAccelerations[] =
 	{
 		FullForwardAcceleration,
 		FullForwardAcceleration,
-		ReplicatedForwardAcceleration,
-		ReplicatedForwardAcceleration,
+		FullForwardAcceleration,
+		FullForwardAcceleration,
 	};
 	static const TCHAR* const LandingHandoffNetworkViews[] =
 	{

--- a/Source/SurvivalRpgEditor/Private/Network/RpgGaspPIENetworkTests.cpp
+++ b/Source/SurvivalRpgEditor/Private/Network/RpgGaspPIENetworkTests.cpp
@@ -21,6 +21,7 @@
 #include "SurvivalRpg/AbilitySystem/RpgAbilitySystemComponent.h"
 #include "SurvivalRpg/Animation/RpgAnimInstance.h"
 #include "SurvivalRpg/Core/Character/RpgCharacter.h"
+#include "SurvivalRpg/Core/Character/RpgCharacterMovementComponent.h"
 #include "SurvivalRpg/Core/Game/Experience/RpgExperienceDefinition.h"
 #include "SurvivalRpg/Core/Game/Experience/RpgExperienceManagerComponent.h"
 #include "SurvivalRpg/Core/Game/RpgGameModeBase.h"
@@ -47,6 +48,13 @@ namespace RpgGaspPIENetworkTests
 		FTimerHandle MovementInputTimer;
 		FTimerHandle ObservationTimer;
 		FVector MovementInputDirection = FVector::ZeroVector;
+		float MovementInputScale = 0.0f;
+		float StableInputScale = -1.0f;
+		double StableInputStartTime = 0.0;
+		int32 AnimationResetBaseline = 0;
+		int32 LastObservedAnimationResetDelta = MIN_int32;
+		double AnimationResetStableStartTime = -1.0;
+		uint64 AnimationResetStableStartFrame = 0;
 		FVector MontageStartLocation = FVector::ZeroVector;
 		double MontageConvergenceStartTime = 0.0;
 		float MaximumMontageDisplacement = 0.0f;
@@ -248,6 +256,12 @@ namespace RpgGaspPIENetworkTests
 		FVector WorldAcceleration = FVector::ZeroVector;
 		float GroundSpeed = 0.0f;
 		bool bHasAcceleration = true;
+		const UCharacterMovementComponent* MovementComponent =
+			Character->GetCharacterMovement();
+		const bool bHasNativeZeroSnapshot =
+			Character->GetLocalRole() != ROLE_SimulatedProxy ||
+			(Character->GetReplicatedMovement().bRepAcceleration &&
+			 Character->GetReplicatedMovement().Acceleration.Size2D() <= 5.0f);
 		return ReadAnimProperty(
 				AnimInstance,
 				TEXT("WorldAcceleration"),
@@ -261,8 +275,170 @@ namespace RpgGaspPIENetworkTests
 				TEXT("bHasAcceleration"),
 				bHasAcceleration) &&
 			!bHasAcceleration && WorldAcceleration.Size2D() <= 5.0f &&
-			Character->GetCharacterMovement()->GetCurrentAcceleration().Size2D() <= 5.0f &&
+			MovementComponent->GetCurrentAcceleration().Size2D() <= 5.0f &&
+			MovementComponent->GetAnalogInputModifier() <= 0.01f &&
+			bHasNativeZeroSnapshot &&
 			GroundSpeed <= 8.0f && Character->GetVelocity().Size2D() <= 8.0f;
+	}
+
+	bool HasExpectedMovementInput(
+		FNetworkState& State,
+		const ENetRole ExpectedLocalRole,
+		const FVector& ExpectedDirection,
+		const float ExpectedScale)
+	{
+		ARpgCharacter* Character = FindCharacterByPlayerId(
+			State.World,
+			State.SubjectPlayerId);
+		URpgCharacterMovementComponent* MovementComponent = Character
+			? Cast<URpgCharacterMovementComponent>(Character->GetCharacterMovement())
+			: nullptr;
+		URpgAnimInstance* AnimInstance = GetPilotAnimInstance(Character);
+		FVector AnimAcceleration = FVector::ZeroVector;
+		const FVector Direction2D = ExpectedDirection.GetSafeNormal2D();
+		const float ClampedScale = FMath::Clamp(ExpectedScale, 0.0f, 1.0f);
+		const float MaxAcceleration = MovementComponent
+			? MovementComponent->GetMaxAcceleration()
+			: 0.0f;
+		const float ExpectedMagnitude = MaxAcceleration * ClampedScale;
+		const float AccelerationTolerance = FMath::Max(2.0f, MaxAcceleration * 0.02f);
+		const FVector CurrentAcceleration = MovementComponent
+			? MovementComponent->GetCurrentAcceleration()
+			: FVector::ZeroVector;
+		const FRepMovement* ReplicatedMovement = Character
+			? &Character->GetReplicatedMovement()
+			: nullptr;
+		const bool bHasNativeProxySnapshot =
+			ExpectedLocalRole != ROLE_SimulatedProxy ||
+			(ReplicatedMovement &&
+			 ReplicatedMovement->bRepAcceleration &&
+			 ReplicatedMovement->Acceleration.Equals(
+				 CurrentAcceleration,
+				 AccelerationTolerance));
+		const bool bMatches =
+			Character &&
+			MovementComponent &&
+			AnimInstance &&
+			Character->GetLocalRole() == ExpectedLocalRole &&
+			MovementComponent->IsMovingOnGround() &&
+			!CurrentAcceleration.ContainsNaN() &&
+			FMath::IsNearlyEqual(
+				CurrentAcceleration.Size2D(),
+				ExpectedMagnitude,
+				AccelerationTolerance) &&
+			FVector::DotProduct(
+				CurrentAcceleration.GetSafeNormal2D(),
+				Direction2D) > 0.98f &&
+			FMath::IsNearlyEqual(
+				MovementComponent->GetAnalogInputModifier(),
+				ClampedScale,
+				0.025f) &&
+			ReadAnimProperty(
+				AnimInstance,
+				TEXT("WorldAcceleration"),
+				AnimAcceleration) &&
+			!AnimAcceleration.ContainsNaN() &&
+			FMath::IsNearlyEqual(
+				AnimAcceleration.Size2D(),
+				ExpectedMagnitude,
+				AccelerationTolerance) &&
+			FVector::DotProduct(
+				AnimAcceleration.GetSafeNormal2D(),
+				Direction2D) > 0.98f &&
+			bHasNativeProxySnapshot;
+
+		if (!bMatches ||
+			!FMath::IsNearlyEqual(State.StableInputScale, ClampedScale, 0.001f))
+		{
+			State.StableInputScale = bMatches ? ClampedScale : -1.0f;
+			State.StableInputStartTime = bMatches ? FPlatformTime::Seconds() : 0.0;
+			return false;
+		}
+
+		return FPlatformTime::Seconds() - State.StableInputStartTime >= 0.2;
+	}
+
+	bool ReadAnimationHistoryResetCount(
+		FNetworkState& State,
+		int32& OutResetCount)
+	{
+		ARpgCharacter* Character = FindCharacterByPlayerId(
+			State.World,
+			State.SubjectPlayerId);
+		return ReadAnimProperty(
+			GetPilotAnimInstance(Character),
+			TEXT("AnimationHistoryResetCount"),
+			OutResetCount);
+	}
+
+	bool ReadAnimationHistoryResetDelta(
+		FNetworkState& State,
+		int32& OutResetDelta)
+	{
+		int32 ResetCount = 0;
+		if (!ReadAnimationHistoryResetCount(State, ResetCount))
+		{
+			return false;
+		}
+
+		OutResetDelta = ResetCount - State.AnimationResetBaseline;
+		if (OutResetDelta != State.LastObservedAnimationResetDelta)
+		{
+			State.LastObservedAnimationResetDelta = OutResetDelta;
+			UE_LOG(
+				LogTemp,
+				Display,
+				TEXT("GASP history-reset observation: ClientIndex=%d Baseline=%d Current=%d Delta=%d"),
+				State.ClientIndex,
+				State.AnimationResetBaseline,
+				ResetCount,
+				OutResetDelta);
+		}
+		return true;
+	}
+
+	bool HasAnimationResetDeltaAtLeast(
+		FNetworkState& State,
+		const int32 MinimumDelta)
+	{
+		int32 ResetDelta = 0;
+		return ReadAnimationHistoryResetDelta(State, ResetDelta) &&
+			ResetDelta >= MinimumDelta;
+	}
+
+	bool HasStableAnimationResetDelta(
+		FNetworkState& State,
+		const int32 ExpectedDelta)
+	{
+		int32 ActualDelta = 0;
+		if (!ReadAnimationHistoryResetDelta(State, ActualDelta))
+		{
+			State.AnimationResetStableStartTime = -1.0;
+			State.AnimationResetStableStartFrame = 0;
+			return false;
+		}
+
+		if (ActualDelta != ExpectedDelta)
+		{
+			State.AnimationResetStableStartTime = -1.0;
+			State.AnimationResetStableStartFrame = 0;
+			return false;
+		}
+
+		const double Now = IsValid(State.World)
+			? State.World->GetTimeSeconds()
+			: -1.0;
+		if (Now < 0.0)
+		{
+			return false;
+		}
+		if (State.AnimationResetStableStartTime < 0.0)
+		{
+			State.AnimationResetStableStartTime = Now;
+			State.AnimationResetStableStartFrame = GFrameCounter;
+		}
+		return Now - State.AnimationResetStableStartTime >= 0.35 &&
+			GFrameCounter - State.AnimationResetStableStartFrame >= 10;
 	}
 
 	bool HasRotationMode(FNetworkState& State, const ERpgCharacterRotationMode ExpectedMode)
@@ -407,12 +583,18 @@ namespace RpgGaspPIENetworkTests
 			{
 				ObserveState(State);
 			}),
-			0.01f,
-			true);
+			0.001f,
+			FTimerManagerTimerParameters{
+				.bLoop = true,
+				.bMaxOncePerFrame = true,
+				.FirstDelay = 0.0f });
 		ActiveTimerStates.AddUnique(&State);
 	}
 
-	void StartMovementInput(FNetworkState& State, const FVector& Direction)
+	void StartMovementInput(
+		FNetworkState& State,
+		const FVector& Direction,
+		const float Scale = 1.0f)
 	{
 		if (!IsValid(State.World))
 		{
@@ -420,6 +602,7 @@ namespace RpgGaspPIENetworkTests
 		}
 
 		State.MovementInputDirection = Direction.GetSafeNormal2D();
+		State.MovementInputScale = FMath::Clamp(Scale, 0.0f, 1.0f);
 		if (State.World->GetTimerManager().IsTimerActive(State.MovementInputTimer))
 		{
 			return;
@@ -434,11 +617,17 @@ namespace RpgGaspPIENetworkTests
 					State.SubjectPlayerId);
 				if (Character && Character->IsLocallyControlled())
 				{
-					Character->AddMovementInput(State.MovementInputDirection, 1.0f);
+					Character->ConsumeMovementInputVector();
+					Character->AddMovementInput(
+						State.MovementInputDirection,
+						State.MovementInputScale);
 				}
 			}),
-			0.01f,
-			true);
+			0.001f,
+			FTimerManagerTimerParameters{
+				.bLoop = true,
+				.bMaxOncePerFrame = true,
+				.FirstDelay = 0.0f });
 		ActiveTimerStates.AddUnique(&State);
 	}
 
@@ -449,6 +638,13 @@ namespace RpgGaspPIENetworkTests
 			State.World->GetTimerManager().ClearTimer(State.MovementInputTimer);
 		}
 		State.MovementInputDirection = FVector::ZeroVector;
+		State.MovementInputScale = 0.0f;
+		if (ARpgCharacter* Character = FindCharacterByPlayerId(
+			State.World,
+			State.SubjectPlayerId))
+		{
+			Character->ConsumeMovementInputVector();
+		}
 	}
 
 	void ClearActiveTimers()
@@ -476,8 +672,8 @@ NETWORK_TEST_CLASS(GaspPilotPIE, "SurvivalRpg.Network")
 	FPacketSimulationSettings PacketSettings;
 	FPrimaryAssetId OriginalExperienceOverride;
 	FVector AuthorityCorrectionBaseline = FVector::ZeroVector;
+	FVector AuthorityTeleportTarget = FVector::ZeroVector;
 	FVector AuthorityMontageEnd = FVector::ZeroVector;
-	double CorrectionStartTime = 0.0;
 	int32 SubjectPlayerId = INDEX_NONE;
 	bool bOriginalDiskPersistence = true;
 	UClass* PilotGameModeClass = nullptr;
@@ -609,7 +805,7 @@ NETWORK_TEST_CLASS(GaspPilotPIE, "SurvivalRpg.Network")
 				[](FNetworkState& State)
 				{
 					StartObservation(State);
-					StartMovementInput(State, FVector::YAxisVector);
+					StartMovementInput(State, FVector::YAxisVector, 0.5f);
 				})
 			.UntilClient(
 				TEXT("Autonomous AnimInstance consumes local acceleration"),
@@ -705,6 +901,103 @@ NETWORK_TEST_CLASS(GaspPilotPIE, "SurvivalRpg.Network")
 						State,
 						ROLE_SimulatedProxy,
 						ROLE_Authority);
+				},
+				NetworkTimeout())
+			.UntilServer(
+				TEXT("Authority preserves the owner's fifty-percent input magnitude"),
+				[](FNetworkState& State)
+				{
+					return HasExpectedMovementInput(
+						State,
+						ROLE_Authority,
+						FVector::YAxisVector,
+						0.5f);
+				},
+				NetworkTimeout())
+			.UntilClient(
+				TEXT("Owner preserves fifty-percent input magnitude"),
+				0,
+				[](FNetworkState& State)
+				{
+					return HasExpectedMovementInput(
+						State,
+						ROLE_AutonomousProxy,
+						FVector::YAxisVector,
+						0.5f);
+				},
+				NetworkTimeout())
+			.UntilClient(
+				TEXT("Moving late join reconstructs fifty-percent proxy input"),
+				1,
+				[](FNetworkState& State)
+				{
+					return HasExpectedMovementInput(
+						State,
+						ROLE_SimulatedProxy,
+						FVector::YAxisVector,
+						0.5f);
+				},
+				NetworkTimeout())
+			.ThenClient(
+				TEXT("Reduce owner input to twenty-five percent"),
+				0,
+				[](FNetworkState& State)
+				{
+					StartMovementInput(State, FVector::YAxisVector, 0.25f);
+				})
+			.UntilServer(
+				TEXT("Authority preserves twenty-five-percent input magnitude"),
+				[](FNetworkState& State)
+				{
+					return HasExpectedMovementInput(
+						State,
+						ROLE_Authority,
+						FVector::YAxisVector,
+						0.25f);
+				},
+				NetworkTimeout())
+			.UntilClients(
+				TEXT("Owner and simulated proxy preserve twenty-five-percent input"),
+				[](FNetworkState& State)
+				{
+					return HasExpectedMovementInput(
+						State,
+						State.ClientIndex == 0
+							? ROLE_AutonomousProxy
+							: ROLE_SimulatedProxy,
+						FVector::YAxisVector,
+						0.25f);
+				},
+				NetworkTimeout())
+			.ThenClient(
+				TEXT("Restore full owner input before the pivot"),
+				0,
+				[](FNetworkState& State)
+				{
+					StartMovementInput(State, FVector::YAxisVector, 1.0f);
+				})
+			.UntilServer(
+				TEXT("Authority restores full input magnitude"),
+				[](FNetworkState& State)
+				{
+					return HasExpectedMovementInput(
+						State,
+						ROLE_Authority,
+						FVector::YAxisVector,
+						1.0f);
+				},
+				NetworkTimeout())
+			.UntilClients(
+				TEXT("Owner and simulated proxy restore full input magnitude"),
+				[](FNetworkState& State)
+				{
+					return HasExpectedMovementInput(
+						State,
+						State.ClientIndex == 0
+							? ROLE_AutonomousProxy
+							: ROLE_SimulatedProxy,
+						FVector::YAxisVector,
+						1.0f);
 				},
 				NetworkTimeout())
 			.ThenClient(
@@ -1027,6 +1320,27 @@ NETWORK_TEST_CLASS(GaspPilotPIE, "SurvivalRpg.Network")
 					{
 						AuthorityCorrectionBaseline = Character->GetActorLocation();
 					}
+					int32 ResetCount = 0;
+					ASSERT_THAT(IsTrue(ReadAnimationHistoryResetCount(
+						State,
+						ResetCount)));
+					State.AnimationResetBaseline = ResetCount;
+					State.LastObservedAnimationResetDelta = MIN_int32;
+					State.AnimationResetStableStartTime = -1.0;
+					State.AnimationResetStableStartFrame = 0;
+				})
+			.ThenClients(
+				TEXT("Capture client animation-history baselines for correction"),
+				[this](FNetworkState& State)
+				{
+					int32 ResetCount = 0;
+					ASSERT_THAT(IsTrue(ReadAnimationHistoryResetCount(
+						State,
+						ResetCount)));
+					State.AnimationResetBaseline = ResetCount;
+					State.LastObservedAnimationResetDelta = MIN_int32;
+					State.AnimationResetStableStartTime = -1.0;
+					State.AnimationResetStableStartFrame = 0;
 				})
 			.ThenClient(
 				TEXT("Create an owner-only lateral prediction divergence"),
@@ -1038,33 +1352,60 @@ NETWORK_TEST_CLASS(GaspPilotPIE, "SurvivalRpg.Network")
 						State.SubjectPlayerId);
 					ASSERT_THAT(IsNotNull(Character));
 					const FVector DivergentLocation =
-						Character->GetActorLocation() + FVector(250.0, 0.0, 0.0);
+						Character->GetActorLocation() + FVector(100.0, 0.0, 0.0);
 					Character->SetActorLocation(
 						DivergentLocation,
 						false,
 						nullptr,
-						ETeleportType::TeleportPhysics);
+						ETeleportType::None);
 					ASSERT_THAT(IsTrue(FMath::Abs(
 						Character->GetActorLocation().X -
-						AuthorityCorrectionBaseline.X) > 150.0));
+							AuthorityCorrectionBaseline.X) > 60.0));
 					StartMovementInput(State, FVector::YAxisVector);
-					CorrectionStartTime = FPlatformTime::Seconds();
+				})
+			.UntilClient(
+				TEXT("Autonomous presentation observes the server correction"),
+				0,
+				[](FNetworkState& State)
+				{
+					return HasAnimationResetDeltaAtLeast(State, 1);
+				},
+				NetworkTimeout())
+			.ThenClient(
+				TEXT("Stop movement immediately after the owner correction"),
+				0,
+				[](FNetworkState& State)
+				{
+					StopMovementInput(State);
 				})
 			.UntilServer(
-				TEXT("Authority rejects the owner-only lateral displacement"),
+				TEXT("Authority settles after the owner correction"),
+				[](FNetworkState& State)
+				{
+					return HasStoppedAnimation(State);
+				},
+				NetworkTimeout())
+			.UntilClients(
+				TEXT("Client views settle after the owner correction"),
+				[](FNetworkState& State)
+				{
+					return HasStoppedAnimation(State);
+				},
+				NetworkTimeout())
+			.UntilServer(
+				TEXT("Authority remains on the server lane after correction"),
 				[this](FNetworkState& State)
 				{
 					ARpgCharacter* Character = FindCharacterByPlayerId(
 						State.World,
 						State.SubjectPlayerId);
-					return FPlatformTime::Seconds() - CorrectionStartTime >= 0.5 &&
-						Character && FMath::Abs(
-							Character->GetActorLocation().X -
-							AuthorityCorrectionBaseline.X) <= 50.0;
+					return Character && FMath::Abs(
+						Character->GetActorLocation().X -
+							AuthorityCorrectionBaseline.X) <= 10.0;
 				},
 				NetworkTimeout())
 			.UntilClient(
-				TEXT("Autonomous pawn reconverges to the server lane"),
+				TEXT("Autonomous pawn converges tightly to the server lane"),
 				0,
 				[this](FNetworkState& State)
 				{
@@ -1073,11 +1414,11 @@ NETWORK_TEST_CLASS(GaspPilotPIE, "SurvivalRpg.Network")
 						State.SubjectPlayerId);
 					return Character && FMath::Abs(
 						Character->GetActorLocation().X -
-						AuthorityCorrectionBaseline.X) <= 50.0;
+							AuthorityCorrectionBaseline.X) <= 10.0;
 				},
 				NetworkTimeout())
 			.UntilClient(
-				TEXT("Simulated proxy remains converged to authority"),
+				TEXT("Simulated proxy remains tightly converged to authority"),
 				1,
 				[this](FNetworkState& State)
 				{
@@ -1086,28 +1427,125 @@ NETWORK_TEST_CLASS(GaspPilotPIE, "SurvivalRpg.Network")
 						State.SubjectPlayerId);
 					return Character && FMath::Abs(
 						Character->GetActorLocation().X -
-						AuthorityCorrectionBaseline.X) <= 75.0;
+							AuthorityCorrectionBaseline.X) <= 10.0;
 				},
 				NetworkTimeout())
-			.ThenClient(
-				TEXT("Stop movement after correction"),
+			.UntilServer(
+				TEXT("Owner correction leaves authority history stable"),
+				[](FNetworkState& State)
+				{
+					return HasStableAnimationResetDelta(State, 0);
+				},
+				NetworkTimeout())
+			.UntilClient(
+				TEXT("Owner correction resets autonomous history exactly once"),
 				0,
 				[](FNetworkState& State)
 				{
-					StopMovementInput(State);
-				})
-			.UntilServer(
-				TEXT("Authority settles before the montage"),
+					return HasStableAnimationResetDelta(State, 1);
+				},
+				NetworkTimeout())
+			.UntilClient(
+				TEXT("Owner correction leaves simulated-proxy history stable"),
+				1,
 				[](FNetworkState& State)
 				{
-					return HasStoppedAnimation(State);
+					return HasStableAnimationResetDelta(State, 0);
+				},
+				NetworkTimeout())
+			.ThenServer(
+				TEXT("Assert the final authority correction reset count"),
+				[this](FNetworkState& State)
+				{
+					int32 ResetDelta = INDEX_NONE;
+					ASSERT_THAT(IsTrue(ReadAnimationHistoryResetDelta(
+						State,
+						ResetDelta)));
+					ASSERT_THAT(IsTrue(ResetDelta == 0));
+				})
+			.ThenClients(
+				TEXT("Assert the final client correction reset counts"),
+				[this](FNetworkState& State)
+				{
+					int32 ResetDelta = INDEX_NONE;
+					ASSERT_THAT(IsTrue(ReadAnimationHistoryResetDelta(
+						State,
+						ResetDelta)));
+					ASSERT_THAT(IsTrue(
+						ResetDelta == (State.ClientIndex == 0 ? 1 : 0)));
+				})
+			.ThenServer(
+				TEXT("Capture authority history before a semantic teleport"),
+				[this](FNetworkState& State)
+				{
+					int32 ResetCount = 0;
+					ASSERT_THAT(IsTrue(ReadAnimationHistoryResetCount(
+						State,
+						ResetCount)));
+					State.AnimationResetBaseline = ResetCount;
+					State.LastObservedAnimationResetDelta = MIN_int32;
+					State.AnimationResetStableStartTime = -1.0;
+					State.AnimationResetStableStartFrame = 0;
+				})
+			.ThenClients(
+				TEXT("Capture client histories before a semantic teleport"),
+				[this](FNetworkState& State)
+				{
+					int32 ResetCount = 0;
+					ASSERT_THAT(IsTrue(ReadAnimationHistoryResetCount(
+						State,
+						ResetCount)));
+					State.AnimationResetBaseline = ResetCount;
+					State.LastObservedAnimationResetDelta = MIN_int32;
+					State.AnimationResetStableStartTime = -1.0;
+					State.AnimationResetStableStartFrame = 0;
+				})
+			.ThenServer(
+				TEXT("Teleport the authoritative subject beyond the no-smoothing range"),
+				[this](FNetworkState& State)
+				{
+					ARpgCharacter* Character = FindCharacterByPlayerId(
+						State.World,
+						State.SubjectPlayerId);
+					ASSERT_THAT(IsNotNull(Character));
+					if (!Character)
+					{
+						return;
+					}
+					AuthorityTeleportTarget =
+						Character->GetActorLocation() + FVector(500.0, 0.0, 0.0);
+					ASSERT_THAT(IsTrue(Character->TeleportTo(
+						AuthorityTeleportTarget,
+						Character->GetActorRotation())));
+					Character->GetCharacterMovement()->StopMovementImmediately();
+					Character->ForceNetUpdate();
+				})
+			.UntilServer(
+				TEXT("Authority consumes the semantic teleport exactly once"),
+				[this](FNetworkState& State)
+				{
+					ARpgCharacter* Character = FindCharacterByPlayerId(
+						State.World,
+						State.SubjectPlayerId);
+					return Character &&
+						FVector::Dist2D(
+							Character->GetActorLocation(),
+							AuthorityTeleportTarget) <= 5.0 &&
+						HasStableAnimationResetDelta(State, 1);
 				},
 				NetworkTimeout())
 			.UntilClients(
-				TEXT("All client views settle before the montage"),
-				[](FNetworkState& State)
+				TEXT("Owner and simulated proxy consume the semantic teleport once"),
+				[this](FNetworkState& State)
 				{
-					return HasStoppedAnimation(State);
+					ARpgCharacter* Character = FindCharacterByPlayerId(
+						State.World,
+						State.SubjectPlayerId);
+					return Character &&
+						FVector::Dist2D(
+							Character->GetActorLocation(),
+							AuthorityTeleportTarget) <= 100.0 &&
+						HasStableAnimationResetDelta(State, 1);
 				},
 				NetworkTimeout())
 			.ThenServer(
@@ -1261,6 +1699,57 @@ NETWORK_TEST_CLASS(GaspPilotPIE, "SurvivalRpg.Network")
 						State.MontageConvergenceStartTime = Now;
 					}
 					return Now - State.MontageConvergenceStartTime >= 0.25;
+				},
+				NetworkTimeout())
+			.UntilServer(
+				TEXT("Authority settles before the stationary late join"),
+				[](FNetworkState& State)
+				{
+					return HasStoppedAnimation(State);
+				},
+				NetworkTimeout())
+			.UntilClients(
+				TEXT("Existing clients settle before the stationary late join"),
+				[](FNetworkState& State)
+				{
+					return HasStoppedAnimation(State);
+				},
+				NetworkTimeout())
+			.ThenClientJoins(NetworkTimeout())
+			.UntilServer(
+				TEXT("Stationary late join establishes the third server connection"),
+				[](FNetworkState& State)
+				{
+					return IsPilotExperienceReady(State, 3);
+				},
+				NetworkTimeout())
+			.UntilClient(
+				TEXT("Stationary late client loads the Pilot Experience and pawn"),
+				2,
+				[](FNetworkState& State)
+				{
+					return IsPilotExperienceReady(State, 3) &&
+						IsPilotCharacterReady(FindLocalCharacter(State.World));
+				},
+				NetworkTimeout())
+			.ThenClient(
+				TEXT("Bind the stationary subject in the final late-client world"),
+				2,
+				[this](FNetworkState& State)
+				{
+					State.SubjectPlayerId = SubjectPlayerId;
+				})
+			.UntilClient(
+				TEXT("Stationary late join reconstructs native zero input"),
+				2,
+				[](FNetworkState& State)
+				{
+					ARpgCharacter* Character = FindCharacterByPlayerId(
+						State.World,
+						State.SubjectPlayerId);
+					return Character &&
+						Character->GetLocalRole() == ROLE_SimulatedProxy &&
+						HasStoppedAnimation(State);
 				},
 				NetworkTimeout())
 			.ThenServer(

--- a/docs/gasp-network-smoke.md
+++ b/docs/gasp-network-smoke.md
@@ -3,7 +3,7 @@
 This runbook owns the reproducible PIE network acceptance for the isolated
 `RpgGaspPilotExperience`. It exercises the real Experience, PawnData, GASP character, AnimBP,
 CharacterMovement, Ability System Component, and replicated montage path without changing the
-default PawnData or adding production runtime behavior.
+default PawnData or introducing an alternate gameplay/runtime owner.
 
 ## Automated acceptance
 
@@ -14,20 +14,28 @@ Test:
 Topology and network profile:
 
 - one-process PIE listen server
-- one initial external client plus one external client joining during movement
-- the original subject is observed as Authority, AutonomousProxy, and late-join SimulatedProxy
+- one initial external client, one external client joining during movement, and one final external
+  client joining while the original subject is stationary
+- the original subject is observed as Authority, AutonomousProxy, and SimulatedProxy on both
+  late-join clients
 - `PktLag=60`, `PktLagVariance=10`, and no configured packet loss
 - one server-spawned editor-only floor fixture provides a shared network-addressable movement base
 
 The test verifies:
 
 - the pilot Experience and GASP pawn composition on every world
-- start, reversal/pivot, stop, and replicated acceleration reconstruction after late join
+- UE 5.8 `FRepMovement` acceleration plus `AnalogInputModifier` parity at 25%, 50%, and 100%
+  input, including the nonzero-to-zero stop edge
+- start, reversal/pivot, stop, and native acceleration reconstruction after moving and stationary
+  late join
 - grounded Foot Placement snapshot validity and the expected network roles
 - replicated Aim and CombatStrafe presentation modes
 - a deliberate 90-degree facing change activates and completes the turn-in-place lifecycle on all three views
 - crouch, physical jump, landing, and return to grounded presentation
-- owner-only movement divergence followed by server-authoritative correction and convergence
+- owner-only movement divergence followed by server-authoritative correction, tight convergence,
+  and exactly one autonomous presentation-history reset without authority/simulated-proxy resets
+- a semantic server teleport produces exactly one presentation-history reset on Authority,
+  AutonomousProxy, and SimulatedProxy
 - local-owner and authoritative ASC montage starts through `DefaultSlot`
 - replicated simulated-proxy montage playback, AnimInstance montage gating, authoritative root
   motion, montage completion, and stable client convergence
@@ -59,10 +67,11 @@ confirmation test.
 
 ## Visual smoke boundary
 
-The automation proves real replication, lifecycle state, movement correction, and montage/root
-motion plumbing. It cannot judge rendered pose choice or presentation quality. A rendered manual
-pass should still inspect start/stop/pivot/TIR, crouch, jump/landing, Foot Placement on uneven
-ground, Aim/CombatStrafe facing, and correction for persistent mesh/capsule separation.
+The automation proves real replication, analog movement intent, lifecycle state, movement-history
+reset plumbing, correction/teleport convergence, and montage/root-motion plumbing. It cannot judge
+rendered pose choice or presentation quality. A rendered manual pass should still inspect
+start/stop/pivot/TIR, crouch, jump/landing, Foot Placement on uneven ground, Aim/CombatStrafe facing,
+and correction for persistent mesh/capsule separation.
 
 This runbook does not claim gameplay-notify or attack-window reliability, ability costs/cooldowns,
 combos, equipment sockets, death/ragdoll presentation, packaged multi-process or Steam behavior,


### PR DESCRIPTION
## Summary

- replace the project-specific acceleration property with the character-scoped UE 5.8 `FRepMovement` acceleration path, so Simulated Proxies reconstruct both acceleration and `AnalogInputModifier`
- keep gameplay truth in CharacterMovement/capsule space while using one network-smoothed presentation frame for remote Pose Search, turn-in-place, aim, locomotion angles, and Foot Placement
- add persistent, role-aware presentation discontinuities for acknowledged owner corrections and semantic teleports, then reset trajectory, Motion Matching, turn, landing, jump, and Foot Placement history together
- extend the real PIE network acceptance with 25/50/100% input, the zero edge, moving and stationary late join, a role-correct owner correction, a semantic server teleport, and post-reset montage/root-motion coverage

## Root cause

The former custom Simulated-Proxy path restored only `Acceleration` after `Super::SimulateMovement`; UE's `AnalogInputModifier` therefore remained at full input and Pose Search predicted the wrong future speed for partial stick input. Presentation snapshots also mixed the corrected capsule transform with the network-smoothed mesh transform, while transient `bJustTeleported` and a project-local distance heuristic were used as animation-history reset signals.

The owner-correction implementation now follows UE 5.8's timestamp-aligned comparison: `LastAckedMove->SavedLocation` versus the server location for that acknowledged move. This was found during the lagged smoke when a client-now/server-past comparison produced repeated reset edges.

## Verification

- UE 5.8 `SurvivalRpgEditor Win64 Development` build: succeeded
- `SurvivalRpg.Animation`: 18/18 succeeded
- rendered D3D12/SM6 PIE network smoke at `PktLag=60`, `PktLagVariance=10`: succeeded twice consecutively
  - owner correction reset deltas: Authority `0`, AutonomousProxy `1`, SimulatedProxy `0`
  - semantic teleport reset deltas: Authority `1`, AutonomousProxy `1`, SimulatedProxy `1`
  - native acceleration/analog parity at 25%, 50%, and 100%, plus nonzero-to-zero
  - moving and stationary late join, DefaultSlot montage, authoritative root motion, and convergence

Local reports:

- `Saved/Automation/GaspSimProxyTrajectoryAnimationFinal`
- `Saved/Automation/GaspSimProxyTrajectoryNetworkFinal3`
- `Saved/Automation/GaspSimProxyTrajectoryNetworkRepeat`

## Evidence boundary and ordering

This PR builds on the merged #81 baseline from #96. Final packaged multi-process/cutover acceptance remains tracked by #55, and remote predicted combat/notify reliability remains tracked by #57. Packet loss, relevancy return, Steam, rendered bone-pose quality, the default PawnData cutover, and the authoritative Sprint lifecycle from #62 are outside this slice.

Possession role changes and selected Pose Search assets are not directly asserted by this test. The role-reset path, native movement snapshot, RotationMode, turn lifecycle, and montage/root-motion seams are covered; visual pose quality remains a manual #55 gate.

Closes #97

Related: #70, #55, #57, #62
