### PR TITLE
Fix GASP coast gait reconstruction for late join

### DIFF
--- a/Plugins/RpgGaspLocomotion/Docs/README.md
+++ b/Plugins/RpgGaspLocomotion/Docs/README.md
@@ -5,11 +5,11 @@ This content-only plugin owns the curated Game Animation Sample Project (GASP) l
 The behavior-preserving source-to-project responsibility map and the staged issue #81 extraction
 order are recorded in [RuntimeOwnershipMap.md](RuntimeOwnershipMap.md).
 
-Issues #81 and #97's real listen-server acceptance procedure is recorded in
+Issues #81, #97, #100, and #101's real listen-server acceptance procedure is recorded in
 [the GASP real-network smoke runbook](../../../docs/gasp-network-smoke.md). It uses an actual PIE
-network session with one initial client plus moving and stationary late joins; rendered
-pose-selection, warping, Foot Placement, and correction quality remain a separate visual
-inspection boundary.
+network session with native acceleration, analog gait prediction/correction, moving and stationary
+late joins, Walk/Run coast late joins, and actor-channel relevancy return; rendered pose-selection,
+warping, Foot Placement, and correction quality remain a separate visual inspection boundary.
 
 ## Curated slice
 
@@ -52,7 +52,7 @@ The complete source-to-target mapping and cleanup policy is recorded in `Curated
 
 `DA_PawnData_GASP` opts into the project-local `FRpgCharacterMovementProfile`; the prototype PawnData explicitly remains opt-out, so its Blueprint-authored CharacterMovement values and the independently selectable Prototype Experience are unchanged. For standing, uncrouched ground movement, `URpgCharacterMovementComponent` resolves the physical input before both ground physics and SavedMove capture: magnitudes at or below `0.10` become zero, while `0.11`, `0.25`, `0.50`, and every other value above the deadzone keep their original analog magnitude without renormalization, apart from CharacterMovement's native `NetQuantize10` precision. Crouching, falling, and custom movement modes retain their legacy input response.
 
-The prediction-owned desired gait enters Run at input `>= 0.70`, retains Run at `>= 0.65`, and exits to Walk only below `0.65`. One CharacterMovement SavedMove `Custom0` flag stores that gait and restores it before authoritative server movement and client replay, so the selected 200/500 forward cap follows the same state through prediction, correction, and move combining. Simulated proxies do not receive the owner's SavedMove flag; they reconstruct the continuous hysteresis state from replicated acceleration. A proxy that is first observed directly inside the `0.65`-to-`0.70` hysteresis band remains an intentionally ambiguous late-join case deferred to issue #101.
+The prediction-owned desired gait enters Run at input `>= 0.70`, retains Run at `>= 0.65`, and exits to Walk only below `0.65`. One CharacterMovement SavedMove `Custom0` flag stores that gait and restores it before authoritative server movement and client replay, so the selected 200/500 forward cap follows the same state through prediction, correction, and move combining. Simulated proxies do not receive the owner's SavedMove flag; they reconstruct active-input gait from replicated acceleration. During inputless Walk/Run coast, the authority publishes one current gait classification with `COND_SimulatedOnly`; a new or newly relevant proxy consumes it before local gait history and therefore preserves Run even below the Walk cap. The value clears to Idle at physical stop and never carries AnimBP, pose, Motion Matching, or movement history. A proxy first observed with active input directly inside the `0.65`-to-`0.70` retention band remains a separate ambiguity outside issue #101.
 
 The profile retains GASP's forward/side/back source values and pure direction mapping as a validated contract, but #99 deliberately activates only the 200/500 forward caps: predicted rotation-request tags are not yet part of CharacterMovement saved moves, so making physical speed depend on controller-facing mode would create correction risk. `URpgAnimInstance` consumes the prepared CMC gait and never reclassifies Walk/Run from a cosmetic presentation threshold. Sprint and prediction-safe directional strafe caps remain separate gameplay slices.
 

--- a/Plugins/RpgGaspLocomotion/Docs/RuntimeOwnershipMap.md
+++ b/Plugins/RpgGaspLocomotion/Docs/RuntimeOwnershipMap.md
@@ -25,6 +25,7 @@ the sample project a runtime dependency.
 | --- | --- | --- | --- |
 | `Update_PropertiesFromCharacter`, `Update_EssentialValues` | `InitializeWithAbilitySystem` for the ASC/tag map; `FRpgAnimInstanceProxy::PreUpdate` for the value snapshot | Existing ASC lifecycle plus proxy snapshot boundary | ASC delegates are initialized on the game thread. `PreUpdate` copies mirrored tag booleans and reads CharacterMovement/world state; no sample character hierarchy is imported. |
 | Character acceleration replication and analog trajectory intent | `ARpgCharacter::ShouldReplicateAcceleration`, UE 5.8 `FRepMovement`, and base `UCharacterMovementComponent::UpdateProxyAcceleration` | The same character-scoped engine path | The project opts only RPG characters into UE 5.8's native acceleration payload. Simulated proxies reconstruct both acceleration and `AnalogInputModifier`; there is no parallel custom acceleration property and no project-wide CVar override. |
+| Walk/Run prediction and inputless coast reconstruction | `URpgCharacterMovementComponent` `DesiredGait`/`GroundGait`, SavedMove `Custom0`, and `ARpgCharacter::GroundCoastGait` | CharacterMovement truth plus a narrow character replication bridge | Authority/autonomous prediction remains SavedMove-owned. Simulated proxies use replicated acceleration while input is active and the simulated-only semantic coast enum only while input is zero. Idle clears at physical stop; no pose, Pose History, Motion Matching, or AnimBP state replicates. |
 | Network correction and semantic-teleport presentation resets | `URpgCharacterMovementComponent` local discontinuity serial, `ARpgCharacter` teleport epoch, and proxy `PreUpdate` | Existing Character/CharacterMovement authority plus one local presentation edge | Autonomous corrections compare the server location with the saved client location at the same acknowledged timestamp. Ordinary simulated-proxy smoothing never resets history; only semantic teleports or corrections beyond UE's no-smoothing range do. The AnimInstance no longer treats transient `bJustTeleported` as a durable network event. |
 | `Update_Trajectory` | Proxy `PreUpdate` orchestrates `PoseSearchGenerateTransformTrajectory`; `RpgPoseSearchTrajectory` owns its sampling constants and validation/correction helpers | Same split: proxy owns generation and snapshot lifetime; focused native helper owns the sampling/correction mechanism | Controller-yaw extrapolation is disabled for the controller-facing project character; raw history stays separate from worker-facing corrected output. |
 | `HandleTransformTrajectoryWorldCollisions` | `RpgPoseSearchTrajectory::ResolveWorldCollision` | Focused game-thread trajectory helper | Uses bounded sphere sweeps, CharacterMovement walkability, explicit validity, floor projection, and a pointer-free landing prediction. It never changes movement or touchdown authority. |
@@ -260,3 +261,25 @@ families, Sprint authority, combat polish, and default PawnData cutover are sepa
   selection, warping, IK quality, gameplay-notify behavior, packaged multi-process networking,
   combat/death/ragdoll behavior, performance, and default cutover remain separate gates. See
   [the network smoke runbook](../../../docs/gasp-network-smoke.md).
+
+## Issue #101 coast-gait replication boundary
+
+- **Authoritative truth:** CharacterMovement resolves Walk/Run from prediction-owned intent while
+  input is active. During inputless physical coast, `ARpgCharacter` stores only the authority's
+  current `Idle/Walk/Run` coast classification.
+- **Replication:** `GroundCoastGait` uses `COND_SimulatedOnly` plus RepNotify. The movement component
+  consumes Walk/Run only for an active standing-ground GASP profile with zero move intent; stop,
+  non-ground movement, and profile opt-out resolve and replicate Idle.
+- **Lifecycle:** a newly created or newly relevant proxy consumes the current coast classification
+  before local history or residual-speed fallback, so Run remains Run below the Walk cap. The hint
+  survives PawnData/profile application ordering and clears deterministically at physical stop.
+- **Presentation boundary:** no AnimBP, Pose Search, Motion Matching, SavedMove, montage, or movement
+  history is replicated. `URpgAnimInstance` continues to consume the prepared CMC gait through its
+  existing worker-thread-safe snapshot.
+- **Experience boundary:** no content asset changes are required. `DA_PawnData_GASP` opts into the
+  mechanism; the prototype PawnData remains opt-out and both Experiences remain independently
+  selectable.
+- **Stable test:**
+  `SurvivalRpg.Network.GaspPilotPIE.GroundCoastLateJoinAndRelevancyReturn` protects Walk and Run
+  late join, Run coast below the Walk cap, real relevancy loss/recreation/return, role parity, and
+  deterministic stop clearing in a rendered listen-server PIE session.

--- a/Source/SurvivalRpg/Core/Character/RpgCharacter.cpp
+++ b/Source/SurvivalRpg/Core/Character/RpgCharacter.cpp
@@ -497,6 +497,11 @@ void ARpgCharacter::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLif
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 
 	DOREPLIFETIME_CONDITION(ThisClass, AnimationTeleportEpoch, COND_SimulatedOnly);
+	DOREPLIFETIME_CONDITION_NOTIFY(
+		ThisClass,
+		GroundCoastGait,
+		COND_SimulatedOnly,
+		REPNOTIFY_Always);
 	DOREPLIFETIME_CONDITION_NOTIFY(ThisClass, RotationMode, COND_None, REPNOTIFY_Always);
 }
 
@@ -511,6 +516,36 @@ void ARpgCharacter::OnRep_AnimationTeleportEpoch()
 		Cast<URpgCharacterMovementComponent>(GetCharacterMovement()))
 	{
 		MovementComponent->NotifyReplicatedAnimationTeleport();
+	}
+}
+
+void ARpgCharacter::OnRep_GroundCoastGait()
+{
+	if (URpgCharacterMovementComponent* MovementComponent =
+		Cast<URpgCharacterMovementComponent>(GetCharacterMovement()))
+	{
+		MovementComponent->NotifyReplicatedGroundCoastGait(GroundCoastGait);
+	}
+}
+
+void ARpgCharacter::SetAuthoritativeGroundCoastGait(
+	ERpgLocomotionGait NewCoastGait)
+{
+	if (!HasAuthority())
+	{
+		return;
+	}
+
+	if (NewCoastGait != ERpgLocomotionGait::Walk &&
+		NewCoastGait != ERpgLocomotionGait::Run)
+	{
+		NewCoastGait = ERpgLocomotionGait::Idle;
+	}
+
+	if (GroundCoastGait != NewCoastGait)
+	{
+		GroundCoastGait = NewCoastGait;
+		ForceNetUpdate();
 	}
 }
 

--- a/Source/SurvivalRpg/Core/Character/RpgCharacter.h
+++ b/Source/SurvivalRpg/Core/Character/RpgCharacter.h
@@ -7,6 +7,7 @@
 #include "ModularCharacter.h"
 #include "GameFramework/Character.h"
 #include "RpgDownedComponent.h"
+#include "RpgCharacterMovementProfile.h"
 #include "RpgCharacterRotationMode.h"
 #include "RpgCharacter.generated.h"
 
@@ -181,6 +182,20 @@ private:
 	UFUNCTION()
 	void OnRep_AnimationTeleportEpoch();
 
+	/**
+	 * Current authority-owned Walk/Run coast classification for simulated proxies.
+	 * Idle means no coast; this is semantic movement state, not replicated pose or AnimBP history.
+	 */
+	UPROPERTY(Transient, ReplicatedUsing = OnRep_GroundCoastGait)
+	ERpgLocomotionGait GroundCoastGait = ERpgLocomotionGait::Idle;
+
+	/** Applies the current coast classification to the local CharacterMovement resolver. */
+	UFUNCTION()
+	void OnRep_GroundCoastGait();
+
+	/** Updates the simulated-proxy coast contract on authority and forces its transition onto the actor channel. */
+	void SetAuthoritativeGroundCoastGait(ERpgLocomotionGait NewCoastGait);
+
 	/** ASC whose rotation request-tag delegates are currently registered. */
 	TWeakObjectPtr<URpgAbilitySystemComponent> RotationModeAbilitySystem;
 
@@ -190,6 +205,8 @@ private:
 	/** Last policy applied to CharacterMovement, used to detect Free-to-controller-facing transitions. */
 	ERpgCharacterRotationMode LastAppliedRotationMode = ERpgCharacterRotationMode::CombatStrafe;
 	bool bHasAppliedRotationPolicy = false;
+
+	friend class URpgCharacterMovementComponent;
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Rpg|Character", Meta = (AllowPrivateAccess = "true"))
 	TObjectPtr<URpgPawnExtensionComponent> PawnExtensionComponent;

--- a/Source/SurvivalRpg/Core/Character/RpgCharacterMovementComponent.cpp
+++ b/Source/SurvivalRpg/Core/Character/RpgCharacterMovementComponent.cpp
@@ -8,6 +8,7 @@
 #include "Components/CapsuleComponent.h"
 #include "NativeGameplayTags.h"
 #include "GameFramework/Character.h"
+#include "RpgCharacter.h"
 
 
 UE_DEFINE_GAMEPLAY_TAG(TAG_Gameplay_MovementStopped, "Gameplay.MovementStopped");
@@ -313,6 +314,17 @@ void URpgCharacterMovementComponent::UpdateCharacterStateBeforeMovement(float De
 	RefreshLocomotionSnapshot();
 }
 
+void URpgCharacterMovementComponent::OnMovementModeChanged(
+	EMovementMode PreviousMovementMode,
+	uint8 PreviousCustomMode)
+{
+	Super::OnMovementModeChanged(PreviousMovementMode, PreviousCustomMode);
+	if (!UsesStandingGroundMovementProfile())
+	{
+		ClearGroundCoastState();
+	}
+}
+
 void URpgCharacterMovementComponent::OnMovementUpdated(
 	float DeltaSeconds,
 	const FVector& OldLocation,
@@ -375,7 +387,24 @@ void URpgCharacterMovementComponent::RefreshLocomotionSnapshot()
 		PhysicalInputMagnitude,
 		DesiredGait,
 		GroundGait,
+		CharacterOwner && CharacterOwner->GetLocalRole() == ROLE_SimulatedProxy
+			? ReplicatedGroundCoastGait
+			: ERpgLocomotionGait::Idle,
 		MovementProfile);
+
+	if (ARpgCharacter* RpgCharacter = Cast<ARpgCharacter>(CharacterOwner);
+		RpgCharacter && RpgCharacter->HasAuthority())
+	{
+		const ERpgLocomotionGait AuthoritativeCoastGait =
+			MovementProfile.bOverrideCharacterMovement &&
+			UsesStandingGroundMovementProfile() &&
+			!bHasMoveIntent &&
+			(GroundGait == ERpgLocomotionGait::Walk ||
+			 GroundGait == ERpgLocomotionGait::Run)
+				? GroundGait
+				: ERpgLocomotionGait::Idle;
+		RpgCharacter->SetAuthoritativeGroundCoastGait(AuthoritativeCoastGait);
+	}
 }
 
 void URpgCharacterMovementComponent::OnTeleported()
@@ -384,9 +413,36 @@ void URpgCharacterMovementComponent::OnTeleported()
 	MarkAnimationDiscontinuity();
 }
 
+void URpgCharacterMovementComponent::StopMovementImmediately()
+{
+	Super::StopMovementImmediately();
+	ClearGroundCoastState();
+}
+
+void URpgCharacterMovementComponent::ClearGroundCoastState()
+{
+	GroundGait = ERpgLocomotionGait::Idle;
+	if (ARpgCharacter* RpgCharacter = Cast<ARpgCharacter>(CharacterOwner);
+		RpgCharacter && RpgCharacter->HasAuthority())
+	{
+		RpgCharacter->SetAuthoritativeGroundCoastGait(
+			ERpgLocomotionGait::Idle);
+	}
+}
+
 void URpgCharacterMovementComponent::NotifyReplicatedAnimationTeleport()
 {
 	MarkAnimationDiscontinuity();
+}
+
+void URpgCharacterMovementComponent::NotifyReplicatedGroundCoastGait(
+	ERpgLocomotionGait NewCoastGait)
+{
+	ReplicatedGroundCoastGait =
+		NewCoastGait == ERpgLocomotionGait::Walk ||
+		NewCoastGait == ERpgLocomotionGait::Run
+			? NewCoastGait
+			: ERpgLocomotionGait::Idle;
 }
 
 void URpgCharacterMovementComponent::OnClientCorrectionReceived(

--- a/Source/SurvivalRpg/Core/Character/RpgCharacterMovementComponent.h
+++ b/Source/SurvivalRpg/Core/Character/RpgCharacterMovementComponent.h
@@ -74,7 +74,14 @@ public:
 	/** Applies the server's semantic teleport edge on a simulated proxy. */
 	void NotifyReplicatedAnimationTeleport();
 
+	/** Stores the authority's current Walk/Run coast classification for late join and relevancy return. */
+	void NotifyReplicatedGroundCoastGait(ERpgLocomotionGait NewCoastGait);
+
+	/** Returns the local simulated-proxy coast hint; Idle means no authority coast is active. */
+	ERpgLocomotionGait GetReplicatedGroundCoastGait() const { return ReplicatedGroundCoastGait; }
+
 	//~UMovementComponent interface
+	virtual void StopMovementImmediately() override;
 	virtual void OnTeleported() override;
 	//~End of UMovementComponent interface
 
@@ -98,6 +105,9 @@ protected:
 		float Friction,
 		bool bFluid,
 		float BrakingDeceleration) override;
+	virtual void OnMovementModeChanged(
+		EMovementMode PreviousMovementMode,
+		uint8 PreviousCustomMode) override;
 	virtual void UpdateCharacterStateBeforeMovement(float DeltaSeconds) override;
 	virtual void OnMovementUpdated(
 		float DeltaSeconds,
@@ -127,6 +137,9 @@ protected:
 	/** Rebuilds the value-only move-intent and gait snapshot after CharacterMovement updates. */
 	void RefreshLocomotionSnapshot();
 
+	/** Clears local ground presentation and the authority transport without discarding a received proxy hint. */
+	void ClearGroundCoastState();
+
 	/** Restores the physical Run latch encoded by a server move or client replay. */
 	void RestorePredictedGaitFromSavedMove(bool bSavedRunGait);
 
@@ -153,6 +166,9 @@ protected:
 
 	/** Current deadzone-resolved physical CMC input used by the GASP braking contract. */
 	bool bHasMovementInput = false;
+
+	/** Simulated-proxy-only semantic coast hint received from the authoritative character. */
+	ERpgLocomotionGait ReplicatedGroundCoastGait = ERpgLocomotionGait::Idle;
 
 	// Cached ground info for the character.  Do not access this directly!  It's only updated when accessed via GetGroundInfo().
 	FRpgCharacterGroundInfo CachedGroundInfo;

--- a/Source/SurvivalRpg/Core/Character/RpgCharacterMovementProfile.cpp
+++ b/Source/SurvivalRpg/Core/Character/RpgCharacterMovementProfile.cpp
@@ -179,6 +179,7 @@ ERpgLocomotionGait RpgCharacterMovementRuntime::ResolveGroundGait(
 	float InputMagnitude,
 	ERpgLocomotionGait DesiredGait,
 	ERpgLocomotionGait PreviousGait,
+	ERpgLocomotionGait CoastGaitHint,
 	const FRpgCharacterMovementProfile& Profile)
 {
 	if (!bIsMovingOnGround ||
@@ -204,6 +205,15 @@ ERpgLocomotionGait RpgCharacterMovementRuntime::ResolveGroundGait(
 			: ERpgLocomotionGait::Walk;
 	}
 
+	// The authority publishes only the current Walk/Run coast classification. Prefer it
+	// over local history so a newly relevant proxy and an existing proxy converge alike.
+	if (Profile.bOverrideCharacterMovement &&
+		(CoastGaitHint == ERpgLocomotionGait::Walk ||
+		 CoastGaitHint == ERpgLocomotionGait::Run))
+	{
+		return CoastGaitHint;
+	}
+
 	// Preserve the moving database while physical deceleration finishes after input release.
 	if (PreviousGait == ERpgLocomotionGait::Walk)
 	{
@@ -214,7 +224,8 @@ ERpgLocomotionGait RpgCharacterMovementRuntime::ResolveGroundGait(
 		return ERpgLocomotionGait::Run;
 	}
 
-	// Active GASP profiles seed late-join stop presentation from replicated physical speed.
+	// A speed fallback keeps malformed or delayed initial snapshots deterministic. The
+	// authoritative coast hint replaces this ambiguity as soon as it arrives.
 	return GroundSpeed <= Profile.WalkSpeeds.Forward
 		? ERpgLocomotionGait::Walk
 		: ERpgLocomotionGait::Run;

--- a/Source/SurvivalRpg/Core/Character/RpgCharacterMovementProfile.h
+++ b/Source/SurvivalRpg/Core/Character/RpgCharacterMovementProfile.h
@@ -172,12 +172,16 @@ namespace RpgCharacterMovementRuntime
 		bool bHasMovementInput,
 		const FRpgCharacterMovementProfile& Profile);
 
-	/** Resolves a stable grounded Idle/Walk/Run gait; deceleration retains the previous moving gait. */
+	/**
+	 * Resolves a stable grounded Idle/Walk/Run gait.
+	 * Deceleration retains local history, while a server coast hint reconstructs newly relevant simulated proxies.
+	 */
 	SURVIVALRPG_API ERpgLocomotionGait ResolveGroundGait(
 		bool bIsMovingOnGround,
 		float GroundSpeed,
 		float InputMagnitude,
 		ERpgLocomotionGait DesiredGait,
 		ERpgLocomotionGait PreviousGait,
+		ERpgLocomotionGait CoastGaitHint,
 		const FRpgCharacterMovementProfile& Profile);
 }

--- a/Source/SurvivalRpgEditor/Private/Character/RpgCharacterMovementProfileTests.cpp
+++ b/Source/SurvivalRpgEditor/Private/Character/RpgCharacterMovementProfileTests.cpp
@@ -9,6 +9,7 @@
 #include "Components/SceneComponent.h"
 #include "Misc/AutomationTest.h"
 #include "Tests/AutomationCommon.h"
+#include "UObject/UnrealType.h"
 #include "SurvivalRpg/Core/Character/RpgCharacter.h"
 #include "SurvivalRpg/Core/Character/RpgCharacterMovementComponent.h"
 #include "SurvivalRpg/Core/Character/RpgCharacterMovementProfile.h"
@@ -83,9 +84,73 @@ bool FRpgCharacterMovementProfileTest::RunTest(const FString& Parameters)
 				GaitCase.InputMagnitude,
 				GaitCase.DesiredGait,
 				GaitCase.PreviousGait,
+				ERpgLocomotionGait::Idle,
 				Profile),
 			GaitCase.ExpectedGait);
 	}
+
+	struct FCoastHintCase
+	{
+		const TCHAR* Label;
+		float GroundSpeed;
+		ERpgLocomotionGait PreviousGait;
+		ERpgLocomotionGait CoastGaitHint;
+		ERpgLocomotionGait ExpectedGait;
+	};
+	const FCoastHintCase CoastHintCases[] = {
+		{TEXT("Late Run coast remains Run above the Walk cap"), 300.0f, ERpgLocomotionGait::Idle, ERpgLocomotionGait::Run, ERpgLocomotionGait::Run},
+		{TEXT("Late Run coast remains Run on the Walk cap"), 200.0f, ERpgLocomotionGait::Idle, ERpgLocomotionGait::Run, ERpgLocomotionGait::Run},
+		{TEXT("Late Run coast remains Run below the Walk cap"), 150.0f, ERpgLocomotionGait::Idle, ERpgLocomotionGait::Run, ERpgLocomotionGait::Run},
+		{TEXT("Late Walk coast remains Walk"), 150.0f, ERpgLocomotionGait::Idle, ERpgLocomotionGait::Walk, ERpgLocomotionGait::Walk},
+		{TEXT("Relevancy return replaces stale local gait history"), 150.0f, ERpgLocomotionGait::Walk, ERpgLocomotionGait::Run, ERpgLocomotionGait::Run},
+		{TEXT("Physical stop wins over a stale Run coast hint"), 2.0f, ERpgLocomotionGait::Run, ERpgLocomotionGait::Run, ERpgLocomotionGait::Idle},
+	};
+	for (const FCoastHintCase& CoastHintCase : CoastHintCases)
+	{
+		TestEqual(
+			CoastHintCase.Label,
+			RpgCharacterMovementRuntime::ResolveGroundGait(
+				true,
+				CoastHintCase.GroundSpeed,
+				0.0f,
+				ERpgLocomotionGait::Idle,
+				CoastHintCase.PreviousGait,
+				CoastHintCase.CoastGaitHint,
+				Profile),
+			CoastHintCase.ExpectedGait);
+	}
+
+	TestEqual(
+		TEXT("Physical input ignores a stale Run coast hint"),
+		RpgCharacterMovementRuntime::ResolveGroundGait(
+			true,
+			150.0f,
+			0.5f,
+			ERpgLocomotionGait::Walk,
+			ERpgLocomotionGait::Run,
+			ERpgLocomotionGait::Run,
+			Profile),
+		ERpgLocomotionGait::Walk);
+	FRpgCharacterMovementProfile PassiveCoastProfile = Profile;
+	PassiveCoastProfile.bOverrideCharacterMovement = false;
+	TestEqual(
+		TEXT("A passive movement profile ignores the coast hint"),
+		RpgCharacterMovementRuntime::ResolveGroundGait(
+			true,
+			150.0f,
+			0.0f,
+			ERpgLocomotionGait::Idle,
+			ERpgLocomotionGait::Idle,
+			ERpgLocomotionGait::Walk,
+			PassiveCoastProfile),
+		RpgCharacterMovementRuntime::ResolveGroundGait(
+			true,
+			150.0f,
+			0.0f,
+			ERpgLocomotionGait::Idle,
+			ERpgLocomotionGait::Idle,
+			ERpgLocomotionGait::Idle,
+			PassiveCoastProfile));
 
 	TestFalse(
 		TEXT("Input at the exclusive intent threshold has no move intent"),
@@ -439,6 +504,69 @@ bool FRpgCharacterMovementProfileTest::RunTest(const FString& Parameters)
 }
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FRpgCharacterGroundCoastReplicationContractTest,
+	"SurvivalRpg.Character.Movement.GroundCoastReplicationContract",
+	EAutomationTestFlags::EditorContext |
+		EAutomationTestFlags::EngineFilter)
+
+bool FRpgCharacterGroundCoastReplicationContractTest::RunTest(
+	const FString& Parameters)
+{
+	const FProperty* CoastGaitProperty =
+		ARpgCharacter::StaticClass()->FindPropertyByName(TEXT("GroundCoastGait"));
+	TestNotNull(
+		TEXT("Character exposes reflected ground-coast state"),
+		CoastGaitProperty);
+	if (CoastGaitProperty)
+	{
+		TestTrue(
+			TEXT("Ground-coast state participates in actor replication"),
+			CoastGaitProperty->HasAnyPropertyFlags(CPF_Net));
+		TestEqual(
+			TEXT("Ground-coast state reconciles through its RepNotify"),
+			CoastGaitProperty->RepNotifyFunc,
+			FName(TEXT("OnRep_GroundCoastGait")));
+	}
+
+	URpgCharacterMovementComponent* MovementComponent =
+		NewObject<URpgCharacterMovementComponent>();
+	TestNotNull(TEXT("Movement component can store a coast hint"), MovementComponent);
+	if (MovementComponent)
+	{
+		MovementComponent->NotifyReplicatedGroundCoastGait(
+			ERpgLocomotionGait::Run);
+		TestEqual(
+			TEXT("Run is retained as a valid replicated coast hint"),
+			MovementComponent->GetReplicatedGroundCoastGait(),
+			ERpgLocomotionGait::Run);
+
+		FRpgCharacterMovementProfile ActiveProfile;
+		ActiveProfile.bOverrideCharacterMovement = true;
+		TestTrue(
+			TEXT("Applying PawnData movement tuning does not discard an earlier RepNotify"),
+			MovementComponent->ApplyMovementProfile(ActiveProfile));
+		TestEqual(
+			TEXT("A pre-PawnData coast hint survives movement-profile initialization"),
+			MovementComponent->GetReplicatedGroundCoastGait(),
+			ERpgLocomotionGait::Run);
+		MovementComponent->StopMovementImmediately();
+		TestEqual(
+			TEXT("A local stop never discards the authority hint cached by a simulated proxy"),
+			MovementComponent->GetReplicatedGroundCoastGait(),
+			ERpgLocomotionGait::Run);
+
+		MovementComponent->NotifyReplicatedGroundCoastGait(
+			ERpgLocomotionGait::Sprint);
+		TestEqual(
+			TEXT("Unsupported Sprint never enters the replicated coast contract"),
+			MovementComponent->GetReplicatedGroundCoastGait(),
+			ERpgLocomotionGait::Idle);
+	}
+
+	return !HasAnyErrors();
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 	FRpgCharacterMovementSavedMoveTest,
 	"SurvivalRpg.Character.Movement.SavedMovePrediction",
 	EAutomationTestFlags::EditorContext |
@@ -499,6 +627,56 @@ bool FRpgCharacterMovementSavedMoveTest::RunTest(const FString& Parameters)
 	{
 		return false;
 	}
+	MovementComponent->SetMovementMode(MOVE_Walking);
+	const FEnumProperty* CoastGaitProperty =
+		FindFProperty<FEnumProperty>(
+			ARpgCharacter::StaticClass(),
+			TEXT("GroundCoastGait"));
+	if (!TestNotNull(
+		TEXT("The authority coast transport is available for lifecycle checks"),
+		CoastGaitProperty))
+	{
+		return false;
+	}
+	auto ReadAuthorityCoastGait = [Character, CoastGaitProperty]()
+	{
+		const void* ValueAddress =
+			CoastGaitProperty->ContainerPtrToValuePtr<void>(Character);
+		return static_cast<ERpgLocomotionGait>(
+			CoastGaitProperty->GetUnderlyingProperty()
+				->GetSignedIntPropertyValue(ValueAddress));
+	};
+	auto SeedAuthorityRunCoast = [MovementComponent]()
+	{
+		MovementComponent->Velocity = FVector(150.0f, 0.0f, 0.0f);
+		MovementComponent->Acceleration = FVector::ZeroVector;
+		MovementComponent->AnalogInputModifier = 0.0f;
+		MovementComponent->DesiredGait = ERpgLocomotionGait::Idle;
+		MovementComponent->GroundGait = ERpgLocomotionGait::Run;
+		MovementComponent->RefreshLocomotionSnapshot();
+	};
+
+	SeedAuthorityRunCoast();
+	TestEqual(
+		TEXT("Authority publishes Run while a physical Run coast is active"),
+		ReadAuthorityCoastGait(),
+		ERpgLocomotionGait::Run);
+	MovementComponent->StopMovementImmediately();
+	TestEqual(
+		TEXT("Synchronous stop clears local grounded presentation"),
+		MovementComponent->GetGroundGait(),
+		ERpgLocomotionGait::Idle);
+	TestEqual(
+		TEXT("Synchronous stop clears the authority coast transport"),
+		ReadAuthorityCoastGait(),
+		ERpgLocomotionGait::Idle);
+
+	SeedAuthorityRunCoast();
+	MovementComponent->DisableMovement();
+	TestEqual(
+		TEXT("Leaving standing-ground movement clears the authority coast transport"),
+		ReadAuthorityCoastGait(),
+		ERpgLocomotionGait::Idle);
 	MovementComponent->SetMovementMode(MOVE_Walking);
 	MovementComponent->DesiredGait = ERpgLocomotionGait::Run;
 	MovementComponent->Acceleration = FVector(560.0f, 0.0f, 0.0f);

--- a/Source/SurvivalRpgEditor/Private/Network/RpgGaspPIENetworkTests.cpp
+++ b/Source/SurvivalRpgEditor/Private/Network/RpgGaspPIENetworkTests.cpp
@@ -52,6 +52,16 @@ namespace RpgGaspPIENetworkTests
 		float StableInputScale = -1.0f;
 		ERpgLocomotionGait StableInputGait = ERpgLocomotionGait::Idle;
 		double StableInputStartTime = 0.0;
+		ERpgLocomotionGait StableCoastGait = ERpgLocomotionGait::Idle;
+		ENetRole StableCoastRole = ROLE_None;
+		bool bStableCoastBelowWalkCap = false;
+		double StableCoastStartTime = 0.0;
+		TWeakObjectPtr<ARpgCharacter> StableCoastSubject;
+		double LastCoastDiagnosticTime = -1.0;
+		FRpgCharacterMovementProfile BaselineCoastProfile;
+		bool bHasBaselineCoastProfile = false;
+		float BaselineSubjectNetCullDistanceSquared = 0.0f;
+		bool bHasBaselineSubjectNetCullDistanceSquared = false;
 		float StableDeadzoneInputScale = -1.0f;
 		double PhysicalDeadzoneStableStartTime = -1.0;
 		FVector PhysicalDeadzoneAnchorLocation = FVector::ZeroVector;
@@ -77,6 +87,7 @@ namespace RpgGaspPIENetworkTests
 		double TurnObservationBaselineYaw = 0.0;
 		bool bSawDefaultSlotMontage = false;
 		bool bSawMontageAnimGate = false;
+		TWeakObjectPtr<ARpgCharacter> SubjectBeforeRelevancyLoss;
 	};
 
 	TArray<FNetworkState*> ActiveTimerStates;
@@ -201,6 +212,28 @@ namespace RpgGaspPIENetworkTests
 		return true;
 	}
 
+	template <typename TValue>
+	bool ReadObjectProperty(
+		const UObject* Object,
+		const FName PropertyName,
+		TValue& OutValue)
+	{
+		if (!IsValid(Object))
+		{
+			return false;
+		}
+
+		FProperty* Property = FindFProperty<FProperty>(Object->GetClass(), PropertyName);
+		if (!Property || Property->GetSize() != sizeof(TValue))
+		{
+			return false;
+		}
+
+		const void* Source = Property->ContainerPtrToValuePtr<void>(Object);
+		Property->CopyCompleteValue(&OutValue, Source);
+		return true;
+	}
+
 	bool IsPilotExperienceReady(FNetworkState& State, const int32 ExpectedClients)
 	{
 		if (!IsValid(State.World))
@@ -320,6 +353,7 @@ namespace RpgGaspPIENetworkTests
 		float GroundSpeed = 0.0f;
 		bool bHasAcceleration = true;
 		ERpgLocomotionGait AnimGait = ERpgLocomotionGait::Run;
+		ERpgLocomotionGait CharacterCoastGait = ERpgLocomotionGait::Run;
 		const bool bHasNativeZeroSnapshot =
 			Character->GetLocalRole() != ROLE_SimulatedProxy ||
 			(Character->GetReplicatedMovement().bRepAcceleration &&
@@ -340,12 +374,19 @@ namespace RpgGaspPIENetworkTests
 				AnimInstance,
 				TEXT("LocomotionGait"),
 				AnimGait) &&
+			ReadObjectProperty(
+				Character,
+				TEXT("GroundCoastGait"),
+				CharacterCoastGait) &&
 			AnimGait == ERpgLocomotionGait::Idle &&
+			CharacterCoastGait == ERpgLocomotionGait::Idle &&
 			!bHasAcceleration && WorldAcceleration.Size2D() <= 5.0f &&
 			MovementComponent->GetCurrentAcceleration().Size2D() <= 5.0f &&
 			MovementComponent->GetAnalogInputModifier() <= 0.01f &&
 			MovementComponent->GetDesiredGait() == ERpgLocomotionGait::Idle &&
 			MovementComponent->GetGroundGait() == ERpgLocomotionGait::Idle &&
+			MovementComponent->GetReplicatedGroundCoastGait() ==
+				ERpgLocomotionGait::Idle &&
 			!MovementComponent->HasMoveIntent() &&
 			FMath::IsNearlyEqual(
 				MovementComponent->GetMaxBrakingDeceleration(),
@@ -587,6 +628,231 @@ namespace RpgGaspPIENetworkTests
 			ExpectedDirection,
 			ExpectedScale,
 			ExpectedGait);
+	}
+
+	bool ApplyDeterministicCoastProfile(
+		FNetworkState& State,
+		const float BrakingDecelerationWithoutInput)
+	{
+		ARpgCharacter* Character = FindCharacterByPlayerId(
+			State.World,
+			State.SubjectPlayerId);
+		URpgCharacterMovementComponent* MovementComponent = Character
+			? Cast<URpgCharacterMovementComponent>(Character->GetCharacterMovement())
+			: nullptr;
+		if (!MovementComponent ||
+			!FMath::IsFinite(BrakingDecelerationWithoutInput) ||
+			BrakingDecelerationWithoutInput < 1.0f)
+		{
+			return false;
+		}
+
+		FRpgCharacterMovementProfile TestProfile =
+			MovementComponent->GetMovementProfile();
+		if (!TestProfile.bOverrideCharacterMovement)
+		{
+			return false;
+		}
+
+		const bool bCapturedBaseline = !State.bHasBaselineCoastProfile;
+		if (bCapturedBaseline)
+		{
+			State.BaselineCoastProfile = TestProfile;
+			State.bHasBaselineCoastProfile = true;
+		}
+
+		TestProfile.bUseSeparateBrakingFriction = false;
+		TestProfile.BrakingFrictionFactor = 0.0f;
+		TestProfile.BrakingDecelerationWithoutInput =
+			BrakingDecelerationWithoutInput;
+		if (!MovementComponent->ApplyMovementProfile(TestProfile))
+		{
+			if (bCapturedBaseline)
+			{
+				State.bHasBaselineCoastProfile = false;
+			}
+			return false;
+		}
+		return true;
+	}
+
+	bool SetDeterministicCoastVelocity(
+		FNetworkState& State,
+		const float GroundSpeed,
+		const FVector& Direction = FVector::YAxisVector)
+	{
+		ARpgCharacter* Character = FindCharacterByPlayerId(
+			State.World,
+			State.SubjectPlayerId);
+		URpgCharacterMovementComponent* MovementComponent = Character
+			? Cast<URpgCharacterMovementComponent>(Character->GetCharacterMovement())
+			: nullptr;
+		if (!MovementComponent || !MovementComponent->IsMovingOnGround() ||
+			!FMath::IsFinite(GroundSpeed) || GroundSpeed <= 0.0f ||
+			Direction.IsNearlyZero())
+		{
+			return false;
+		}
+
+		MovementComponent->Velocity = Direction.GetSafeNormal2D() * GroundSpeed;
+		MovementComponent->UpdateComponentVelocity();
+		if (Character->HasAuthority())
+		{
+			MovementComponent->ForceReplicationUpdate();
+			Character->ForceNetUpdate();
+		}
+		return true;
+	}
+
+	bool RestorePilotProfileAndStop(FNetworkState& State)
+	{
+		ARpgCharacter* Character = FindCharacterByPlayerId(
+			State.World,
+			State.SubjectPlayerId);
+		URpgCharacterMovementComponent* MovementComponent = Character
+			? Cast<URpgCharacterMovementComponent>(Character->GetCharacterMovement())
+			: nullptr;
+		if (!MovementComponent || !State.bHasBaselineCoastProfile ||
+			!MovementComponent->ApplyMovementProfile(State.BaselineCoastProfile))
+		{
+			return false;
+		}
+		State.bHasBaselineCoastProfile = false;
+
+		MovementComponent->StopMovementImmediately();
+		MovementComponent->UpdateComponentVelocity();
+		if (Character->HasAuthority())
+		{
+			MovementComponent->ForceReplicationUpdate();
+			Character->ForceNetUpdate();
+		}
+		return true;
+	}
+
+	bool HasExpectedCoastGait(
+		FNetworkState& State,
+		const ENetRole ExpectedLocalRole,
+		const ERpgLocomotionGait ExpectedGait,
+		const bool bRequireBelowWalkCap)
+	{
+		ARpgCharacter* Character = FindCharacterByPlayerId(
+			State.World,
+			State.SubjectPlayerId);
+		URpgCharacterMovementComponent* MovementComponent = Character
+			? Cast<URpgCharacterMovementComponent>(Character->GetCharacterMovement())
+			: nullptr;
+		URpgAnimInstance* AnimInstance = GetPilotAnimInstance(Character);
+		ERpgLocomotionGait AnimGait = ERpgLocomotionGait::Idle;
+		ERpgLocomotionGait CharacterCoastGait = ERpgLocomotionGait::Idle;
+		const float GroundSpeed = Character
+			? Character->GetVelocity().Size2D()
+			: 0.0f;
+		const float WalkCap = MovementComponent
+			? MovementComponent->GetMovementProfile().WalkSpeeds.Forward
+			: 0.0f;
+		const ERpgLocomotionGait ExpectedCharacterCoastGait =
+			ExpectedLocalRole == ROLE_AutonomousProxy
+				? ERpgLocomotionGait::Idle
+				: ExpectedGait;
+		const ERpgLocomotionGait ExpectedMovementHint =
+			ExpectedLocalRole == ROLE_SimulatedProxy
+				? ExpectedGait
+				: ERpgLocomotionGait::Idle;
+		const FRepMovement* ReplicatedMovement = Character
+			? &Character->GetReplicatedMovement()
+			: nullptr;
+		const bool bHasNativeZeroSnapshot =
+			ExpectedLocalRole != ROLE_SimulatedProxy ||
+			(ReplicatedMovement &&
+			 ReplicatedMovement->bRepAcceleration &&
+			 ReplicatedMovement->Acceleration.Size2D() <= 5.0f);
+		const bool bReadAnimGait = ReadAnimProperty(
+			AnimInstance,
+			TEXT("LocomotionGait"),
+			AnimGait);
+		const bool bReadCharacterCoastGait = ReadObjectProperty(
+			Character,
+			TEXT("GroundCoastGait"),
+			CharacterCoastGait);
+		const bool bMatches = Character && MovementComponent && AnimInstance &&
+			Character->GetLocalRole() == ExpectedLocalRole &&
+			MovementComponent->IsMovingOnGround() &&
+			MovementComponent->GetMovementProfile().bOverrideCharacterMovement &&
+			GroundSpeed >= MovementComponent->GetMovementProfile().StationarySpeedThreshold &&
+			(!bRequireBelowWalkCap || GroundSpeed < WalkCap - 5.0f) &&
+			MovementComponent->GetCurrentAcceleration().Size2D() <= 5.0f &&
+			MovementComponent->GetAnalogInputModifier() <= 0.01f &&
+			MovementComponent->GetDesiredGait() == ERpgLocomotionGait::Idle &&
+			MovementComponent->GetGroundGait() == ExpectedGait &&
+			MovementComponent->GetReplicatedGroundCoastGait() ==
+				ExpectedMovementHint &&
+			!MovementComponent->HasMoveIntent() &&
+			bReadAnimGait && AnimGait == ExpectedGait &&
+			bReadCharacterCoastGait &&
+			CharacterCoastGait == ExpectedCharacterCoastGait &&
+			bHasNativeZeroSnapshot;
+
+		const double Now = FPlatformTime::Seconds();
+		if (!bMatches && Now - State.LastCoastDiagnosticTime >= 1.0)
+		{
+			State.LastCoastDiagnosticTime = Now;
+			UE_LOG(
+				LogTemp,
+				Display,
+				TEXT("GASP coast mismatch: expected role=%d gait=%d belowWalk=%d | character=%d role=%d speed=%.1f walkCap=%.1f move=%d ground=%d desired=%d intent=%d accel=%.1f analog=%.3f hint=%d transportRead=%d transport=%d animRead=%d anim=%d nativeZero=%d"),
+				static_cast<int32>(ExpectedLocalRole),
+				static_cast<int32>(ExpectedGait),
+				static_cast<int32>(bRequireBelowWalkCap),
+				static_cast<int32>(Character != nullptr),
+				Character ? static_cast<int32>(Character->GetLocalRole()) : -1,
+				static_cast<double>(GroundSpeed),
+				static_cast<double>(WalkCap),
+				static_cast<int32>(MovementComponent != nullptr),
+				MovementComponent ? static_cast<int32>(MovementComponent->GetGroundGait()) : -1,
+				MovementComponent ? static_cast<int32>(MovementComponent->GetDesiredGait()) : -1,
+				static_cast<int32>(MovementComponent ? MovementComponent->HasMoveIntent() : false),
+				static_cast<double>(MovementComponent ? MovementComponent->GetCurrentAcceleration().Size2D() : -1.0f),
+				static_cast<double>(MovementComponent ? MovementComponent->GetAnalogInputModifier() : -1.0f),
+				MovementComponent ? static_cast<int32>(MovementComponent->GetReplicatedGroundCoastGait()) : -1,
+				static_cast<int32>(bReadCharacterCoastGait),
+				static_cast<int32>(CharacterCoastGait),
+				static_cast<int32>(bReadAnimGait),
+				static_cast<int32>(AnimGait),
+				static_cast<int32>(bHasNativeZeroSnapshot));
+		}
+
+		if (!bMatches || State.StableCoastSubject.Get() != Character ||
+			State.StableCoastRole != ExpectedLocalRole ||
+			State.StableCoastGait != ExpectedGait ||
+			State.bStableCoastBelowWalkCap != bRequireBelowWalkCap)
+		{
+			State.StableCoastSubject = bMatches ? Character : nullptr;
+			State.StableCoastRole = bMatches ? ExpectedLocalRole : ROLE_None;
+			State.StableCoastGait = bMatches
+				? ExpectedGait
+				: ERpgLocomotionGait::Idle;
+			State.bStableCoastBelowWalkCap = bMatches && bRequireBelowWalkCap;
+			State.StableCoastStartTime = bMatches ? Now : 0.0;
+			return false;
+		}
+
+		return Now - State.StableCoastStartTime >= 0.2;
+	}
+
+	bool HasSubjectActorChannel(
+		FNetworkState& State,
+		const int32 ClientIndex,
+		const bool bExpectedOpen)
+	{
+		ARpgCharacter* Subject = FindCharacterByPlayerId(
+			State.World,
+			State.SubjectPlayerId);
+		UNetConnection* Connection = State.ClientConnections.IsValidIndex(ClientIndex)
+			? State.ClientConnections[ClientIndex]
+			: nullptr;
+		return Subject && IsValid(Connection) &&
+			Connection->ContainsActorChannel(TWeakObjectPtr<AActor>(Subject)) ==
+				bExpectedOpen;
 	}
 
 	bool HasStablePhysicalDeadzone(
@@ -2268,6 +2534,764 @@ NETWORK_TEST_CLASS(GaspPilotPIE, "SurvivalRpg.Network")
 				})
 			.ThenClients(
 				TEXT("Cleanup client observers"),
+				[](FNetworkState& State)
+				{
+					StopMovementInput(State);
+					State.World->GetTimerManager().ClearTimer(State.ObservationTimer);
+				});
+	}
+
+	TEST_METHOD(GroundCoastLateJoinAndRelevancyReturn)
+	{
+		using namespace RpgGaspPIENetworkTests;
+
+		Network
+			.SpawnAndReplicate<
+				ARpgGaspNetworkFloorFixture,
+				&FNetworkState::Floor>(
+				NetworkTimeout())
+			.UntilServer(
+				TEXT("Pilot Experience loads for the coast test on the listen server"),
+				[](FNetworkState& State)
+				{
+					return IsPilotExperienceReady(State, 1);
+				},
+				NetworkTimeout())
+			.UntilClients(
+				TEXT("Initial coast-test client loads the Pilot pawn"),
+				[](FNetworkState& State)
+				{
+					return IsPilotExperienceReady(State, 1) &&
+						IsPilotCharacterReady(FindLocalCharacter(State.World));
+				},
+				NetworkTimeout())
+			.ThenServer(
+				TEXT("Place the coast-test pawns on separate floor lanes"),
+				[](FNetworkState& State)
+				{
+					int32 LaneIndex = 0;
+					for (TActorIterator<ARpgCharacter> It(State.World); It; ++It)
+					{
+						ARpgCharacter* Character = *It;
+						const FVector Location(
+							-800.0 + static_cast<double>(LaneIndex++) * 800.0,
+							0.0,
+							100.0);
+						Character->TeleportTo(Location, FRotator::ZeroRotator);
+						Character->GetCharacterMovement()->StopMovementImmediately();
+						Character->GetCharacterMovement()->SetMovementMode(MOVE_Walking);
+						Character->ForceNetUpdate();
+					}
+				})
+			.UntilClient(
+				TEXT("Initial coast-test client owns a grounded GASP pawn"),
+				0,
+				[](FNetworkState& State)
+				{
+					ARpgCharacter* Character = FindLocalCharacter(State.World);
+					return IsPilotCharacterReady(Character) &&
+						Character->GetLocalRole() == ROLE_AutonomousProxy &&
+						Character->GetCharacterMovement()->IsMovingOnGround();
+				},
+				NetworkTimeout())
+			.ThenClient(
+				TEXT("Capture the coast-test subject identity"),
+				0,
+				[this](FNetworkState& State)
+				{
+					ARpgCharacter* Character = FindLocalCharacter(State.World);
+					ASSERT_THAT(IsNotNull(Character));
+					ASSERT_THAT(IsNotNull(Character->GetPlayerState()));
+					SubjectPlayerId = Character->GetPlayerState()->GetPlayerId();
+					ASSERT_THAT(IsTrue(SubjectPlayerId != INDEX_NONE));
+					State.SubjectPlayerId = SubjectPlayerId;
+				})
+			.ThenServer(
+				TEXT("Bind the coast-test subject on authority"),
+				[this](FNetworkState& State)
+				{
+					State.SubjectPlayerId = SubjectPlayerId;
+				})
+			.UntilServer(
+				TEXT("Authority starts the coast test from a stable stop"),
+				[](FNetworkState& State)
+				{
+					return HasStoppedAnimation(State);
+				},
+				NetworkTimeout())
+			.UntilClient(
+				TEXT("Owner starts the coast test from a stable stop"),
+				0,
+				[](FNetworkState& State)
+				{
+					return HasStoppedAnimation(State);
+				},
+				NetworkTimeout())
+			.ThenClient(
+				TEXT("Establish Walk before the first late join"),
+				0,
+				[](FNetworkState& State)
+				{
+					StartMovementInput(State, FVector::YAxisVector, 0.50f);
+				})
+			.UntilServer(
+				TEXT("Authority establishes Walk before the first late join"),
+				[](FNetworkState& State)
+				{
+					return HasExpectedMovementInput(
+						State,
+						ROLE_Authority,
+						FVector::YAxisVector,
+						0.50f,
+						ERpgLocomotionGait::Walk);
+				},
+				NetworkTimeout())
+			.UntilClient(
+				TEXT("Owner establishes Walk before the first late join"),
+				0,
+				[](FNetworkState& State)
+				{
+					return HasExpectedMovementInput(
+						State,
+						ROLE_AutonomousProxy,
+						FVector::YAxisVector,
+						0.50f,
+						ERpgLocomotionGait::Walk);
+				},
+				NetworkTimeout())
+			.ThenServer(
+				TEXT("Apply the deterministic Walk-coast window on authority"),
+				[this](FNetworkState& State)
+				{
+					ASSERT_THAT(IsTrue(ApplyDeterministicCoastProfile(State, 1.0f)));
+				})
+			.ThenClient(
+				TEXT("Apply the deterministic Walk-coast window on the owner"),
+				0,
+				[this](FNetworkState& State)
+				{
+					ASSERT_THAT(IsTrue(ApplyDeterministicCoastProfile(State, 1.0f)));
+				})
+			.UntilServer(
+				TEXT("Authority re-establishes Walk after the test-profile copy"),
+				[](FNetworkState& State)
+				{
+					return HasExpectedMovementInput(
+						State,
+						ROLE_Authority,
+						FVector::YAxisVector,
+						0.50f,
+						ERpgLocomotionGait::Walk);
+				},
+				NetworkTimeout())
+			.UntilClient(
+				TEXT("Owner re-establishes Walk after the test-profile copy"),
+				0,
+				[](FNetworkState& State)
+				{
+					return HasExpectedMovementInput(
+						State,
+						ROLE_AutonomousProxy,
+						FVector::YAxisVector,
+						0.50f,
+						ERpgLocomotionGait::Walk);
+				},
+				NetworkTimeout())
+			.ThenClient(
+				TEXT("Release Walk input for the late-join coast"),
+				0,
+				[](FNetworkState& State)
+				{
+					StopMovementInput(State);
+				})
+			.UntilServer(
+				TEXT("Authority enters a real no-input Walk coast"),
+				[](FNetworkState& State)
+				{
+					return HasExpectedCoastGait(
+						State,
+						ROLE_Authority,
+						ERpgLocomotionGait::Walk,
+						false);
+				},
+				NetworkTimeout())
+			.UntilClient(
+				TEXT("Owner enters the same no-input Walk coast"),
+				0,
+				[](FNetworkState& State)
+				{
+					return HasExpectedCoastGait(
+						State,
+						ROLE_AutonomousProxy,
+						ERpgLocomotionGait::Walk,
+						false);
+				},
+				NetworkTimeout())
+			.ThenServer(
+				TEXT("Set a deterministic physical Walk-coast speed on authority"),
+				[this](FNetworkState& State)
+				{
+					ASSERT_THAT(IsTrue(SetDeterministicCoastVelocity(State, 140.0f)));
+				})
+			.ThenClient(
+				TEXT("Set the matching physical Walk-coast speed on the owner"),
+				0,
+				[this](FNetworkState& State)
+				{
+					ASSERT_THAT(IsTrue(SetDeterministicCoastVelocity(State, 140.0f)));
+				})
+			.UntilServer(
+				TEXT("Authority holds Walk coast below its forward cap"),
+				[](FNetworkState& State)
+				{
+					return HasExpectedCoastGait(
+						State,
+						ROLE_Authority,
+						ERpgLocomotionGait::Walk,
+						true);
+				},
+				NetworkTimeout())
+			.UntilClient(
+				TEXT("Owner holds Walk coast below its forward cap"),
+				0,
+				[](FNetworkState& State)
+				{
+					return HasExpectedCoastGait(
+						State,
+						ROLE_AutonomousProxy,
+						ERpgLocomotionGait::Walk,
+						true);
+				},
+				NetworkTimeout())
+			.ThenClientJoins(NetworkTimeout())
+			.UntilServer(
+				TEXT("Walk-coast late join establishes the second connection"),
+				[](FNetworkState& State)
+				{
+					return IsPilotExperienceReady(State, 2);
+				},
+				NetworkTimeout())
+			.UntilClient(
+				TEXT("Walk-coast late client loads the Pilot Experience"),
+				1,
+				[](FNetworkState& State)
+				{
+					if (!IsValid(State.Floor))
+					{
+						for (TActorIterator<ARpgGaspNetworkFloorFixture> It(State.World);
+							It; ++It)
+						{
+							State.Floor = *It;
+							break;
+						}
+					}
+					ARpgCharacter* LocalCharacter = FindLocalCharacter(State.World);
+					return IsPilotExperienceReady(State, 2) &&
+						IsValid(State.Floor) &&
+						IsPilotCharacterReady(LocalCharacter) &&
+						LocalCharacter->GetCharacterMovement()->IsMovingOnGround();
+				},
+				NetworkTimeout())
+			.ThenClients(
+				TEXT("Bind the Walk-coast subject in both client worlds"),
+				[this](FNetworkState& State)
+				{
+					State.SubjectPlayerId = SubjectPlayerId;
+				})
+			.UntilServer(
+				TEXT("Authority remains in Walk coast during late join"),
+				[](FNetworkState& State)
+				{
+					return HasExpectedCoastGait(
+						State,
+						ROLE_Authority,
+						ERpgLocomotionGait::Walk,
+						true);
+				},
+				NetworkTimeout())
+			.UntilClient(
+				TEXT("Owner remains in Walk coast during late join"),
+				0,
+				[](FNetworkState& State)
+				{
+					return HasExpectedCoastGait(
+						State,
+						ROLE_AutonomousProxy,
+						ERpgLocomotionGait::Walk,
+						true);
+				},
+				NetworkTimeout())
+			.UntilClient(
+				TEXT("New simulated proxy reconstructs Walk from its initial coast snapshot"),
+				1,
+				[](FNetworkState& State)
+				{
+					return HasExpectedCoastGait(
+						State,
+						ROLE_SimulatedProxy,
+						ERpgLocomotionGait::Walk,
+						true);
+				},
+				NetworkTimeout())
+			.ThenServer(
+				TEXT("Restore normal braking and stop after the Walk late join"),
+				[this](FNetworkState& State)
+				{
+					ASSERT_THAT(IsTrue(RestorePilotProfileAndStop(State)));
+				})
+			.ThenClient(
+				TEXT("Restore normal owner braking after the Walk late join"),
+				0,
+				[this](FNetworkState& State)
+				{
+					ASSERT_THAT(IsTrue(RestorePilotProfileAndStop(State)));
+				})
+			.UntilServer(
+				TEXT("Authority clears Walk coast at physical stop"),
+				[](FNetworkState& State)
+				{
+					return HasStoppedAnimation(State);
+				},
+				NetworkTimeout())
+			.UntilClients(
+				TEXT("Owner and late proxy clear Walk coast at physical stop"),
+				[](FNetworkState& State)
+				{
+					return HasStoppedAnimation(State);
+				},
+				NetworkTimeout())
+			.ThenClient(
+				TEXT("Establish Run before the second late join"),
+				0,
+				[](FNetworkState& State)
+				{
+					StartMovementInput(State, FVector::YAxisVector, 1.0f);
+				})
+			.UntilServer(
+				TEXT("Authority establishes Run before the second late join"),
+				[](FNetworkState& State)
+				{
+					return HasExpectedMovementInput(
+						State,
+						ROLE_Authority,
+						FVector::YAxisVector,
+						1.0f,
+						ERpgLocomotionGait::Run);
+				},
+				NetworkTimeout())
+			.UntilClients(
+				TEXT("Owner and existing simulated proxy establish Run"),
+				[](FNetworkState& State)
+				{
+					return HasExpectedMovementInput(
+						State,
+						State.ClientIndex == 0
+							? ROLE_AutonomousProxy
+							: ROLE_SimulatedProxy,
+						FVector::YAxisVector,
+						1.0f,
+						ERpgLocomotionGait::Run);
+				},
+				NetworkTimeout())
+			.ThenServer(
+				TEXT("Apply the deterministic Run-coast window on authority"),
+				[this](FNetworkState& State)
+				{
+					ASSERT_THAT(IsTrue(ApplyDeterministicCoastProfile(State, 1.0f)));
+				})
+			.ThenClient(
+				TEXT("Apply the deterministic Run-coast window on the owner"),
+				0,
+				[this](FNetworkState& State)
+				{
+					ASSERT_THAT(IsTrue(ApplyDeterministicCoastProfile(State, 1.0f)));
+				})
+			.UntilServer(
+				TEXT("Authority re-establishes Run after the test-profile copy"),
+				[](FNetworkState& State)
+				{
+					return HasExpectedMovementInput(
+						State,
+						ROLE_Authority,
+						FVector::YAxisVector,
+						1.0f,
+						ERpgLocomotionGait::Run);
+				},
+				NetworkTimeout())
+			.UntilClients(
+				TEXT("Owner and simulated proxy re-establish Run"),
+				[](FNetworkState& State)
+				{
+					return HasExpectedMovementInput(
+						State,
+						State.ClientIndex == 0
+							? ROLE_AutonomousProxy
+							: ROLE_SimulatedProxy,
+						FVector::YAxisVector,
+						1.0f,
+						ERpgLocomotionGait::Run);
+				},
+				NetworkTimeout())
+			.ThenClient(
+				TEXT("Release Run input for the late-join coast"),
+				0,
+				[](FNetworkState& State)
+				{
+					StopMovementInput(State);
+				})
+			.UntilServer(
+				TEXT("Authority enters a real no-input Run coast"),
+				[](FNetworkState& State)
+				{
+					return HasExpectedCoastGait(
+						State,
+						ROLE_Authority,
+						ERpgLocomotionGait::Run,
+						false);
+				},
+				NetworkTimeout())
+			.UntilClient(
+				TEXT("Owner enters the same no-input Run coast"),
+				0,
+				[](FNetworkState& State)
+				{
+					return HasExpectedCoastGait(
+						State,
+						ROLE_AutonomousProxy,
+						ERpgLocomotionGait::Run,
+						false);
+				},
+				NetworkTimeout())
+			.ThenServer(
+				TEXT("Set Run coast below the Walk cap on authority"),
+				[this](FNetworkState& State)
+				{
+					ASSERT_THAT(IsTrue(SetDeterministicCoastVelocity(State, 180.0f)));
+				})
+			.ThenClient(
+				TEXT("Set matching Run coast below the Walk cap on the owner"),
+				0,
+				[this](FNetworkState& State)
+				{
+					ASSERT_THAT(IsTrue(SetDeterministicCoastVelocity(State, 180.0f)));
+				})
+			.UntilServer(
+				TEXT("Authority retains Run below the Walk cap"),
+				[](FNetworkState& State)
+				{
+					return HasExpectedCoastGait(
+						State,
+						ROLE_Authority,
+						ERpgLocomotionGait::Run,
+						true);
+				},
+				NetworkTimeout())
+			.UntilClients(
+				TEXT("Owner and existing proxy retain Run below the Walk cap"),
+				[](FNetworkState& State)
+				{
+					return HasExpectedCoastGait(
+						State,
+						State.ClientIndex == 0
+							? ROLE_AutonomousProxy
+							: ROLE_SimulatedProxy,
+						ERpgLocomotionGait::Run,
+						true);
+				},
+				NetworkTimeout())
+			.ThenClientJoins(NetworkTimeout())
+			.UntilServer(
+				TEXT("Run-coast late join establishes the third connection"),
+				[](FNetworkState& State)
+				{
+					return IsPilotExperienceReady(State, 3);
+				},
+				NetworkTimeout())
+			.UntilClient(
+				TEXT("Run-coast late client loads the Pilot Experience"),
+				2,
+				[](FNetworkState& State)
+				{
+					if (!IsValid(State.Floor))
+					{
+						for (TActorIterator<ARpgGaspNetworkFloorFixture> It(State.World);
+							It; ++It)
+						{
+							State.Floor = *It;
+							break;
+						}
+					}
+					ARpgCharacter* LocalCharacter = FindLocalCharacter(State.World);
+					return IsPilotExperienceReady(State, 3) &&
+						IsValid(State.Floor) &&
+						IsPilotCharacterReady(LocalCharacter) &&
+						LocalCharacter->GetCharacterMovement()->IsMovingOnGround();
+				},
+				NetworkTimeout())
+			.ThenClients(
+				TEXT("Bind the Run-coast subject in every client world"),
+				[this](FNetworkState& State)
+				{
+					State.SubjectPlayerId = SubjectPlayerId;
+				})
+			.UntilServer(
+				TEXT("Authority remains in sub-Walk-cap Run coast"),
+				[](FNetworkState& State)
+				{
+					return HasExpectedCoastGait(
+						State,
+						ROLE_Authority,
+						ERpgLocomotionGait::Run,
+						true);
+				},
+				NetworkTimeout())
+			.UntilClient(
+				TEXT("Owner remains in sub-Walk-cap Run coast"),
+				0,
+				[](FNetworkState& State)
+				{
+					return HasExpectedCoastGait(
+						State,
+						ROLE_AutonomousProxy,
+						ERpgLocomotionGait::Run,
+						true);
+				},
+				NetworkTimeout())
+			.UntilClient(
+				TEXT("Existing proxy retains Run through the second late join"),
+				1,
+				[](FNetworkState& State)
+				{
+					return HasExpectedCoastGait(
+						State,
+						ROLE_SimulatedProxy,
+						ERpgLocomotionGait::Run,
+						true);
+				},
+				NetworkTimeout())
+			.UntilClient(
+				TEXT("New proxy reconstructs Run below the Walk cap from its initial snapshot"),
+				2,
+				[](FNetworkState& State)
+				{
+					return HasExpectedCoastGait(
+						State,
+						ROLE_SimulatedProxy,
+						ERpgLocomotionGait::Run,
+						true);
+				},
+				NetworkTimeout())
+			.ThenClient(
+				TEXT("Remember the existing proxy before relevancy loss"),
+				1,
+				[this](FNetworkState& State)
+				{
+					State.SubjectBeforeRelevancyLoss = FindCharacterByPlayerId(
+						State.World,
+						State.SubjectPlayerId);
+					ASSERT_THAT(IsTrue(State.SubjectBeforeRelevancyLoss.IsValid()));
+				})
+			.ThenServer(
+				TEXT("Move one observer outside the subject relevancy radius"),
+				[this](FNetworkState& State)
+				{
+					ARpgCharacter* Subject = FindCharacterByPlayerId(
+						State.World,
+						State.SubjectPlayerId);
+					ASSERT_THAT(IsNotNull(Subject));
+					ASSERT_THAT(IsTrue(State.ClientConnections.IsValidIndex(2)));
+					ASSERT_THAT(IsTrue(State.ClientConnections.IsValidIndex(1)));
+					APlayerController* ControlController =
+						State.ClientConnections[2]->PlayerController;
+					APlayerController* RelevancyController =
+						State.ClientConnections[1]->PlayerController;
+					APawn* ControlPawn = ControlController
+						? ControlController->GetPawn()
+						: nullptr;
+					APawn* RelevancyPawn = RelevancyController
+						? RelevancyController->GetPawn()
+						: nullptr;
+					ASSERT_THAT(IsNotNull(ControlPawn));
+					ASSERT_THAT(IsNotNull(RelevancyPawn));
+					if (Subject && ControlPawn && RelevancyPawn)
+					{
+						State.BaselineSubjectNetCullDistanceSquared =
+							Subject->GetNetCullDistanceSquared();
+						State.bHasBaselineSubjectNetCullDistanceSquared = true;
+						Subject->SetNetCullDistanceSquared(FMath::Square(25000.0f));
+						ASSERT_THAT(IsTrue(ControlPawn->TeleportTo(
+							Subject->GetActorLocation() + FVector(1000.0, 0.0, 0.0),
+							FRotator::ZeroRotator)));
+						ASSERT_THAT(IsTrue(RelevancyPawn->TeleportTo(
+							Subject->GetActorLocation() + FVector(60000.0, 0.0, 0.0),
+							FRotator::ZeroRotator)));
+						ControlPawn->GetMovementComponent()->StopMovementImmediately();
+						RelevancyPawn->GetMovementComponent()->StopMovementImmediately();
+						Subject->ForceNetUpdate();
+					}
+				})
+			.UntilServer(
+				TEXT("Observer actor channel closes outside relevancy"),
+				[](FNetworkState& State)
+				{
+					return HasSubjectActorChannel(State, 1, false) &&
+						HasSubjectActorChannel(State, 2, true);
+				},
+				NetworkTimeout())
+			.UntilClient(
+				TEXT("Observer destroys the old subject proxy outside relevancy"),
+				1,
+				[](FNetworkState& State)
+				{
+					return !State.SubjectBeforeRelevancyLoss.IsValid() &&
+						FindCharacterByPlayerId(
+							State.World,
+							State.SubjectPlayerId) == nullptr;
+				},
+				NetworkTimeout())
+			.UntilClient(
+				TEXT("Control proxy remains in Run coast while the observer is irrelevant"),
+				2,
+				[](FNetworkState& State)
+				{
+					return HasExpectedCoastGait(
+						State,
+						ROLE_SimulatedProxy,
+						ERpgLocomotionGait::Run,
+						true);
+				},
+				NetworkTimeout())
+			.ThenServer(
+				TEXT("Return the observer inside subject relevancy"),
+				[this](FNetworkState& State)
+				{
+					ARpgCharacter* Subject = FindCharacterByPlayerId(
+						State.World,
+						State.SubjectPlayerId);
+					APlayerController* RelevancyController =
+						State.ClientConnections.IsValidIndex(1)
+							? State.ClientConnections[1]->PlayerController
+							: nullptr;
+					APawn* RelevancyPawn = RelevancyController
+						? RelevancyController->GetPawn()
+						: nullptr;
+					ASSERT_THAT(IsNotNull(Subject));
+					ASSERT_THAT(IsNotNull(RelevancyPawn));
+					if (Subject && RelevancyPawn)
+					{
+						ASSERT_THAT(IsTrue(RelevancyPawn->TeleportTo(
+							Subject->GetActorLocation() + FVector(500.0, 0.0, 0.0),
+							FRotator::ZeroRotator)));
+						RelevancyPawn->GetMovementComponent()->StopMovementImmediately();
+						Subject->ForceNetUpdate();
+					}
+				})
+			.UntilServer(
+				TEXT("Observer actor channel reopens after relevancy return"),
+				[](FNetworkState& State)
+				{
+					return HasSubjectActorChannel(State, 1, true);
+				},
+				NetworkTimeout())
+			.UntilClient(
+				TEXT("Recreated proxy reconstructs Run coast after relevancy return"),
+				1,
+				[](FNetworkState& State)
+				{
+					ARpgCharacter* RecreatedSubject = FindCharacterByPlayerId(
+						State.World,
+						State.SubjectPlayerId);
+					return RecreatedSubject &&
+						RecreatedSubject != State.SubjectBeforeRelevancyLoss.Get() &&
+						HasExpectedCoastGait(
+							State,
+							ROLE_SimulatedProxy,
+							ERpgLocomotionGait::Run,
+							true);
+				},
+				NetworkTimeout())
+			.UntilServer(
+				TEXT("Authority stays in Run coast through relevancy return"),
+				[](FNetworkState& State)
+				{
+					return HasExpectedCoastGait(
+						State,
+						ROLE_Authority,
+						ERpgLocomotionGait::Run,
+						true);
+				},
+				NetworkTimeout())
+			.UntilClient(
+				TEXT("Owner stays in Run coast through relevancy return"),
+				0,
+				[](FNetworkState& State)
+				{
+					return HasExpectedCoastGait(
+						State,
+						ROLE_AutonomousProxy,
+						ERpgLocomotionGait::Run,
+						true);
+				},
+				NetworkTimeout())
+			.UntilClient(
+				TEXT("Control proxy stays in Run coast through relevancy return"),
+				2,
+				[](FNetworkState& State)
+				{
+					return HasExpectedCoastGait(
+						State,
+						ROLE_SimulatedProxy,
+						ERpgLocomotionGait::Run,
+						true);
+				},
+				NetworkTimeout())
+			.ThenServer(
+				TEXT("Restore normal relevancy and braking after Run coast"),
+				[this](FNetworkState& State)
+				{
+					ARpgCharacter* Subject = FindCharacterByPlayerId(
+						State.World,
+						State.SubjectPlayerId);
+					ASSERT_THAT(IsNotNull(Subject));
+					ASSERT_THAT(IsTrue(
+						State.bHasBaselineSubjectNetCullDistanceSquared));
+					if (Subject)
+					{
+						Subject->SetNetCullDistanceSquared(
+							State.BaselineSubjectNetCullDistanceSquared);
+						State.bHasBaselineSubjectNetCullDistanceSquared = false;
+					}
+					ASSERT_THAT(IsTrue(RestorePilotProfileAndStop(State)));
+				})
+			.ThenClient(
+				TEXT("Restore normal owner braking after Run coast"),
+				0,
+				[this](FNetworkState& State)
+				{
+					ASSERT_THAT(IsTrue(RestorePilotProfileAndStop(State)));
+				})
+			.UntilServer(
+				TEXT("Authority clears Run coast at physical stop"),
+				[](FNetworkState& State)
+				{
+					return HasStoppedAnimation(State);
+				},
+				NetworkTimeout())
+			.UntilClients(
+				TEXT("Every client clears Run coast and replicated hints at stop"),
+				[](FNetworkState& State)
+				{
+					return HasStoppedAnimation(State);
+				},
+				NetworkTimeout())
+			.ThenServer(
+				TEXT("Cleanup coast-test server timers"),
+				[](FNetworkState& State)
+				{
+					State.World->GetTimerManager().ClearTimer(State.ObservationTimer);
+				})
+			.ThenClients(
+				TEXT("Cleanup coast-test client timers"),
 				[](FNetworkState& State)
 				{
 					StopMovementInput(State);

--- a/docs/gasp-cmc-migration-plan.md
+++ b/docs/gasp-cmc-migration-plan.md
@@ -28,7 +28,7 @@ The CMC AnimBP closure still pulls in experimental state-machine databases, larg
 - Replicate compressed acceleration to simulated proxies so remote starts, stops, and pivots have the same inputs as the owning client.
 - For standing, uncrouched ground movement, resolve a physical deadzone of `<= 0.10` before physics and SavedMove capture; preserve every magnitude above it, including `0.11`, `0.25`, and `0.50`, without renormalization beyond CharacterMovement's native `NetQuantize10` precision.
 - Keep desired gait prediction-owned: enter Run at `>= 0.70`, retain it at `>= 0.65`, and exit only below `0.65`. Store that state in one SavedMove `Custom0` flag and restore it for authoritative server movement and client replay.
-- Let simulated proxies reconstruct the continuous gait state from replicated acceleration. Direct late join inside the `0.65`-to-`0.70` hysteresis band remains deferred to issue #101.
+- Let simulated proxies reconstruct active-input gait from replicated acceleration. During inputless Walk/Run coast, replicate only the authority's current coast classification to simulated proxies so initial replication and relevancy return preserve the selected gait below the Walk cap; clear it deterministically at physical stop without replicating AnimBP, pose, or movement history. A proxy first observed with active input directly inside the `0.65`-to-`0.70` retention band remains a separate ambiguity outside issue #101.
 - Preserve the legacy input response for crouching, falling, and custom movement modes.
 - Let a PawnData-selected movement profile own GASP-pilot Walk/Run caps, response values, and the CMC gait consumed by animation; legacy PawnData remains opt-out.
 - Reparent the current `ABP_Unarmed` to the RPG base without changing its pose graph.
@@ -53,7 +53,7 @@ The CMC AnimBP closure still pulls in experimental state-machine databases, larg
 
 - Verify locomotion transitions, foot placement, LOD cost, and database memory.
 - Verify attack combos, block, dodge, hit reactions, death, equipment sockets, and harvesting montage rewards.
-- Test listen server plus two clients, simulated proxies, and late join.
+- Test a listen server with an autonomous owner and at least two observing clients, including simulated proxies, correction, Walk/Run coast late join, physical-stop cleanup, and actor-channel relevancy loss/return.
 - Keep the prototype and GASP PawnData/AnimBP paths cooked, separate, and directly selectable through their Experiences in the same build.
 - A later cutover may change only which Experience is selected by default; it must not repoint the prototype Experience or delete its PawnData/AnimBP.
 - Switch Experiences only at a supported world/session boundary (World Settings, URL, PIE, or command line), never by hot-swapping an already-running pawn.
@@ -62,7 +62,7 @@ The CMC AnimBP closure still pulls in experimental state-machine databases, larg
 
 - No runtime dependency on GASP's character Blueprint, Mover graph, traversal graph, generic retarget collection, or sample camera stack.
 - The AnimBP update path performs no character, component, ASC, or world queries on worker threads.
-- Simulated proxies reconstruct the continuous gait state from acceleration needed for start, stop, and pivot selection, including after a neutral late join; a proxy first observed directly inside the hysteresis band remains issue #101.
+- Simulated proxies reconstruct active-input gait from acceleration needed for start, stop, and pivot selection. A server-owned Walk/Run coast classification seeds only inputless simulated-proxy coast after late join or relevancy return, remains stable below the Walk cap, and clears to Idle at physical stop without replicating presentation history.
 - Existing GAS montages continue to use `DefaultSlot` and retain their gameplay notifies and root-motion behavior.
 - Walk/Run speed caps, response values, controlled Free yaw, and stable gait are selected by GASP PawnData and applied by CharacterMovement before animation consumes them.
 - Standing-ground input at or below `0.10` produces no physical movement; `0.11`, `0.25`, and `0.50` remain analog-scaled without renormalization beyond native movement-network precision, while crouching, falling, and custom movement retain their legacy response.

--- a/docs/gasp-network-smoke.md
+++ b/docs/gasp-network-smoke.md
@@ -7,9 +7,17 @@ default PawnData or introducing an alternate gameplay/runtime owner.
 
 ## Automated acceptance
 
-Test:
+Primary test:
 
 `SurvivalRpg.Network.GaspPilotPIE.ReplicationLateJoinCorrectionAndDefaultSlotMontage`
+
+Focused issue #101 coast-gait test:
+
+`SurvivalRpg.Network.GaspPilotPIE.GroundCoastLateJoinAndRelevancyReturn`
+
+Focused issue #100 analog-gait regression:
+
+`SurvivalRpg.Network.GaspPilotPIE.AnalogGaitPredictionAndCorrection`
 
 Topology and network profile:
 
@@ -39,6 +47,11 @@ The test verifies:
 - local-owner and authoritative ASC montage starts through `DefaultSlot`
 - replicated simulated-proxy montage playback, AnimInstance montage gating, authoritative root
   motion, montage completion, and stable client convergence
+- Walk coast on Authority, AutonomousProxy, and a newly joined SimulatedProxy
+- Run coast below the 200 cm/s Walk cap on existing and newly joined proxies
+- an actual simulated-proxy relevancy loss, actor/channel teardown, recreated proxy on return, and
+  preservation of the authoritative Run coast classification
+- deterministic coast-gait clearing to Idle at physical stop on every role
 
 Run from PowerShell with a rendered RHI; `NullRHI` is intentionally not used for this PIE test:
 
@@ -60,20 +73,32 @@ Run from PowerShell with a rendered RHI; `NullRHI` is intentionally not used for
 Record the tested commit, UE version, test result, topology, network profile, report path, and log
 path in the PR or issue. `Saved` reports are local evidence and are not committed.
 
+Run the focused coast-gait contract with the same rendered-RHI options by substituting the test
+name above and using dedicated `Issue101Network` report/log paths. The test uses one initial client,
+late-joins two more clients during real CharacterMovement coast, and moves the first observer out
+of and back into network relevancy while another client remains near the subject.
+
 The test temporarily selects the pilot Experience and disables disk persistence on the concrete
 GameMode CDO. Both values are restored during teardown. The owner and authority start the same
 dynamic montage through their ASCs, but this is not a GameplayAbility activation or prediction
 confirmation test.
 
+The coast test applies a deterministic low release-deceleration value only to in-memory copies of
+the authority and owner movement profiles, then drives real CharacterMovement velocity. Teardown
+restores the exact captured movement profiles and actor cull distance; no PawnData, Experience, or
+other content asset is mutated or saved.
+
 ## Visual smoke boundary
 
 The automation proves real replication, analog movement intent, lifecycle state, movement-history
-reset plumbing, correction/teleport convergence, and montage/root-motion plumbing. It cannot judge
-rendered pose choice or presentation quality. A rendered manual pass should still inspect
+reset plumbing, correction/teleport convergence, montage/root-motion plumbing, Walk/Run coast
+initial replication, and the tested actor-channel relevancy-return path. It cannot judge rendered
+pose choice or presentation quality. A rendered manual pass should still inspect
 start/stop/pivot/TIR, crouch, jump/landing, Foot Placement on uneven ground, Aim/CombatStrafe facing,
 and correction for persistent mesh/capsule separation.
 
 This runbook does not claim gameplay-notify or attack-window reliability, ability costs/cooldowns,
 combos, equipment sockets, death/ragdoll presentation, packaged multi-process or Steam behavior,
-relevancy return, packet-loss handling, performance, memory, or the default PawnData cutover. Those
-remain in their dedicated multiplayer/combat/cutover issues.
+relevancy-return behavior outside the focused coast-gait contract, packet-loss handling,
+performance, memory, or the default PawnData cutover. Those remain in their dedicated
+multiplayer/combat/cutover issues.


### PR DESCRIPTION
Closes #101

## Summary

- add one authority-owned `Idle/Walk/Run` coast classification on `ARpgCharacter`, replicated only to simulated proxies
- let newly joined and newly relevant proxies reconstruct Walk/Run coast before local gait history or residual-speed fallback
- clear the transport synchronously on physical stop and when leaving standing-ground movement
- keep AnimBP, Pose Search, Motion Matching, SavedMove history, PawnData assets, and Experience composition out of the replication contract
- preserve `RpgPrototypeExperience` as an unchanged, independently selectable opt-out path

## Verification

- UE 5.8.1 `SurvivalRpgEditor Win64 Development` build succeeded
- `SurvivalRpg.Character.Movement.ProfileAndGait`
- `SurvivalRpg.Character.Movement.GroundCoastReplicationContract`
- `SurvivalRpg.Character.Movement.SavedMovePrediction`
- `SurvivalRpg.Animation.Gasp.PilotAssetContract`
- rendered D3D12 PIE: `SurvivalRpg.Network.GaspPilotPIE.GroundCoastLateJoinAndRelevancyReturn`
  - Walk coast late join
  - Run coast late join below the 200 cm/s Walk cap
  - actual relevancy loss, actor-channel/proxy teardown, recreation, and return
  - Authority / AutonomousProxy / SimulatedProxy parity and deterministic stop cleanup
- regression: `AnalogGaitPredictionAndCorrection` passed; `ReplicationLateJoinCorrectionAndDefaultSlotMontage` passed on an isolated rerun

One combined three-test editor invocation hit a timing timeout in the older #97 correction-injection step; the isolated #97 rerun completed successfully.